### PR TITLE
Test against latest Ruby 2.1 & 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.1
-  - ruby-head
+  - 2.0
+  - 2.1
+  - 2.2
   - jruby-19mode
   - rbx-2
+  - ruby-head
 
 matrix:
   allow_failures:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,8 @@ please at an entry to the "unreleased changes" section below.
 
 ### Unreleased changes
 
-- Nothing yet!
-
----
+- Drop support for Ruby 1.9.3.
+- Add support for Ruby 2.2.
 
 ### Version 2.0.6
 

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ end
 
 ### Compatibility
 
-Tested using Travis CI against Ruby 1.9.3, Ruby 2.0.0, Ruby 2.1.1, Rubinius, and JRuby
+Tested using Travis CI against Ruby 2.0, 2.1, 2.2, Rubinius, and JRuby.
 
 ### Reliance on DNS
 


### PR DESCRIPTION
Hi there,

this PR includes 3 things regarding the build environment:

* Run specs against latest Ruby 2.1 (2.1.5 instead of 2.1.1)
* Add support for Ruby 2.2
* Drop support for Ruby 1.9.3

We could also think about removing support for MRI 1.9.3 as official support has ended just recently: https://www.ruby-lang.org/en/news/2015/02/23/support-for-ruby-1-9-3-has-ended/.

@jstorimer, @wvanbergen looking forward to your feedback. :)

Cheers