### PR TITLE
Allow DNS retry on SocketErrors

### DIFF
--- a/lib/statsd/instrument/backends/udp_backend.rb
+++ b/lib/statsd/instrument/backends/udp_backend.rb
@@ -86,6 +86,7 @@ module StatsD::Instrument::Backends
       end
     rescue SocketError, IOError, SystemCallError => e
       StatsD.logger.error "[StatsD] #{e.class.name}: #{e.message}"
+      invalidate_socket
     end
 
     def invalidate_socket


### PR DESCRIPTION
Currently, when using a DNS hostname for the statsd endpoint and a SocketError is rescued, a retry DNS lookup is never made and statsd-instrument never recovers. By invalidating the socket object on error, a DNS lookup is made when the object is recreated allowing statsd-instrument to recover. @csfrancis I'm not sure if this might cause a DoS on non DNS related errors?