### PR TITLE
[WIP] Use Module builder pattern for method instrumentation

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -206,6 +206,10 @@ module StatsD
       remove_from_method(method, name, :measure)
     end
 
+    def self.count_method(method_name, **kwargs)
+      StatsD::Instrument::MethodCounter.new(method_name, **kwargs)
+    end
+
     private
 
     def statsd_instrumentation_for(method, name, action)
@@ -403,5 +407,6 @@ require 'statsd/instrument/environment'
 require 'statsd/instrument/helpers'
 require 'statsd/instrument/assertions'
 require 'statsd/instrument/metric_expectation'
+require 'statsd/instrument/method_counter'
 require 'statsd/instrument/matchers' if defined?(::RSpec)
 require 'statsd/instrument/railtie' if defined?(Rails)

--- a/lib/statsd/instrument/method_counter.rb
+++ b/lib/statsd/instrument/method_counter.rb
@@ -1,0 +1,35 @@
+module StatsD
+  module Instrument
+    class MethodCounter < Module
+      attr_reader :method_name
+
+      def initialize(method_name, metric_name: nil, sample_rate: 1.0, value: 1, tags: [])
+        @method_name = method_name.to_sym
+
+        metric = StatsD::Instrument::Metric.new(
+          type: :c,
+          name: metric_name || generate_metric_name,
+          value: value,
+          sample_rate: sample_rate,
+          tags: StatsD::Instrument::Metric.normalize_tags(tags),
+        )
+
+        define_method(method_name) do |*args, &block|
+          begin
+            super(*args, &block)
+          ensure
+            StatsD.backend.collect_metric(metric)
+          end
+        end
+      end
+
+      def generate_metric_name
+        method_name.to_s
+      end
+
+      def inspect
+        "#<#{self.class.name}[#{method_name.inspect}]>"
+      end
+    end
+  end
+end

--- a/test/method_counter_test.rb
+++ b/test/method_counter_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class MethodCounterTest < Minitest::Test
+  include StatsD::Instrument::Assertions
+
+  class ToBeInstrumented
+    prepend StatsD::Instrument.count_method(:to_be_counted)
+
+    def to_be_counted
+      :return_value
+    end
+
+    def inspect
+      'original_inspect'
+    end
+
+    def self.to_be_counted_too
+      :return_value
+    end
+  end
+
+  def test_instrumented_method_increments_statsd_counter_when_called
+    assert_statsd_increment('to_be_counted') do
+      return_value = ToBeInstrumented.new.to_be_counted
+      assert_equal :return_value, return_value
+    end
+  end
+
+  def test_count_method_ancestors
+    counter_module = ToBeInstrumented.ancestors.first
+    assert_instance_of StatsD::Instrument::MethodCounter, counter_module
+    assert_equal :to_be_counted, counter_module.method_name
+    assert_equal '#<StatsD::Instrument::MethodCounter[:to_be_counted]>', counter_module.inspect
+  end
+
+  def test_no_littering_in_instrumented_class
+    refute_includes ToBeInstrumented.new.methods, :count_method
+    refute_includes ToBeInstrumented.new.methods, :method_name
+    refute_includes ToBeInstrumented.methods, :count_method
+    refute_includes ToBeInstrumented.methods, :method_name
+
+    assert_equal 'original_inspect', ToBeInstrumented.new.inspect
+    assert_equal 'MethodCounterTest::ToBeInstrumented', ToBeInstrumented.inspect
+  end
+end


### PR DESCRIPTION
I've never been a big fan of the metaprogramming methods in this library that we use to add StatsD instrumentation to methods. With this PR, I am changing it to use a [module builder pattern](http://dejimata.com/2017/5/20/the-ruby-module-builder-pattern), that has some nice properties over the current approach.

Basic usage is like this:

``` ruby
class MyClass
  def some_method
    # ...
  end

  prepend StatsD::Instrument.count_method(:some_method)
end
```

The advantage of this approach:
- No new methods defined on the class or the metaclass. The only thing added is a prepended module to the ancestors chain.
- The prepended module is generated, but easily identifiable because it has a proper class name and implements `inspect`:

```
Myclass.ancestors
=> [#<StatsD::Instrument::MethodCounter[:some_method]>, MyClass, ...]
```

### [WIP] Use Metric object for streamlined customization.

Right now, we offer a bunch of different methods to deal with different outcomes (`statsd_count`, `statsd_count_if`, `statsd_count_success`), and a bunch of ordered parameters to influence the metric that gets sent to the backend (tags, sample rate), which sometimes can be set to a `proc` for dynamic behavior. It's not very consistent, and the long list of ordered parameters make the API hard to remember. Most of this is a result from starting from a very simple library, and bolting new functionality on top over time.

Since version 2.0, we have a `StatsD::Instrument::Metric` object that includes all the information about the metric that will be sent. I'd like to find a way to expose this object after the method is called, but before it is sent to the backend. Based on the method invocation context (parameters, exception, return value), you should be able to edit or discard the metric object.

Not too sure about the API, but here are some ideas:

``` ruby
# proposal one
class MyClass
  def some_method
    # ...
  end

  prepend StatsD::Instrument.count_method(:some_method,
    on_exception: lambda { |metric, context| metric.discard },
    on_success: lambda { |metric, context| metric.name = mertic.name + ".{context.return_value}"'} 
  )
end
```

### TODO

- [ ] Make sure class methods work too (`prepend` is private, so `self.class.prepend` doesn't work).
- [ ] Default metric name should include the class, not just method name.
- [ ] Maintain method visibility - if the original method was private, the instrumented one should be private too.
- [ ] Set up deprecations for old metaprogramming methods.