### PR TITLE
Support for dynamic metric options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ please at an entry to the "unreleased changes" section below.
 
 - Drop support for Ruby 1.9.3.
 - Add support for Ruby 2.2.
+- Adds support for metric options that are a hash to have a lambda as a value which has access to the method caller and args. This is implemented specifically for tags but could support future options.
 
 ### Version 2.0.6
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ The Datadog implementation support tags, which you can use to slice and dice met
 ``` ruby
 StatsD.increment('my.counter', tags: ['env:production', 'unicorn'])
 GoogleBase.statsd_count :insert, 'GoogleBase.insert', tags: ['env:production']
+
+# Use a lambda for generating dynamic tags from the caller or method arguments
+GoogleBase.statsd_count :insert, 'GoogleBase.insert', tags: lambda { |calle, args| [args[0]] }
 ```
 
 If implementation is not set to `:datadog`, tags will not be included in the UDP packets, and a

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -168,10 +168,11 @@ module StatsD
     # @param name (see #statsd_measure)
     # @param metric_options (see #statsd_measure)
     # @return [void]
-    def statsd_count(method, name, *metric_options)
+    def statsd_count(method, name, *metric_option_args)
+      #metric_options = metric_options_args
       add_to_method(method, name, :count) do |old_method, new_method, metric_name|
         define_method(new_method) do |*args, &block|
-          metric_options = StatsD::Instrument.process_metric_options(metric_options, self, *args)
+          metric_options = StatsD::Instrument.process_metric_options(metric_option_args, self, *args)
           StatsD.increment(StatsD::Instrument.generate_metric_name(metric_name, self, *args), 1, *metric_options)
           send(old_method, *args, &block)
         end

--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -103,6 +103,6 @@ class StatsD::Instrument::Metric
   def self.normalize_tags(tags)
     return unless tags
     tags = tags.map { |k, v| k.to_s + ":".freeze + v.to_s } if tags.is_a?(Hash)
-    tags.map { |tag| tag.tr('|,'.freeze, ''.freeze) }
+    tags.map { |tag| tag.to_s.tr('|,'.freeze, ''.freeze) }
   end
 end


### PR DESCRIPTION
Specifically implemented and tested for using a lambda as a tag value which will take the caller and wrapped function args as params. The code is designed to support future metric options.

@jstorimer @wvanbergen 
