### PR TITLE
Add type assertion for sample_rate

### DIFF
--- a/lib/statsd/instrument/assertions.rb
+++ b/lib/statsd/instrument/assertions.rb
@@ -42,6 +42,7 @@ module StatsD::Instrument::Assertions
 
     metrics.each do |metric|
 
+      assert within_numeric_range?(metric.sample_rate), "Unexpected sample rate type for metric #{metric_name}, must be numeric"
       assert_equal options[:sample_rate], metric.sample_rate, "Unexpected StatsD sample rate for metric #{metric_name}" if options[:sample_rate]
       assert_equal options[:value], metric.value, "Unexpected value submitted for StatsD metric #{metric_name}" if options[:value]
 
@@ -65,5 +66,9 @@ module StatsD::Instrument::Assertions
 
       metric
     end
+  end
+
+  def within_numeric_range?(object)
+    object.kind_of?(Numeric) && (0.0..1.0).cover?(object)
   end
 end

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -163,6 +163,14 @@ class AssertionsTest < Minitest::Test
     end
   end
 
+  def test_assert_statsd_call_with_wrong_sample_rate_type
+    assert_assertion_triggered "Unexpected sample rate type for metric counter, must be numeric" do
+      @test_case.assert_statsd_increment('counter', tags: ['a', 'b']) do
+        StatsD.increment('counter', sample_rate: 'abc', tags:  ['a', 'b'])
+      end
+    end
+  end
+
   def test_nested_assertions
     assert_no_assertion_triggered do
       @test_case.assert_statsd_increment('counter1') do


### PR DESCRIPTION
Adds type assertion for `sample_rate` ensuring its numeric. This is a nice to have, cause I messed up the ordering of a statsd call in a different repo, which caused my hash for `tags` to be interpreted as `sample_rate`. I had tests that didn't catch this, because I didn't add any assertions on the `sample_rate`.  

@wvanbergen @fw42 