### PR TITLE
Support an ordered set of options when asserting statsd calls

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -399,5 +399,6 @@ require 'statsd/instrument/backend'
 require 'statsd/instrument/environment'
 require 'statsd/instrument/helpers'
 require 'statsd/instrument/assertions'
+require 'statsd/instrument/metric_expectation'
 require 'statsd/instrument/matchers' if defined?(::RSpec)
 require 'statsd/instrument/railtie' if defined?(Rails)

--- a/lib/statsd/instrument/metric_expectation.rb
+++ b/lib/statsd/instrument/metric_expectation.rb
@@ -1,0 +1,67 @@
+# @private
+class StatsD::Instrument::MetricExpectation
+
+  attr_accessor :times, :type, :name, :value, :sample_rate, :tags
+  attr_reader :ignore_tags
+
+  def initialize(options = {})
+    @type = options[:type] or raise ArgumentError, "Metric :type is required."
+    @name = options[:name] or raise ArgumentError, "Metric :name is required."
+    @name = StatsD.prefix ? "#{StatsD.prefix}.#{@name}" : @name unless options[:no_prefix]
+    @tags = StatsD::Instrument::Metric.normalize_tags(options[:tags])
+    @times = options[:times] or raise ArgumentError, "Metric :times is required."
+    @sample_rate = options[:sample_rate]
+    @value = options[:value]
+    @ignore_tags = StatsD::Instrument::Metric.normalize_tags(options[:ignore_tags])
+  end
+
+  def matches(actual_metric)
+    return false if sample_rate && sample_rate != actual_metric.sample_rate
+    return false if value && value != actual_metric.value
+
+    if tags
+
+      expected_tags = Set.new(tags)
+      actual_tags = Set.new(actual_metric.tags)
+
+      if ignore_tags
+        ignored_tags = Set.new(ignore_tags) - expected_tags
+        actual_tags -= ignored_tags
+
+        if ignore_tags.is_a?(Array)
+          actual_tags.delete_if{ |key| ignore_tags.include?(key.split(":").first) }
+        end
+      end
+
+      return expected_tags.subset?(actual_tags)
+    end
+    true
+  end
+
+  def default_value
+    case type
+      when :c; 1
+    end
+  end
+
+  TYPES = {
+      c:  'increment',
+      ms: 'measure',
+      g:  'gauge',
+      h:  'histogram',
+      kv: 'key/value',
+      s:  'set',
+  }
+
+  def to_s
+    str = "#{TYPES[type]} #{name}:#{value}"
+    str << " @#{sample_rate}" if sample_rate != 1.0
+    str << " " << tags.map { |t| "##{t}"}.join(' ') if tags
+    str << " times:#{times}" if times > 1
+    str
+  end
+
+  def inspect
+    "#<StatsD::Instrument::MetricExpectation #{self.to_s}>"
+  end
+end


### PR DESCRIPTION
Currently, when we assert metrics recorded from statsd calls, we allow developers to specify a single set of options for metrics. This prevents us from validating cases where we have multiple metrics with the same name and type being recorded, but with different options, e.g., the following:
```
StatsD.increment('counter', tags: { foo: 1 })
StatsD.increment('counter', tags: { foo: 1 })
StatsD.increment('counter', tags: { foo: 2 })
```
This change allows us to specify an ordered array of metric options via `StatsD::Instrument::Assertions#assert_statsd_calls` so the above case could be validated as shown below:

```
foo_1_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
foo_2_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
@test_case.assert_statsd_calls([foo_1_metric, foo_2_metric]) do
  StatsD.increment('counter', tags: { foo: 1 })
  StatsD.increment('counter', tags: { foo: 1 })
  StatsD.increment('counter', tags: { foo: 2 })
end
```
