### PR TITLE
Sampling rate for meta-progamming instumentation

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -27,15 +27,15 @@ module StatsD
   end
 
   module Instrument
-    def statsd_measure(method, name)
+    def statsd_measure(method, name, sample_rate = StatsD.default_sample_rate)
       add_to_method(method, name, :measure) do |old_method, new_method, metric_name, *args|
         define_method(new_method) do |*args, &block|
-          StatsD.measure(metric_name) { send(old_method, *args, &block) }
+          StatsD.measure(metric_name, nil, sample_rate) { send(old_method, *args, &block) }
         end
       end
     end
 
-    def statsd_count_success(method, name)
+    def statsd_count_success(method, name, sample_rate = StatsD.default_sample_rate)
       add_to_method(method, name, :count_success) do |old_method, new_method, metric_name|
         define_method(new_method) do |*args, &block|
           begin
@@ -47,13 +47,13 @@ module StatsD
             truthiness = (yield(result) rescue false) if block_given?
             result
           ensure
-            StatsD.increment("#{metric_name}." + (truthiness == false ? 'failure' : 'success'))
+            StatsD.increment("#{metric_name}." + (truthiness == false ? 'failure' : 'success'), sample_rate)
           end
         end
       end
     end
 
-    def statsd_count_if(method, name)
+    def statsd_count_if(method, name, sample_rate = StatsD.default_sample_rate)
       add_to_method(method, name, :count_if) do |old_method, new_method, metric_name|
         define_method(new_method) do |*args, &block|
           begin
@@ -65,16 +65,16 @@ module StatsD
             truthiness = (yield(result) rescue false) if block_given?
             result
           ensure
-            StatsD.increment(metric_name) if truthiness
+            StatsD.increment(metric_name, sample_rate) if truthiness
           end
         end
       end
     end
 
-    def statsd_count(method, name)
+    def statsd_count(method, name, sample_rate = StatsD.default_sample_rate)
       add_to_method(method, name, :count) do |old_method, new_method, metric_name|
         define_method(new_method) do |*args, &block|
-          StatsD.increment(metric_name)
+          StatsD.increment(metric_name, sample_rate)
           send(old_method, *args, &block)
         end
       end

--- a/test/statsd-instrument_test.rb
+++ b/test/statsd-instrument_test.rb
@@ -64,7 +64,7 @@ class StatsDTest < Test::Unit::TestCase
   def test_statsd_count_if
     ActiveMerchant::Gateway.statsd_count_if :ssl_post, 'ActiveMerchant.Gateway.if'
 
-    StatsD.expects(:increment).with(includes('if')).once
+    StatsD.expects(:increment).with(includes('if'), 1).once
     ActiveMerchant::Gateway.new.purchase(true)
     ActiveMerchant::Gateway.new.purchase(false)
   end
@@ -84,18 +84,18 @@ class StatsDTest < Test::Unit::TestCase
       result[:success]
     end
 
-    StatsD.expects(:increment).with(includes('block')).once
+    StatsD.expects(:increment).with(includes('block'), 1).once
     ActiveMerchant::UniqueGateway.new.purchase(true)
     ActiveMerchant::UniqueGateway.new.purchase(false)
   end
 
   def test_statsd_count_success
-    ActiveMerchant::Gateway.statsd_count_success :ssl_post, 'ActiveMerchant.Gateway'
+    ActiveMerchant::Gateway.statsd_count_success :ssl_post, 'ActiveMerchant.Gateway', 0.5
 
-    StatsD.expects(:increment).with(includes('success'))
+    StatsD.expects(:increment).with(includes('success'), 0.5)
     ActiveMerchant::Gateway.new.purchase(true)
 
-    StatsD.expects(:increment).with(includes('failure'))
+    StatsD.expects(:increment).with(includes('failure'), 0.5)
     ActiveMerchant::Gateway.new.purchase(false)
   end
 
@@ -114,17 +114,17 @@ class StatsDTest < Test::Unit::TestCase
       result[:success]
     end
 
-    StatsD.expects(:increment).with(includes('success'))
+    StatsD.expects(:increment).with(includes('success'), StatsD.default_sample_rate)
     ActiveMerchant::UniqueGateway.new.purchase(true)
 
-    StatsD.expects(:increment).with(includes('failure'))
+    StatsD.expects(:increment).with(includes('failure'), StatsD.default_sample_rate)
     ActiveMerchant::UniqueGateway.new.purchase(false)
   end
 
   def test_statsd_count
     ActiveMerchant::Gateway.statsd_count :ssl_post, 'ActiveMerchant.Gateway.ssl_post'
 
-    StatsD.expects(:increment).with(includes('ssl_post'))
+    StatsD.expects(:increment).with(includes('ssl_post'), 1)
     ActiveMerchant::Gateway.new.purchase(true)
   end
 
@@ -146,11 +146,12 @@ class StatsDTest < Test::Unit::TestCase
   end
 
   def test_statsd_measure
-    ActiveMerchant::UniqueGateway.statsd_measure :ssl_post, 'ActiveMerchant.Gateway.ssl_post'
+    ActiveMerchant::UniqueGateway.statsd_measure :ssl_post, 'ActiveMerchant.Gateway.ssl_post', 0.3
 
-    StatsD.expects(:write).with('ActiveMerchant.Gateway.ssl_post', is_a(Float), :ms, is_a(Numeric)).returns({:success => true})
+    StatsD.expects(:write).with('ActiveMerchant.Gateway.ssl_post', is_a(Float), :ms, 0.3).returns({:success => true})
     ActiveMerchant::UniqueGateway.new.purchase(true)
   end
+
 
   def test_statsd_measure_with_method_receiving_block
     ActiveMerchant::Base.statsd_measure :post_with_block, 'ActiveMerchant.Base.post_with_block'
@@ -164,7 +165,7 @@ class StatsDTest < Test::Unit::TestCase
     ActiveMerchant::Gateway.singleton_class.extend StatsD::Instrument
     ActiveMerchant::Gateway.singleton_class.statsd_count :sync, 'ActiveMerchant.Gateway.sync'
 
-    StatsD.expects(:increment).with(includes('sync'))
+    StatsD.expects(:increment).with(includes('sync'), 1)
     ActiveMerchant::Gateway.sync
   end
 


### PR DESCRIPTION
Let the `statsd_*` methods pass a  sample rate  down to `write`

@jstorimer
