### PR TITLE
metric: replacing :: is not needed for statsd protocol

### DIFF
--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -101,8 +101,8 @@ class StatsD::Instrument::Metric
   # @param tags [Array<String>, Hash<String, String>, nil] Tags specified in any form.
   # @return [Array<String>, nil] the list of tags in canonical form.
   def self.normalize_tags(tags)
-    return if tags.nil?
-    tags = tags.map { |k, v| "#{k.to_s.tr(':', '')}:#{v.to_s.tr(':', '')}" } if tags.is_a?(Hash)
+    return unless tags
+    tags = tags.map { |k, v| k.to_s + ":".freeze + v.to_s } if tags.is_a?(Hash)
     tags.map { |tag| tag.tr('|,'.freeze, ''.freeze) }
   end
 end

--- a/test/metric_test.rb
+++ b/test/metric_test.rb
@@ -26,7 +26,7 @@ class MetricTest < Minitest::Test
 
   def test_handle_bad_tags
     assert_equal ['ignored'], StatsD::Instrument::Metric.normalize_tags(['igno|red'])
-    assert_equal ['lolclass:omglol'], StatsD::Instrument::Metric.normalize_tags({ :"lol::class" => "omg::lol" })
+    assert_equal ['lol::class:omg::lol'], StatsD::Instrument::Metric.normalize_tags({ :"lol::class" => "omg::lol" })
   end
 
   def test_rewrite_tags_provided_as_hash


### PR DESCRIPTION
Rice up `normalize_tags` even harder. With e.g. the Datadog statsd implementation it's not actually required to replace colons, they can be part of tags since keys and values are seperated by the first colon—different tags by colon. I think this is reasonable to do.

What do you think @wvanbergen ?