### PR TITLE
Add RSpec matchers for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,10 @@ warning is logged to `StatsD.logger`.
 
 ## Testing
 
-This library comes with a module called `StatsD::Instrument::Assertions` to help you write tests
+This library comes with a module called `StatsD::Instrument::Assertions` and `StatsD::Instrument::Matchers` to help you write tests
 to verify StatsD is called properly.
+
+### minitest
 
 ``` ruby
 class MyTestcase < Minitest::Test
@@ -252,6 +254,31 @@ class MyTestcase < Minitest::Test
     assert_equal :c, metrics[0].type
     assert_equal 1, metrics[0].value
     assert_equal 0.01, metrics[0].sample_rate
+  end
+end
+
+```
+
+### RSpec
+
+```ruby
+RSpec.describe 'Matchers' do
+  context 'trigger_statsd_increment' do
+    it 'will pass if there is exactly one matching StatsD call' do
+      expect { StatsD.increment('counter') }.to trigger_statsd_increment('counter')
+    end
+
+    it 'will pass if it matches the correct number of times' do
+      expect { 
+        2.times do
+          StatsD.increment('counter') 
+        end
+      }.to trigger_statsd_increment('counter', times: 2)
+    end
+
+    it 'will pass if there is no matching StatsD call on negative expectation' do
+      expect { StatsD.increment('other_counter') }.not_to trigger_statsd_increment('counter')
+    end
   end
 end
 

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -354,6 +354,8 @@ end
 require 'statsd/instrument/version'
 require 'statsd/instrument/metric'
 require 'statsd/instrument/backend'
-require 'statsd/instrument/assertions'
 require 'statsd/instrument/environment'
+require 'statsd/instrument/helpers'
+require 'statsd/instrument/assertions'
+require 'statsd/instrument/matchers' if defined?(::RSpec)
 require 'statsd/instrument/railtie' if defined?(Rails)

--- a/lib/statsd/instrument/assertions.rb
+++ b/lib/statsd/instrument/assertions.rb
@@ -1,17 +1,5 @@
 module StatsD::Instrument::Assertions
-
-  def capture_statsd_calls(&block)
-    mock_backend = StatsD::Instrument::Backends::CaptureBackend.new
-    old_backend, StatsD.backend = StatsD.backend, mock_backend
-    block.call
-    mock_backend.collected_metrics
-  ensure
-    if old_backend.kind_of?(StatsD::Instrument::Backends::CaptureBackend)
-      old_backend.collected_metrics.concat(mock_backend.collected_metrics)
-    end
-
-    StatsD.backend = old_backend
-  end
+  include StatsD::Instrument::Helpers
 
   def assert_no_statsd_calls(metric_name = nil, &block)
     metrics = capture_statsd_calls(&block)

--- a/lib/statsd/instrument/helpers.rb
+++ b/lib/statsd/instrument/helpers.rb
@@ -1,0 +1,14 @@
+module StatsD::Instrument::Helpers
+  def capture_statsd_calls(&block)
+    mock_backend = StatsD::Instrument::Backends::CaptureBackend.new
+    old_backend, StatsD.backend = StatsD.backend, mock_backend
+    block.call
+    mock_backend.collected_metrics
+  ensure
+    if old_backend.kind_of?(StatsD::Instrument::Backends::CaptureBackend)
+      old_backend.collected_metrics.concat(mock_backend.collected_metrics)
+    end
+
+    StatsD.backend = old_backend
+  end
+end

--- a/lib/statsd/instrument/matchers.rb
+++ b/lib/statsd/instrument/matchers.rb
@@ -1,0 +1,72 @@
+require 'rspec/expectations'
+
+module StatsD::Instrument::Matchers
+  CUSTOM_MATCHERS = {
+    increment: :c,
+    measure: :ms,
+    gauge: :g,
+    histogram: :h,
+    set: :s,
+    key_value: :kv
+  }
+
+  class Matcher
+    include StatsD::Instrument::Helpers
+
+    def initialize(metric_type, metric_name, options = {})
+      @metric_type = metric_type
+      @metric_name = metric_name
+      @options = options
+    end
+
+    def matches?(block)
+      begin
+        expect_statsd_call(@metric_type, @metric_name, @options, &block)
+      rescue RSpec::Expectations::ExpectationNotMetError => e
+        @message = e.message
+
+        false
+      end
+    end
+
+    def failure_message
+      @message
+    end
+
+    def failure_message_when_negated
+      "No StatsD calls for metric #{@metric_name} expected."
+    end
+
+    def supports_block_expectations?
+      true
+    end
+
+    private
+
+    def expect_statsd_call(metric_type, metric_name, options, &block)
+      metrics = capture_statsd_calls(&block)
+      metrics = metrics.select { |m| m.type == metric_type && m.name == metric_name }
+
+      raise RSpec::Expectations::ExpectationNotMetError, "No StatsD calls for metric #{metric_name} were made." if metrics.empty?
+      raise RSpec::Expectations::ExpectationNotMetError, "The numbers of StatsD calls for metric #{metric_name} was unexpected. Expected #{options[:times].inspect}, got #{metrics.length}" if options[:times] && options[:times] != metrics.length
+
+      metric = metrics.first
+
+      raise RSpec::Expectations::ExpectationNotMetError, "Unexpected value submitted for StatsD metric #{metric_name}" if options[:sample_rate] && options[:sample_rate] != metric.sample_rate
+      raise RSpec::Expectations::ExpectationNotMetError, "Unexpected StatsD sample rate for metric #{metric_name}" if options[:value] && options[:value] != metric.value
+      raise RSpec::Expectations::ExpectationNotMetError, "Unexpected StatsD tags for metric #{metric_name}" if options[:tags] && options[:tags] != metric.tags
+
+      true
+    end
+  end
+
+  CUSTOM_MATCHERS.each do |method_name, metric_type|
+    klass = Class.new(Matcher)
+
+    define_method "trigger_statsd_#{method_name}" do |metric_name, options = {}|
+      klass.new(metric_type, metric_name, options)
+    end
+
+    StatsD::Instrument::Matchers.const_set(method_name.capitalize, klass)
+  end
+end

--- a/statsd-instrument.gemspec
+++ b/statsd-instrument.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest'
+  spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'mocha'
   spec.add_development_dependency 'yard'
   spec.add_development_dependency 'benchmark-ips'

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -1,25 +1,10 @@
 require 'test_helper'
 
 class AssertionsTest < Minitest::Test
-
   def setup
     test_class = Class.new(Minitest::Test)
     test_class.send(:include, StatsD::Instrument::Assertions)
     @test_case = test_class.new('fake')
-  end
-
-  def test_capture_metrics_inside_block_only
-    StatsD.increment('counter')
-    metrics = @test_case.capture_statsd_calls do
-      StatsD.increment('counter')
-      StatsD.gauge('gauge', 12)
-    end
-    StatsD.gauge('gauge', 15)
-
-    assert_equal 2, metrics.length
-    assert_equal 'counter', metrics[0].name
-    assert_equal 'gauge', metrics[1].name
-    assert_equal 12, metrics[1].value
   end
 
   def test_assert_no_statsd_calls
@@ -45,7 +30,7 @@ class AssertionsTest < Minitest::Test
       @test_case.assert_no_statsd_calls do
         StatsD.increment('other')
       end
-    end    
+    end
   end
 
   def test_assert_statsd_call
@@ -132,7 +117,7 @@ class AssertionsTest < Minitest::Test
           StatsD.increment('counter2')
         end
       end
-    end    
+    end
 
     assert_assertion_triggered do
       @test_case.assert_statsd_increment('counter1') do

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class HelpersTest < Minitest::Test
+  def setup
+    test_class = Class.new(Minitest::Test)
+    test_class.send(:include, StatsD::Instrument::Helpers)
+    @test_case = test_class.new('fake')
+  end
+
+  def test_capture_metrics_inside_block_only
+    StatsD.increment('counter')
+    metrics = @test_case.capture_statsd_calls do
+      StatsD.increment('counter')
+      StatsD.gauge('gauge', 12)
+    end
+    StatsD.gauge('gauge', 15)
+
+    assert_equal 2, metrics.length
+    assert_equal 'counter', metrics[0].name
+    assert_equal 'gauge', metrics[1].name
+    assert_equal 12, metrics[1].value
+  end
+end
+

--- a/test/matchers_test.rb
+++ b/test/matchers_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+require 'statsd/instrument/matchers'
+
+class MatchersTest < Minitest::Test
+  def test_statsd_increment_matched
+    assert StatsD::Instrument::Matchers::Increment.new(:c, 'counter', {}).matches? lambda { StatsD.increment('counter') }
+  end
+
+  def test_statsd_increment_not_matched
+    refute StatsD::Instrument::Matchers::Increment.new(:c, 'counter', {}).matches? lambda { StatsD.increment('not_counter') }
+  end
+
+  def test_statsd_increment_with_times_matched
+    assert StatsD::Instrument::Matchers::Increment.new(:c, 'counter', times: 1).matches? lambda { StatsD.increment('counter') }
+  end
+
+  def test_statsd_increment_with_times_not_matched
+    refute StatsD::Instrument::Matchers::Increment.new(:c, 'counter', times: 2).matches? lambda { StatsD.increment('counter', times: 3) }
+  end
+
+  def test_statsd_increment_with_sample_rate_matched
+    assert StatsD::Instrument::Matchers::Increment.new(:c, 'counter', sample_rate: 0.5).matches? lambda { StatsD.increment('counter', sample_rate: 0.5) }
+  end
+
+  def test_statsd_increment_with_sample_rate_not_matched
+    refute StatsD::Instrument::Matchers::Increment.new(:c, 'counter', sample_rate: 0.5).matches? lambda { StatsD.increment('counter', sample_rate: 0.7) }
+  end
+
+  def test_statsd_increment_with_value_matched
+    assert StatsD::Instrument::Matchers::Increment.new(:c, 'counter', value: 1).matches? lambda { StatsD.increment('counter') }
+  end
+
+  def test_statsd_increment_with_value_not_matched
+    refute StatsD::Instrument::Matchers::Increment.new(:c, 'counter', value: 3).matches? lambda { StatsD.increment('counter') }
+  end
+
+  def test_statsd_increment_with_tags_matched
+    assert StatsD::Instrument::Matchers::Increment.new(:c, 'counter', tags: ['a', 'b']).matches? lambda { StatsD.increment('counter', tags: ['a', 'b']) }
+  end
+
+  def test_statsd_increment_with_tags_not_matched
+    refute StatsD::Instrument::Matchers::Increment.new(:c, 'counter', tags: ['a', 'b']).matches? lambda { StatsD.increment('counter', tags: ['c']) }
+  end
+end


### PR DESCRIPTION
Created a new set of matchers that can be use in RSpec with all the current methods of `statsd-instrument`.

```ruby
expect { StatsD.increment('counter') }.to trigger_statsd_increment('counter')
expect { StatsD.increment('counter') }.not_to trigger_statsd_increment('other_counter')
```
ping @wvanbergen @jstorimer 
cc @davidcornu @unixcharles 