### PR TITLE
tags+times bug

### DIFF
--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -81,6 +81,20 @@ class AssertionsTest < Minitest::Test
     end
 
     assert_no_assertion_triggered do
+      @test_case.assert_statsd_increment('counter', times: 2, tags: ['foo:1']) do
+        StatsD.increment('counter', tags: { foo: 1 })
+        StatsD.increment('counter', tags: { foo: 1 })
+      end
+    end
+
+    assert_assertion_triggered do
+      @test_case.assert_statsd_increment('counter', times: 2, tags: ['foo:1']) do
+        StatsD.increment('counter', tags: { foo: 1 })
+        StatsD.increment('counter', tags: { foo: 2 })
+      end
+    end
+
+    assert_no_assertion_triggered do
       @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: ['a', 'b']) do
         StatsD.increment('counter', sample_rate: 0.5, tags: ['a', 'b'])
       end


### PR DESCRIPTION
I think I found a small and subtle bug in the StatsD assertion helper.

When submitting the same metric twice with different tags, the assertion helper with `times: 2` will not complain, even if only one of the metrics has the expected tag.

@wvanbergen, do you agree that this is a bug? If so, @surrahman, can you look into a fix?