### PR TITLE
Support nested StatsD assertions

### DIFF
--- a/lib/statsd/instrument/assertions.rb
+++ b/lib/statsd/instrument/assertions.rb
@@ -6,6 +6,10 @@ module StatsD::Instrument::Assertions
     block.call
     mock_backend.collected_metrics
   ensure
+    if old_backend.kind_of?(StatsD::Instrument::Backends::CaptureBackend)
+      old_backend.collected_metrics.concat(mock_backend.collected_metrics)
+    end
+
     StatsD.backend = old_backend
   end
 

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -113,7 +113,44 @@ class AssertionsTest < Minitest::Test
         StatsD.increment('counter', tags: ['a:b', 'c:d'])
       end
     end
-  end  
+  end
+
+  def test_nested_assertions
+    assert_no_assertion_triggered do
+      @test_case.assert_statsd_increment('counter1') do
+        @test_case.assert_statsd_increment('counter2') do
+          StatsD.increment('counter1')
+          StatsD.increment('counter2')
+        end
+      end
+    end
+
+    assert_no_assertion_triggered do
+      @test_case.assert_statsd_increment('counter1') do
+        StatsD.increment('counter1')
+        @test_case.assert_statsd_increment('counter2') do
+          StatsD.increment('counter2')
+        end
+      end
+    end    
+
+    assert_assertion_triggered do
+      @test_case.assert_statsd_increment('counter1') do
+        @test_case.assert_statsd_increment('counter2') do
+          StatsD.increment('counter2')
+        end
+      end
+    end
+
+    assert_assertion_triggered do
+      @test_case.assert_statsd_increment('counter1') do
+        @test_case.assert_statsd_increment('counter2') do
+          StatsD.increment('counter1')
+        end
+        StatsD.increment('counter2')
+      end
+    end
+  end
 
   private
 


### PR DESCRIPTION
Makes sure that nested StatsD metric assertion methods work as you expect.

@richardmonette @pickle27 for review.
