### PR TITLE
Return the metric instance for every StatsD call.

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -123,8 +123,9 @@ module StatsD
       end
 
       result = nil
-      ms = value || 1000 * Benchmark.realtime { result = block.call }
-      collect_metric(hash_argument(metric_options).merge(type: :ms, name: key, value: ms))
+      value = 1000 * Benchmark.realtime { result = block.call } if block_given?
+      metric = collect_metric(hash_argument(metric_options).merge(type: :ms, name: key, value: value))
+      result = metric unless block_given?
       result
     end
 
@@ -174,7 +175,8 @@ module StatsD
     end
 
     def collect_metric(options)
-      backend.collect_metric(StatsD::Instrument::Metric.new(options))
+      backend.collect_metric(metric = StatsD::Instrument::Metric.new(options))
+      metric
     end
   end
 end

--- a/test/statsd_test.rb
+++ b/test/statsd_test.rb
@@ -9,7 +9,9 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_measure_with_explicit_value
-    metric = capture_statsd_call { StatsD.measure('values.foobar', 42) }
+    result = nil
+    metric = capture_statsd_call { result = StatsD.measure('values.foobar', 42) }
+    assert_equal metric, result
     assert_equal 'values.foobar', metric.name
     assert_equal 42, metric.value
     assert_equal :ms, metric.type
@@ -34,7 +36,9 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_increment
-    metric = capture_statsd_call { StatsD.increment('values.foobar', 3) }
+    result = nil
+    metric = capture_statsd_call { result = StatsD.increment('values.foobar', 3) }
+    assert_equal metric, result
     assert_equal :c, metric.type
     assert_equal 'values.foobar', metric.name
     assert_equal 3, metric.value
@@ -55,28 +59,36 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_gauge
-    metric = capture_statsd_call { StatsD.gauge('values.foobar', 12) }
+    result = nil
+    metric = capture_statsd_call { result = StatsD.gauge('values.foobar', 12) }
+    assert_equal metric, result
     assert_equal :g, metric.type
     assert_equal 'values.foobar', metric.name
     assert_equal 12, metric.value
   end
 
   def test_statsd_set
-    metric = capture_statsd_call { StatsD.set('values.foobar', 'unique_identifier') }
+    result = nil
+    metric = capture_statsd_call { result = StatsD.set('values.foobar', 'unique_identifier') }
+    assert_equal metric, result
     assert_equal :s, metric.type
     assert_equal 'values.foobar', metric.name
     assert_equal 'unique_identifier', metric.value
   end
 
   def test_statsd_histogram
-    metric = capture_statsd_call { StatsD.histogram('values.foobar', 42) }
+    result = nil
+    metric = capture_statsd_call { result = StatsD.histogram('values.foobar', 42) }
+    assert_equal metric, result
     assert_equal :h, metric.type
     assert_equal 'values.foobar', metric.name
     assert_equal 42, metric.value
   end
 
   def test_statsd_key_value
-    metric = capture_statsd_call { StatsD.key_value('values.foobar', 42) }
+    result = nil
+    metric = capture_statsd_call { result = StatsD.key_value('values.foobar', 42) }
+    assert_equal metric, result
     assert_equal :kv, metric.type
     assert_equal 'values.foobar', metric.name
     assert_equal 42, metric.value


### PR DESCRIPTION
The should always be a truish value, no matter what backend is being used. 

The only exception is when calling StastD.measure with a block, in which case it will return the return value of the block.

@camilo @csfrancis @jduff @jstorimer 
