### PR TITLE
Block must be given to assert_statsd_call

### DIFF
--- a/lib/statsd/instrument/assertions.rb
+++ b/lib/statsd/instrument/assertions.rb
@@ -33,6 +33,10 @@ module StatsD::Instrument::Assertions
 
   # @private
   def assert_statsd_calls(expected_metrics, &block)
+    unless block
+      raise ArgumentError, "block must be given"
+    end
+
     metrics = capture_statsd_calls(&block)
     matched_expected_metrics = []
 

--- a/test/statsd_instrumentation_test.rb
+++ b/test/statsd_instrumentation_test.rb
@@ -208,6 +208,13 @@ class StatsDInstrumentationTest < Minitest::Test
     ActiveMerchant::UniqueGateway.statsd_remove_measure :ssl_post, 'ActiveMerchant::Gateway.ssl_post'
   end
 
+  def test_statsd_measure_yells_without_block
+    err = assert_raises(ArgumentError) do
+      assert_statsd_measure('ActiveMerchant.Gateway.ssl_post')
+    end
+    assert_equal "block must be given", err.to_s
+  end
+
   def test_statsd_measure_with_method_receiving_block
     ActiveMerchant::Base.statsd_measure :post_with_block, 'ActiveMerchant.Base.post_with_block'
 


### PR DESCRIPTION
Now if you forgot a block, it fails with:

```
  1) Error:
StatsDInstrumentationTest#test_statsd_measure_yells_without_block:
NoMethodError: undefined method `call' for nil:NilClass
    /Users/kir/Projects/opensource/statsd-instrument/lib/statsd/instrument/helpers.rb:5:in `capture_statsd_calls'
    /Users/kir/Projects/opensource/statsd-instrument/lib/statsd/instrument/assertions.rb:36:in `assert_statsd_calls'
    /Users/kir/Projects/opensource/statsd-instrument/lib/statsd/instrument/assertions.rb:78:in `assert_statsd_call'
    /Users/kir/Projects/opensource/statsd-instrument/lib/statsd/instrument/assertions.rb:15:in `assert_statsd_measure'
    test/statsd_instrumentation_test.rb:212:in `test_statsd_measure_yells_without_block'
```

review @wvanbergen 