### PR TITLE
Ask Rails for the environment when Rails is loaded and not just defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ please at an entry to the "unreleased changes" section below.
 - Drop support for Ruby 1.9.3.
 - Add support for Ruby 2.2.
 - Make library compatible with RSpec 2.
+- Ask Rails for the environment if Rails is loaded, not just defined
 
 ### Version 2.0.6
 

--- a/lib/statsd/instrument/environment.rb
+++ b/lib/statsd/instrument/environment.rb
@@ -28,7 +28,7 @@ module StatsD::Instrument::Environment
   #
   # @return [String] The detected environment.
   def environment
-    if defined?(Rails)
+    if defined?(Rails) && Rails.respond_to?(:env)
       Rails.env.to_s
     else
       ENV['RAILS_ENV'] || ENV['RACK_ENV'] || ENV['ENV'] || 'development'

--- a/test/environment_test.rb
+++ b/test/environment_test.rb
@@ -1,5 +1,7 @@
 require 'test_helper'
 
+module Rails; end
+
 class EnvironmentTest < Minitest::Test
 
   def setup
@@ -31,5 +33,14 @@ class EnvironmentTest < Minitest::Test
     assert_equal '127.0.0.1', backend.host
     assert_equal 1234, backend.port
     assert_equal :datadog, backend.implementation
+  end
+
+  def test_uses_env_when_rails_does_not_respond_to_env
+    assert_equal ENV['ENV'], StatsD::Instrument::Environment.environment
+  end
+
+  def test_uses_rails_env_when_rails_is_available
+    Rails.stubs(:env).returns('production')
+    assert_equal 'production', StatsD::Instrument::Environment.environment
   end
 end


### PR DESCRIPTION
I'm working on an app that uses statsd-instrument alongside other libraries. One of those libraries defines `Rails`, but that version of Rails does not have `env` defined on it. This raises an exception when the app boots:

`.../.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/statsd-instrument-2.1.1/lib/statsd/instrument/environment.rb:32:in 'environment': undefined method 'env' for Rails:Module (NoMethodError)`

This happens because statsd-instrument's environment detecting method checks if Rails is defined, and if it is, calls `env` on it. This PR adds an additional guard and a test.

@jstorimer I believe I'm supposed to ping you for a code review, please? Let me know if you have suggestions or know of a reason this change is inappropriate. Thanks!