### PR TITLE
Adds filter to capture_statsd_calls

### DIFF
--- a/lib/statsd/instrument/helpers.rb
+++ b/lib/statsd/instrument/helpers.rb
@@ -1,9 +1,14 @@
 module StatsD::Instrument::Helpers
-  def capture_statsd_calls(&block)
+  def capture_statsd_calls(filter: nil, &block)
     mock_backend = StatsD::Instrument::Backends::CaptureBackend.new
     old_backend, StatsD.backend = StatsD.backend, mock_backend
     block.call
-    mock_backend.collected_metrics
+    if filter
+      filter = Regexp.new(filter)
+      mock_backend.collected_metrics.select{|m| filter.match(m.name) }
+    else
+      mock_backend.collected_metrics
+    end
   ensure
     if old_backend.kind_of?(StatsD::Instrument::Backends::CaptureBackend)
       old_backend.collected_metrics.concat(mock_backend.collected_metrics)

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -20,5 +20,32 @@ class HelpersTest < Minitest::Test
     assert_equal 'gauge', metrics[1].name
     assert_equal 12, metrics[1].value
   end
+
+  def test_capture_metrics_inside_with_a_filter
+    StatsD.increment('counter')
+    metrics = @test_case.capture_statsd_calls(filter: 'request') do
+      StatsD.increment('request_count')
+      StatsD.gauge('request_time', 100)
+      StatsD.gauge('gauge', 12)
+    end
+
+    assert_equal 2, metrics.length
+    assert_equal 'request_count', metrics[0].name
+    assert_equal 'request_time', metrics[1].name
+    assert_equal 100, metrics[1].value
+  end
+
+  def test_capture_metrics_inside_with_a_regexp_filter
+    StatsD.increment('counter')
+    metrics = @test_case.capture_statsd_calls(filter: /req.*time/) do
+      StatsD.increment('request_count')
+      StatsD.gauge('request_time', 100)
+      StatsD.gauge('gauge', 12)
+    end
+
+    assert_equal 1, metrics.length
+    assert_equal 'request_time', metrics[0].name
+    assert_equal 100, metrics[0].value
+  end
 end
 


### PR DESCRIPTION
The default `capture_statsd_calls` behaviour is to, naturally, capture everything. On occasion you may have other StatsD calls in the execution flow that are not relevant to your test and appear in the returned metrics. These irrelevant metrics need to be filtered out in order to perform you assertions.

This PR adds an optional `filter` argument to the command that will only return metrics whose name matches the filter. The argument accepts either a String or Regexp as valid match. 

@wvanbergen @fw42