### PR TITLE
Assertions don't fail on exceptions

### DIFF
--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -149,6 +149,25 @@ class AssertionsTest < Minitest::Test
     end
   end
 
+  def test_assert_calls_while_exception
+    assert_no_assertion_triggered do
+      assert_raises(RuntimeError) do
+        @test_case.assert_statsd_increment('counter') do
+          StatsD.increment('counter')
+          raise "foo"
+        end
+      end
+    end
+
+    assert_assertion_triggered do
+      assert_raises(RuntimeError) do
+        @test_case.assert_statsd_increment('counter') do
+          raise "foo"
+        end
+      end
+    end
+  end
+
   def test_tags_will_match_subsets
     assert_no_assertion_triggered do
       @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: { a: 1 }) do


### PR DESCRIPTION
Imagine a test like this:
```ruby
test "foo" do
  assert_raises(RuntimeError) do
    assert_statsd_increment("blabla") do
      raise "hello"
    end
  end
end
```
This test passes, even though no StatsD metric was emitted. This is super confusing.

I'm not sure what the best way to fix this is, but I think the test in this PR captures the problem.

Any thoughts? @wvanbergen 