### PR TITLE
Bugfix for StatsD#measure

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -89,9 +89,9 @@ module StatsD
   # glork:320|ms
   def self.measure(key, milli = nil)
     result = nil
-    ms = Benchmark.ms do
+    ms = milli || Benchmark.ms do
       result = yield 
-    end if milli.nil?
+    end
 
     write(key, ms, :ms)
     result

--- a/test/statsd-instrument_test.rb
+++ b/test/statsd-instrument_test.rb
@@ -147,4 +147,10 @@ class StatsDTest < Test::Unit::TestCase
     StatsD.increment('fooz')
     StatsD.enabled = true
   end
+  
+  def test_statsd_measure_with_explicit_value
+    StatsD.expects(:write).with('values.foobar', 42, :ms)
+
+    StatsD.measure('values.foobar', 42)
+  end
 end


### PR DESCRIPTION
Hi there,

I added a missing 'require benchmark' and fixed the

``` ruby
# You can pass a key and a ms value
StatsD.measure('GoogleBase.insert', 2.55)
```

call which didn't work as advertised for explicitly handed values.

Cheers
mat
