### PR TITLE
Correct code examples in README when using statsd_count_if

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ So now, if GoogleBase#insert raises an exception or returns false (ie. result ==
 
 ``` ruby
 GoogleBase.statsd_count_if :insert, 'GoogleBase.insert' do |response|
-  result.code == 200
+  response.code == 200
 end
 ```
 
@@ -119,7 +119,7 @@ Again you can pass a block to define what success means.
 
 ``` ruby
 GoogleBase.statsd_count_if :insert, 'GoogleBase.insert' do |response|
-  result.code == 200
+  response.code == 200
 end
 ```
 


### PR DESCRIPTION
The `statsd_count_if` code examples define the variable passed into the block as `response` but use `result` inside. This is a simple change to correct the blocks to also use `response` instead of `result`.
