### PR TITLE
assertion options[:ignore_tags]

### DIFF
--- a/lib/statsd/instrument/assertions.rb
+++ b/lib/statsd/instrument/assertions.rb
@@ -43,7 +43,22 @@ module StatsD::Instrument::Assertions
 
     assert_equal options[:sample_rate], metric.sample_rate, "Unexpected value submitted for StatsD metric #{metric_name}" if options[:sample_rate]
     assert_equal options[:value], metric.value, "Unexpected StatsD sample rate for metric #{metric_name}" if options[:value]
-    assert_equal Set.new(StatsD::Instrument::Metric.normalize_tags(options[:tags])), Set.new(metric.tags), "Unexpected StatsD tags for metric #{metric_name}" if options[:tags]
+
+    if options[:tags]
+      expected_tags = Set.new(StatsD::Instrument::Metric.normalize_tags(options[:tags]))
+      actual_tags = Set.new(metric.tags)
+
+      if options[:ignore_tags]
+        ignored_tags = Set.new(StatsD::Instrument::Metric.normalize_tags(options[:ignore_tags])) - expected_tags
+        actual_tags -= ignored_tags
+
+        if options[:ignore_tags].is_a?(Array)
+          actual_tags.delete_if{ |key| options[:ignore_tags].include?(key.split(":").first) }
+        end
+      end
+
+      assert_equal expected_tags, actual_tags, "Unexpected StatsD tags for metric #{metric_name}"
+    end
 
     metric
   end

--- a/lib/statsd/instrument/assertions.rb
+++ b/lib/statsd/instrument/assertions.rb
@@ -57,7 +57,8 @@ module StatsD::Instrument::Assertions
         end
       end
 
-      assert_equal expected_tags, actual_tags, "Unexpected StatsD tags for metric #{metric_name}"
+      assert_equal expected_tags, actual_tags,
+        "Unexpected StatsD tags for metric #{metric_name}. Expected: #{expected_tags.inspect}, actual: #{actual_tags.inspect}"
     end
 
     metric

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -87,6 +87,48 @@ class AssertionsTest < Minitest::Test
     end
 
     assert_assertion_triggered do
+      @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: ['a', 'b'], ignore_tags: ['b']) do
+        StatsD.increment('counter', sample_rate: 0.5, tags: ['a'])
+      end
+    end
+
+    assert_no_assertion_triggered do
+      @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: ['a'], ignore_tags: ['b']) do
+        StatsD.increment('counter', sample_rate: 0.5, tags: ['a', 'b'])
+      end
+    end
+
+    assert_no_assertion_triggered do
+      @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: ['a'], ignore_tags: ['b']) do
+        StatsD.increment('counter', sample_rate: 0.5, tags: ['a'])
+      end
+    end
+
+    assert_no_assertion_triggered do
+      @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: { a: 1 }, ignore_tags: { b: 2 }) do
+        StatsD.increment('counter', sample_rate: 0.5, tags: { a: 1, b: 2 })
+      end
+    end
+
+    assert_assertion_triggered do
+      @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: { a: 1 }, ignore_tags: { b: 2 }) do
+        StatsD.increment('counter', sample_rate: 0.5, tags: { a: 1, b: 3 })
+      end
+    end
+
+    assert_assertion_triggered do
+      @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: { a: 1, b: 3 }, ignore_tags: ['b']) do
+        StatsD.increment('counter', sample_rate: 0.5, tags: { a: 1, b: 2 })
+      end
+    end
+
+    assert_no_assertion_triggered do
+      @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: { a: 1 }, ignore_tags: ['b']) do
+        StatsD.increment('counter', sample_rate: 0.5, tags: { a: 1, b: 2 })
+      end
+    end
+
+    assert_assertion_triggered do
       @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: ['a', 'b']) do
         StatsD.increment('counter', sample_rate: 0.2, tags: ['c'])
       end


### PR DESCRIPTION
This adds `options[:ignore_tags]` to the StatsD test assertions, allowing you to add a list (or hash) of tags that are allowed to be present even though they weren't expected (but if they were expected then they have to be present).

The splitting thing seems a bit hacky, but not sure how else to do it.

@wvanbergen, thoughts?