### PR TITLE
allow string or symbol for mode

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -134,7 +134,7 @@ module StatsD
 
     command << "|@#{sample_rate}" if sample_rate < 1
 
-    if mode == :production
+    if mode.to_s == 'production'
       socket_wrapper { socket.send(command, 0, host, port) }
     else
       logger.info "[StatsD] #{command}"

--- a/test/statsd-instrument_test.rb
+++ b/test/statsd-instrument_test.rb
@@ -47,6 +47,7 @@ ActiveMerchant::Base.extend StatsD::Instrument
 
 class StatsDTest < Test::Unit::TestCase
   def setup
+    StatsD.mode = nil
     StatsD.stubs(:increment)
   end
 
@@ -146,6 +147,18 @@ class StatsDTest < Test::Unit::TestCase
     StatsD.expects(:logger).never
     StatsD.increment('fooz')
     StatsD.enabled = true
+  end
+
+  def test_statsd_mode
+    StatsD.unstub(:increment)
+    StatsD.logger.expects(:info).once
+    StatsD.expects(:socket_wrapper).twice
+    StatsD.mode = :foo
+    StatsD.increment('foo')
+    StatsD.mode = :production
+    StatsD.increment('foo')
+    StatsD.mode = 'production'
+    StatsD.increment('foo')
   end
 
   def test_statsd_prefix


### PR DESCRIPTION
If the mode attribute was set to `'production'` and not `:production`, it wouldn't work as expected. This should fix that.
