### PR TITLE
Make prefix more flexible in metrics

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -368,6 +368,7 @@ module StatsD
   # @param options (see StatsD::Instrument::Metric#initialize)
   # @return [StatsD::Instrument::Metric] The meric that was sent to the backend.
   def collect_metric(options)
+    options[:prefix] ||= prefix
     backend.collect_metric(metric = StatsD::Instrument::Metric.new(options))
     metric
   end

--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -3,7 +3,7 @@
 # @!attribute type
 #   @return [Symbol] The metric type. Must be one of {StatsD::Instrument::Metric::TYPES}
 # @!attribute name
-#   @return [String] The name of the metric. {StatsD#prefix} will automatically be applied
+#   @return [String] The name of the metric. <tt>:prefix</tt> option will automatically be applied
 #     to the metric in the constructor, unless the <tt>:no_prefix</tt> option is set.
 # @!attribute value
 #   @see #default_value
@@ -36,7 +36,8 @@ class StatsD::Instrument::Metric
   #
   # @option options [Symbol] :type The type of the metric.
   # @option options [String] :name The name of the metric without prefix.
-  # @option options [Boolean] :no_prefix Set to <tt>true</tt> if you don't want to apply {StatsD#prefix}
+  # @option options [String] :prefix The prefix of the metric.
+  # @option options [Boolean] :no_prefix Set to <tt>true</tt> if you don't want to apply prefix
   # @option options [Numeric, String, nil] :value The value to collect for the metric. If set to
   #   <tt>nil>/tt>, {#default_value} will be used.
   # @option options [Numeric, nil] :sample_rate The sample rate to use. If not set, it will use
@@ -46,7 +47,7 @@ class StatsD::Instrument::Metric
   def initialize(options = {})
     @type = options[:type] or raise ArgumentError, "Metric :type is required."
     @name = options[:name] or raise ArgumentError, "Metric :name is required."
-    @name = StatsD.prefix ? "#{StatsD.prefix}.#{@name}" : @name unless options[:no_prefix]
+    @name = options[:prefix] ? "#{options[:prefix]}.#{@name}" : @name unless options[:no_prefix]
 
     @value       = options[:value] || default_value
     @sample_rate = options[:sample_rate] || StatsD.default_sample_rate

--- a/test/metric_test.rb
+++ b/test/metric_test.rb
@@ -16,11 +16,10 @@ class MetricTest < Minitest::Test
   end
 
   def test_name_prefix
-    StatsD.stubs(:prefix).returns('prefix')
-    m = StatsD::Instrument::Metric.new(type: :c, name: 'counter')
+    m = StatsD::Instrument::Metric.new(type: :c, name: 'counter', prefix: 'prefix')
     assert_equal 'prefix.counter', m.name
 
-    m = StatsD::Instrument::Metric.new(type: :c, name: 'counter', no_prefix: true)
+    m = StatsD::Instrument::Metric.new(type: :c, name: 'counter', prefix: 'prefix', no_prefix: true)
     assert_equal 'counter', m.name
   end
 


### PR DESCRIPTION
This opens ability to set `prefix` in other module that extends `StatsD`.

```
module FooStatsD; end; 
FooStatsD.extend(StatsD)

FooStatsD.prefix = "foo"
FooStatsD.increment("bar", 1) # => #<StatsD::Instrument::Metric increment foo.bar:1>

StatsD.prefix = "baz"
StatsD.increment("bar", 1) # => #<StatsD::Instrument::Metric increment baz.bar:1>
```

This is a solution based on https://github.com/Shopify/statsd-instrument/issues/64

> Once was necessary to have different prefixes and another time to have different servers where metrics are collected.
