### PR TITLE
Use environment variables for default configuration

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -224,5 +224,5 @@ end
 
 StatsD.enabled = true
 StatsD.default_sample_rate = 1.0
-StatsD.implementation = ENV.has_key?('STATSD_IMPLEMENTATION') ? ENV['STATSD_IMPLEMENTATION'].to_sym : :statsd
+StatsD.implementation = ENV.fetch('STATSD_IMPLEMENTATION', 'statsd').to_sym
 StatsD.server = ENV['STATSD_ADDR'] if ENV.has_key?('STATSD_ADDR')


### PR DESCRIPTION
This PR uses the STATSD_IMPLEMENTATION and STATSD_ADDR environment variables to automatically configure StatsD if they are set.

If you have multiple apps, they usually share the same StatsD infrastructure. With these environment variables, its easy to share and update the configuration between all apps/hosts within the data centre. Having to update it it in all apps is a PITA.

@jstorimer 
