### PR TITLE
Topic/rspec matchers improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ please at an entry to the "unreleased changes" section below.
 - Add support for Ruby 2.2.
 - Make library compatible with RSpec 2.
 - Ask Rails for the environment if Rails is loaded, not just defined
+- RSpec: verbose failure messages (expected vs. actual), rspec-mock argument matchers support
 
 ### Version 2.0.6
 

--- a/README.md
+++ b/README.md
@@ -280,6 +280,12 @@ RSpec.describe 'Matchers' do
       }.to trigger_statsd_increment('counter', times: 2)
     end
 
+    it 'will pass if it matches argument' do
+      expect {
+        StatsD.measure('counter', 0.3001)
+      }.to trigger_statsd_measure('counter', value: be_between(0.29, 0.31))
+    end
+
     it 'will pass if there is no matching StatsD call on negative expectation' do
       expect { StatsD.increment('other_counter') }.not_to trigger_statsd_increment('counter')
     end

--- a/lib/statsd/instrument/matchers.rb
+++ b/lib/statsd/instrument/matchers.rb
@@ -55,7 +55,10 @@ module StatsD::Instrument::Matchers
       [:sample_rate, :value, :tags].each do |expectation|
         next unless options[expectation]
 
-        if metrics.all? { |m| m.public_send(expectation) != options[expectation] }
+        num_matches = metrics.count { |m| m.public_send(expectation) == options[expectation] }
+        found = options[:times] ? num_matches == options[:times] : num_matches > 0
+
+        if !found
           raise RSpec::Expectations::ExpectationNotMetError, "Unexpected StatsD #{expectation.to_s.gsub('_', ' ')} for metric #{metric_name}"
         end
       end

--- a/lib/statsd/instrument/matchers.rb
+++ b/lib/statsd/instrument/matchers.rb
@@ -59,11 +59,24 @@ module StatsD::Instrument::Matchers
         found = options[:times] ? num_matches == options[:times] : num_matches > 0
 
         if !found
-          raise RSpec::Expectations::ExpectationNotMetError, "Unexpected StatsD #{expectation.to_s.gsub('_', ' ')} for metric #{metric_name}"
+          message = metric_information(metric_name, options, metrics, expectation)
+          raise RSpec::Expectations::ExpectationNotMetError, message
         end
       end
 
       true
+    end
+
+    def metric_information(metric_name, options, metrics, expectation)
+      message = "expected StatsD #{expectation.inspect} for metric '#{metric_name}' to be called"
+
+      message += "\n  "
+      message += options[:times] ? "exactly #{options[:times]} times" : "at least once"
+      message += " with: #{options[expectation]}"
+
+      message += "\n  captured metric values: #{metrics.map(&expectation).join(', ')}"
+
+      message
     end
   end
 

--- a/lib/statsd/instrument/matchers.rb
+++ b/lib/statsd/instrument/matchers.rb
@@ -55,7 +55,11 @@ module StatsD::Instrument::Matchers
       [:sample_rate, :value, :tags].each do |expectation|
         next unless options[expectation]
 
-        num_matches = metrics.count { |m| m.public_send(expectation) == options[expectation] }
+        num_matches = metrics.count do |m|
+          matcher = RSpec::Matchers::BuiltIn::Match.new(options[expectation])
+          matcher.matches?(m.public_send(expectation))
+        end
+
         found = options[:times] ? num_matches == options[:times] : num_matches > 0
 
         if !found

--- a/test/matchers_test.rb
+++ b/test/matchers_test.rb
@@ -50,6 +50,20 @@ class MatchersTest < Minitest::Test
     assert StatsD::Instrument::Matchers::Increment.new(:c, 'counter', value: 1).matches? lambda { StatsD.increment('counter') }
   end
 
+  def test_statsd_increment_with_value_matched_when_multiple_metrics
+    assert StatsD::Instrument::Matchers::Increment.new(:c, 'counter', value: 1).matches? lambda {
+      StatsD.increment('counter', value: 2)
+      StatsD.increment('counter', value: 1)
+    }
+  end
+
+  def test_statsd_increment_with_value_not_matched_when_multiple_metrics
+    refute StatsD::Instrument::Matchers::Increment.new(:c, 'counter', value: 1).matches? lambda {
+      StatsD.increment('counter', value: 2)
+      StatsD.increment('counter', value: 3)
+    }
+  end
+
   def test_statsd_increment_with_value_not_matched
     refute StatsD::Instrument::Matchers::Increment.new(:c, 'counter', value: 3).matches? lambda { StatsD.increment('counter') }
   end

--- a/test/matchers_test.rb
+++ b/test/matchers_test.rb
@@ -89,4 +89,14 @@ class MatchersTest < Minitest::Test
       StatsD.increment('counter', value: 2)
     }
   end
+
+  def test_statsd_increment_with_sample_rate_and_argument_matcher_matched
+    between_matcher = RSpec::Matchers::BuiltIn::BeBetween.new(0.4, 0.6).inclusive
+    assert StatsD::Instrument::Matchers::Increment.new(:c, 'counter', sample_rate: between_matcher).matches? lambda { StatsD.increment('counter', sample_rate: 0.5) }
+  end
+
+  def test_statsd_increment_with_sample_rate_and_argument_matcher_not_matched
+    between_matcher = RSpec::Matchers::BuiltIn::BeBetween.new(0.4, 0.6).inclusive
+    refute StatsD::Instrument::Matchers::Increment.new(:c, 'counter', sample_rate: between_matcher).matches? lambda { StatsD.increment('counter', sample_rate: 0.7) }
+  end
 end


### PR DESCRIPTION
content of pull request (all RSpec Matchers related):

1) fixed bug where :times combined with additional expectations would always succeed even if values were different (added tests as proof: _with_times_and_value_matched/not_matched)

2) actual vs. expected failure message output

3) support for rspec-mock style argument matchers (added tests as proof: _argument_matcher_matched/not_atched)


explanation:

1) see test and first commit message (448f3af9a610edfe23222345c3741c34e23e60a8)

2) the matcher captures all statsd calls, so they won't show up in the statsd log (if using logger backend), making debugging difficult. the usual rspec style actual/expected comparison solves this. 

3) vitally important for the use case 'measurement': for example, Timecop isn't entirely precise, resulting in a measurement of 0.5001 if calling Timecop.travel(0.5). rspec argument matchers solve this by not being restricted to :== comparing floats. See example in README.md.


guidelines for conrtibuting:

(ping as requested: @jstorimer @wvanbergen)

I tried to match your coding style, but there was no rubocop config, so if you're concerned about any flavor I introduced, feel free to edit yourselves or request a change, I'm happy to oblige!

The Travis build didn't pass for 'rbx-2', but that was already failing in master.