### PR TITLE
Friendly assertion error if tags do not match

### DIFF
--- a/lib/statsd/instrument/assertions.rb
+++ b/lib/statsd/instrument/assertions.rb
@@ -69,10 +69,12 @@ module StatsD::Instrument::Assertions
         end
       end
 
-      assert(expected_metric_times_remaining == 0,
-        "Metric expected #{expected_metric_times} times but seen " \
+      msg = +"Metric expected #{expected_metric_times} times but seen " \
         "#{expected_metric_times - expected_metric_times_remaining} " \
-        "times: #{expected_metric.inspect}")
+        "times: #{expected_metric.inspect}."
+      msg << "\nCaptured metrics with the same key: #{filtered_metrics}" if filtered_metrics.any?
+
+      assert(expected_metric_times_remaining == 0, msg)
     end
     expected_metrics -= matched_expected_metrics
 

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -165,6 +165,15 @@ class AssertionsTest < Minitest::Test
     end
   end
 
+  def test_tags_friendly_error
+    @test_case.assert_statsd_increment('counter', tags: { class: "AnotherJob" }) do
+      StatsD.increment('counter', tags: { class: "MyJob" })
+    end
+  rescue MiniTest::Assertion => assertion
+    assert_match(/Captured metrics with the same key/, assertion.message)
+    assert_match(/MyJob/, assertion.message)
+  end
+
   def test_multiple_metrics_are_not_order_dependent
     assert_no_assertion_triggered do
       foo_1_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:1'])


### PR DESCRIPTION
In case your code is:

```ruby
StatsD.increment('counter', tags: { tag1: "MyJob" })
```

and your expectation is:

```ruby
assert_statsd_increment('counter', tags: { tag1: "AnotherJob" }) do
```

The assertion message should be friendly and give a tip that there was another event with the same key. Something similar to what Webmock does.

review @wvanbergen 