### PR TITLE
Add live_modes to allow different modes to log to statsd

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ This is the same as what Etsy uses (mentioned in the README for http://github.co
 StatsD.server = 'statsd.myservice.com:8125'
 StatsD.logger = Rails.logger
 StatsD.mode = :production
+StatsD.live_modes = [:production, :staging] # Optional. Default is [:production].
 StatsD.prefix = 'my_app' # An optional prefix to be added to each stat.
 StatsD.default_sample_rate = 0.1 # Sample 10% of events. By default all events are reported.
 ```
 
-If you set the mode to anything besides production then the library will print its calls to the logger, rather than sending them over the wire.
+If you set the mode to anything besides what is in `live_modes`, then the library will print its calls to the logger, rather than sending them over the wire.
 
 ## StatsD keys
 

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -11,12 +11,13 @@ end
 
 module StatsD
   class << self
-    attr_accessor :host, :port, :mode, :logger, :enabled, :default_sample_rate,
+    attr_accessor :host, :port, :live_modes, :mode, :logger, :enabled, :default_sample_rate,
                   :prefix, :implementation
   end
   self.enabled = true
   self.default_sample_rate = 1.0
   self.implementation = :statsd
+  self.live_modes = %w(production)
 
   TimeoutClass = defined?(::SystemTimer) ? ::SystemTimer : ::Timeout
 
@@ -146,7 +147,7 @@ module StatsD
     command << "|@#{sample_rate}" if sample_rate < 1 || (self.implementation == :statsite && sample_rate > 1)
     command << "\n" if self.implementation == :statsite
 
-    if mode.to_s == 'production'
+    if live_modes.map { |m| m.to_s }.include?(mode.to_s)
       socket_wrapper { socket.send(command, 0, host, port) }
     else
       logger.info "[StatsD] #{command}"
@@ -159,4 +160,3 @@ module StatsD
     logger.error e
   end
 end
-

--- a/test/statsd-instrument_test.rb
+++ b/test/statsd-instrument_test.rb
@@ -252,6 +252,19 @@ class StatsDTest < Test::Unit::TestCase
     StatsD.increment('foo')
   end
 
+  def test_statds_live_modes
+    StatsD.unstub(:increment)
+    StatsD.logger.expects(:info).once
+    StatsD.expects(:socket_wrapper).twice
+    StatsD.live_modes = %w(production staging)
+    StatsD.mode = :production
+    StatsD.increment('foo')
+    StatsD.mode = :staging
+    StatsD.increment('foo')
+    StatsD.mode = :foo
+    StatsD.increment('foo')
+  end
+
   def test_statsd_prefix
     StatsD.unstub(:increment)
     StatsD.prefix = 'my_app'


### PR DESCRIPTION
Gives more flexibility to log different modes to StatsD.

This is especially useful when assigning `Rails.env` to `mode`.
