### PR TITLE
Fix exception in timout rescue when using SystemTimer on 1.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source "http://rubygems.org"
 
 # Specify your gem's dependencies in statsd-instrument.gemspec
 gemspec
+
+gem 'SystemTimer', :platform => :mri_18, :require => ''

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -16,7 +16,7 @@ module StatsD
   self.enabled = true
   self.default_sample_rate = 1
   
-  Timeout = defined?(::SystemTimer) ? ::SystemTimer : ::Timeout
+  TimeoutClass = defined?(::SystemTimer) ? ::SystemTimer : ::Timeout
 
   # StatsD.server = 'localhost:1234'
   def self.server=(conn)
@@ -141,7 +141,7 @@ module StatsD
   end
 
   def self.socket_wrapper(options = {})
-    Timeout.timeout(options.fetch(:timeout, 0.1)) { yield }
+    TimeoutClass.timeout(options.fetch(:timeout, 0.1)) { yield }
   rescue Timeout::Error, SocketError, IOError, SystemCallError => e
     logger.error e
   end

--- a/test/statsd-instrument_test.rb
+++ b/test/statsd-instrument_test.rb
@@ -1,3 +1,9 @@
+# Allow testing with the SystemTimer gem on 1.8
+if RUBY_VERSION =~ /^1.8/
+  puts "Loading SystemTimer gem"
+  require 'system_timer'
+end
+
 require 'statsd-instrument'
 require 'test/unit'
 require 'mocha'


### PR DESCRIPTION
Silly naming conflict when using SystemTimer. For safety, I created a new class name rather than just refrerring to the timeout exception as ::Timeout::Error. Added 1.8-specific test to catch this.
