### PR TITLE
Add prefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This is the same as what Etsy uses (mentioned in the README for http://github.co
 StatsD.server = 'statsd.myservice.com:8125'
 StatsD.logger = Rails.logger
 StatsD.mode = :production
+StatsD.prefix = 'my_app' # An optional prefix to be added to each stat.
 StatsD.default_sample_rate = 0.1 # Sample 10% of events. By default all events are reported.
 ```
 

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -11,7 +11,8 @@ end
 
 module StatsD
   class << self
-    attr_accessor :host, :port, :mode, :logger, :enabled, :default_sample_rate
+    attr_accessor :host, :port, :mode, :logger, :enabled, :default_sample_rate,
+                  :prefix
   end
   self.enabled = true
   self.default_sample_rate = 1
@@ -123,7 +124,7 @@ module StatsD
     return unless enabled
     return if sample_rate < 1 && rand > sample_rate
 
-    command = "#{k}:#{v}"
+    command = "#{self.prefix + '.' if self.prefix}#{k}:#{v}"
     case op
     when :incr
       command << '|c'

--- a/test/statsd-instrument_test.rb
+++ b/test/statsd-instrument_test.rb
@@ -147,7 +147,21 @@ class StatsDTest < Test::Unit::TestCase
     StatsD.increment('fooz')
     StatsD.enabled = true
   end
-  
+
+  def test_statsd_prefix
+    StatsD.unstub(:increment)
+    StatsD.prefix = 'my_app'
+    StatsD.logger.expects(:info).once.with do |string|
+      string.include?('my_app.foo')
+    end
+    StatsD.logger.expects(:info).once.with do |string|
+      string.include?('food')
+    end
+    StatsD.increment('foo')
+    StatsD.prefix = nil
+    StatsD.increment('food')
+  end
+
   def test_statsd_measure_with_explicit_value
     StatsD.expects(:write).with('values.foobar', 42, :ms)
 


### PR DESCRIPTION
Adds the ability to set a prefix which should be prepended to each stat.

Not sure if this is the ideal way to implement or test, but it's a nice feature to have (especially if you're using multiple apps or projects), so please modify and merge.
