### PR TITLE
Fallback to Time.now for rubies that don't support Process.clock_gettime

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -9,13 +9,13 @@ module StatsD
     end
 
     if Process.respond_to?(:clock_gettime)
-      def self.time
+      def self.duration
         start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         yield
         Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
       end
     else
-      def self.time
+      def self.duration
         start = Time.now
         yield
         Time.now - start
@@ -136,7 +136,7 @@ module StatsD
       end
 
       result = nil
-      value  = 1000 * StatsD::Instrument.time { result = block.call } if block_given?
+      value  = 1000 * StatsD::Instrument.duration { result = block.call } if block_given?
       metric = collect_metric(hash_argument(metric_options).merge(type: :ms, name: key, value: value))
       result = metric unless block_given?
       result

--- a/test/statsd_test.rb
+++ b/test/statsd_test.rb
@@ -23,7 +23,7 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_measure_with_benchmarked_duration
-    StatsD::Instrument.stubs(:time).returns(1.12)
+    StatsD::Instrument.stubs(:duration).returns(1.12)
     metric = capture_statsd_call do
       StatsD.measure('values.foobar') { 'foo' }
     end


### PR DESCRIPTION
Follow-up on https://github.com/Shopify/statsd-instrument/pull/42.

`Process.clock_gettime` was only added to Ruby [in version `2.1.0`](https://github.com/ruby/ruby/blob/v2_1_0/NEWS#L113-L114). Older versions do not have a way to access the monotonic clock so we should fallback to `Time.now`.

Ping @wvanbergen 
