### PR TITLE
Create a stderr logger by default

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -1,5 +1,6 @@
 require 'socket'
 require 'benchmark'
+require 'logger'
 
 require 'statsd/instrument/version'
 
@@ -248,3 +249,4 @@ StatsD.default_sample_rate = 1.0
 StatsD.implementation = ENV.fetch('STATSD_IMPLEMENTATION', 'statsd').to_sym
 StatsD.server = ENV['STATSD_ADDR'] if ENV.has_key?('STATSD_ADDR')
 StatsD.mode = ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
+StatsD.logger = Logger.new($stderr)


### PR DESCRIPTION
@phoet for review please.

I think stderr makes most sense because in production mode it only writes errors to the logger.
