### PR TITLE
Check if logger is available before sending log messages

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -189,8 +189,8 @@ module StatsD
       hash = {}
       args.each_with_index do |value, index|
         hash[order[index]] = value
-      end    
-      
+      end
+
       return hash
     end
 
@@ -215,14 +215,14 @@ module StatsD
       if mode.to_s == 'production'
         socket.send(command, 0)
       else
-        logger.info "[StatsD] #{command}"
+        logger.info "[StatsD] #{command}" if logger
       end
     rescue SocketError, IOError, SystemCallError => e
-      logger.error e
+      logger.error e if logger
     end
 
     def clean_tags(tags)
-      tags.map do |tag| 
+      tags.map do |tag|
         components = tag.split(':', 2)
         components.map { |c| c.gsub(/[^\w\.-]+/, '_') }.join(':')
       end

--- a/test/statsd_test.rb
+++ b/test/statsd_test.rb
@@ -85,7 +85,7 @@ class StatsDTest < Test::Unit::TestCase
     StatsD.increment('counter', 1, 0.5)
 
     StatsD.stubs(:rand).returns(0.4)
-    StatsD.increment('counter', 1, 0.5)    
+    StatsD.increment('counter', 1, 0.5)
   end
 
   def test_support_counter_syntax
@@ -184,7 +184,7 @@ class StatsDTest < Test::Unit::TestCase
 
     @logger.expects(:info).with(regexp_matches(/\A\[StatsD\] /))
     StatsD.increment('counter')
-  end  
+  end
 
   def test_production_mode_uses_udp_socket
     StatsD.stubs(:mode).returns(:production)
@@ -203,7 +203,7 @@ class StatsDTest < Test::Unit::TestCase
 
     StatsD.server = "localhost:1234"
     StatsD.send(:socket)
-    
+
     StatsD.port = 2345
     StatsD.send(:socket)
 
@@ -214,7 +214,7 @@ class StatsDTest < Test::Unit::TestCase
   def test_socket_error_should_not_raise_but_log
     StatsD.stubs(:mode).returns(:production)
     @socket.stubs(:connect).raises(SocketError)
-    
+
     @logger.expects(:error).with(instance_of(SocketError))
     StatsD.measure('values.foobar', 42)
   end
@@ -222,7 +222,7 @@ class StatsDTest < Test::Unit::TestCase
   def test_system_call_error_should_not_raise_but_log
     StatsD.stubs(:mode).returns(:production)
     @socket.stubs(:send).raises(Errno::ETIMEDOUT)
-    
+
     @logger.expects(:error).with(instance_of(Errno::ETIMEDOUT))
     StatsD.measure('values.foobar', 42)
   end
@@ -233,6 +233,13 @@ class StatsDTest < Test::Unit::TestCase
 
     @logger.expects(:error).with(instance_of(IOError))
     StatsD.measure('values.foobar', 42)
+  end
+
+  def test_io_error_should_log_only_if_logger_available
+    StatsD.stubs(:mode).returns(:production)
+    @socket.stubs(:send).raises(IOError)
+    StatsD.stubs(:logger).returns nil
+    assert_nothing_raised(NoMethodError) { StatsD.measure('values.foobar', 42) }
   end
 
   def test_live_local_udp_socket


### PR DESCRIPTION
I was wondering whether checking for the logger being available before sending messages to it would be a good idea. 

I just had to deal with a long debugging session to pinpoint this problem, and the code I am suggesting is the same that I have running on my local changed version of the gem.

One could argue that is better to let the call fail, but the problem is that this is not easy to trace and understand where the error message is coming from. Moreover, I could not find anywhere in the documentation that setting up the logger is mandatory.

Perhaps making the logger required would be a better solution, but I am not sure.

Please let me know what you think.
