### PR TITLE
Removing colons from the metric name.

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -131,6 +131,8 @@ module StatsD
     return unless enabled
     return if sample_rate < 1 && rand > sample_rate
 
+    k =  k.gsub('::', '.')
+
     command = "#{self.prefix + '.' if self.prefix}#{k}:#{v}"
     case op
     when :incr

--- a/test/statsd-instrument_test.rb
+++ b/test/statsd-instrument_test.rb
@@ -136,6 +136,15 @@ class StatsDTest < Test::Unit::TestCase
     assert_equal 'block called', return_value
   end
 
+  def test_statsd_measure_with_nested_modules
+    ActiveMerchant::UniqueGateway.statsd_measure :ssl_post, 'ActiveMerchant::Gateway.ssl_post'
+
+    StatsD.stubs(:mode).returns(:production)
+    UDPSocket.any_instance.expects(:send).with(regexp_matches(/ActiveMerchant\.Gateway\.ssl_post:\d\.\d{2,}\|ms/), 0, 'localhost', 123).at_least(1)
+
+    ActiveMerchant::UniqueGateway.new.purchase(true)
+  end
+
   def test_statsd_measure
     ActiveMerchant::UniqueGateway.statsd_measure :ssl_post, 'ActiveMerchant.Gateway.ssl_post'
 


### PR DESCRIPTION
`:` has special meaning as separator for statsd. If you trying to instument any metric  that has a colon in its name it  will just never be captured (at least not appear in graphite). 

This makes it simpler to instrument `Foo::Bar.baz`  without having to gsub each metric individually.   
