### PR TITLE
Add backwards compatability for RSpec 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ please at an entry to the "unreleased changes" section below.
 
 - Drop support for Ruby 1.9.3.
 - Add support for Ruby 2.2.
+- Make library compatible with RSpec 2.
 
 ### Version 2.0.6
 

--- a/lib/statsd/instrument/matchers.rb
+++ b/lib/statsd/instrument/matchers.rb
@@ -1,4 +1,5 @@
 require 'rspec/expectations'
+require 'rspec/version'
 
 module StatsD::Instrument::Matchers
   CUSTOM_MATCHERS = {
@@ -11,7 +12,7 @@ module StatsD::Instrument::Matchers
   }
 
   class Matcher
-    include RSpec::Matchers::Composable
+    include RSpec::Matchers::Composable if RSpec::Version::STRING.start_with?('3')
     include StatsD::Instrument::Helpers
 
     def initialize(metric_type, metric_name, options = {})


### PR DESCRIPTION
RSpec::Matchers::Composable was introduced in RSpec 3, so check the current RSpec version before including it in the matcher.

https://github.com/Shopify/statsd-instrument/issues/77