### PR TITLE
webscale: do less work when normalizing tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ doc
 .bundle
 Gemfile.lock
 pkg/*
+vendor/

--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -103,9 +103,6 @@ class StatsD::Instrument::Metric
   def self.normalize_tags(tags)
     return if tags.nil?
     tags = tags.map { |k, v| "#{k}:#{v}" } if tags.is_a?(Hash)
-    tags.map do |tag|
-      components = tag.split(':', 2)
-      components.map { |c| c.gsub(/[^\w\.-]+/, '_') }.join(':')
-    end
+    tags.map { |tag| tag.tr('|'.freeze, ''.freeze) }
   end
 end

--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -102,7 +102,7 @@ class StatsD::Instrument::Metric
   # @return [Array<String>, nil] the list of tags in canonical form.
   def self.normalize_tags(tags)
     return if tags.nil?
-    tags = tags.map { |k, v| "#{k}:#{v}" } if tags.is_a?(Hash)
-    tags.map { |tag| tag.tr('|'.freeze, ''.freeze) }
+    tags = tags.map { |k, v| "#{k.to_s.tr(':', '')}:#{v.to_s.tr(':', '')}" } if tags.is_a?(Hash)
+    tags.map { |tag| tag.tr('|,'.freeze, ''.freeze) }
   end
 end

--- a/statsd-instrument.gemspec
+++ b/statsd-instrument.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'mocha'
   spec.add_development_dependency 'yard'
+  spec.add_development_dependency 'benchmark-ips'
 end

--- a/test/benchmark/tags.rb
+++ b/test/benchmark/tags.rb
@@ -1,0 +1,34 @@
+require 'statsd-instrument'
+require 'benchmark/ips'
+
+Benchmark.ips do |bench|
+  bench.report("normalized tags with simple hash") do
+    StatsD::Instrument::Metric.normalize_tags(:tag => 'value')
+  end
+
+  bench.report("normalized tags with simple array") do
+    StatsD::Instrument::Metric.normalize_tags(['test:test'])
+  end
+
+  bench.report("normalized tags with large hash") do
+    StatsD::Instrument::Metric.normalize_tags({
+      mobile: true,
+      pod: "1",
+      protocol: "https",
+      country: "Langbortistan",
+      complete: true,
+      shop: "omg shop that has a longer name",
+    })
+  end
+
+  bench.report("normalized tags with large array") do
+    StatsD::Instrument::Metric.normalize_tags([
+      "mobile:true",
+      "pod:1",
+      "protocol:https",
+      "country:Langbortistan",
+      "complete:true",
+      "shop:omg_shop_that_has_a_longer_name",
+    ])
+  end
+end

--- a/test/metric_test.rb
+++ b/test/metric_test.rb
@@ -24,13 +24,10 @@ class MetricTest < Minitest::Test
     assert_equal 'counter', m.name
   end
 
-  def test_rewrite_shitty_tags
-    assert_equal ['igno_red'], StatsD::Instrument::Metric.normalize_tags(['igno,red'])
-    assert_equal ['igno_red'], StatsD::Instrument::Metric.normalize_tags(['igno  red'])
-    assert_equal ['test:test_test'], StatsD::Instrument::Metric.normalize_tags(['test:test:test'])
-    assert_equal ['topic:foo_foo', 'bar_'], StatsD::Instrument::Metric.normalize_tags(['topic:foo : foo', 'bar '])
+  def test_handle_bad_tags
+    assert_equal ['ignored'], StatsD::Instrument::Metric.normalize_tags(['igno|red'])
   end
-  
+
   def test_rewrite_tags_provided_as_hash
     assert_equal ['tag:value'], StatsD::Instrument::Metric.normalize_tags(:tag => 'value')
     assert_equal ['tag:value', 'tag2:value2'], StatsD::Instrument::Metric.normalize_tags(:tag => 'value', :tag2 => 'value2')

--- a/test/metric_test.rb
+++ b/test/metric_test.rb
@@ -26,6 +26,7 @@ class MetricTest < Minitest::Test
 
   def test_handle_bad_tags
     assert_equal ['ignored'], StatsD::Instrument::Metric.normalize_tags(['igno|red'])
+    assert_equal ['lolclass:omglol'], StatsD::Instrument::Metric.normalize_tags({ :"lol::class" => "omg::lol" })
   end
 
   def test_rewrite_tags_provided_as_hash


### PR DESCRIPTION
A lot of CPU time is spent normalizing tags. A profile from our application shows `~1.3%` CPU is spent doing this:

```
==================================
  Mode: cpu(1000)
  Samples: 27777 (0.26% miss rate)
  GC: 1281 (4.61%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      2191   (7.9%)        1721   (6.2%)     #<Module:0x007fd1fd6e3288>.load_with_autoloading
       606   (2.2%)         606   (2.2%)     block (4 levels) in Class#class_attribute
       569   (2.0%)         569   (2.0%)     ThreadSafe::NonConcurrentCacheBackend#[]
       561   (2.0%)         561   (2.0%)     block in ActiveRecord::Reflection::ClassMethods#reflections
       487   (1.8%)         487   (1.8%)     ActiveSupport::PerThreadRegistry#instance
       412   (1.5%)         412   (1.5%)     Sharding::Switcher.current_shard_id
      1453   (5.2%)         399   (1.4%)     block in ActiveRecord::AttributeMethods::Read#read_attribute
       358   (1.3%)         358   (1.3%)     block (2 levels) in StatsD::Instrument::Metric.normalize_tags
       269   (1.0%)         269   (1.0%)     block (2 levels) in <class:Numeric>
       258   (0.9%)         251   (0.9%)     Memcached#check_return_code
```

The logic currently is fairly complicated, because it tries to compensate for bad tags. This code sits in a hot path (we use it for every single query), thus I think we should trade speed for usability here and only avoid the case where you can "break" out of the tags with a `|`, and allow even `:` because checking for it slows us down significantly. Implementors of tags generally just scan until `|` or a newline, which means they're fine with `,` and other special characters. A `:` can somewhat mess things up, but I don't think that's on us. This is consistent with [how the Datadog Ruby gem does it](https://github.com/DataDog/dogstatsd-ruby/blob/01627ca39d73febf510584a5e407b33a77354099/lib/statsd.rb#L259).

This PR speeds up tag generating up to `5x`. It's significantly faster to use the array-based syntax, which I may tune our application to use for more of the hot calls through `StatsD`.

**Before**

```
Calculating -------------------------------------                                                                                                                                            
normalized tags with simple hash                                                                                                                                                             
                        14.584k i/100ms                                                                                                                                                      
normalized tags with simple array                                                                                                                                                            
                        22.438k i/100ms                                                                                                                                                      
normalized tags with large hash                                                                                                                                                              
                         3.169k i/100ms                                                                                                                                                      
normalized tags with large array                                                                                                                                                             
                         4.778k i/100ms                                                                                                                                                      
-------------------------------------------------                                                                                                                                            
normalized tags with simple hash                                                                                                                                                             
                        196.370k (±17.1%) i/s -    947.960k                                                                                                                                  
normalized tags with simple array                                                                                                                                                            
                        306.619k (±14.6%) i/s -      1.503M                                                                                                                                  
normalized tags with large hash                                                                                                                                                              
                         34.976k (±20.2%) i/s -    167.957k                                                                                                                                  
normalized tags with large array                                                                                                                                                             
                         54.995k (±16.2%) i/s -    267.568k
```

**After**

```
Calculating -------------------------------------                                                                                                                                            
normalized tags with simple hash                                                                                                                                                             
                        27.198k i/100ms                                                                                                                                                      
normalized tags with simple array                                                                                                                                                            
                        43.078k i/100ms                                                                                                                                                      
normalized tags with large hash                                                                                                                                                              
                         9.015k i/100ms                                                                                                                                                      
normalized tags with large array                                                                                                                                                             
                        18.329k i/100ms                                                                                                                                                      
-------------------------------------------------                                                                                                                                            
normalized tags with simple hash                                                                                                                                                             
                        442.597k (±19.4%) i/s -      2.094M                                                                                                                                  
normalized tags with simple array                                                                                                                                                            
                        937.828k (±14.8%) i/s -      4.566M                                                                                                                                  
normalized tags with large hash                                                                                                                                                              
                        107.640k (±16.7%) i/s -    522.870k                                                                                                                                  
normalized tags with large array                                                                                                                                                             
                        215.219k (±13.5%) i/s -      1.063M
```

@csfrancis @camilo @wvanbergen 