### PR TITLE
Handle ThreadError on exit signal

### DIFF
--- a/test/udp_backend_test.rb
+++ b/test/udp_backend_test.rb
@@ -19,13 +19,13 @@ class UDPBackendTest < Minitest::Test
 
     @backend.server = "localhost:1234"
     @backend.socket
-    
+
     @backend.port = 2345
     @backend.socket
 
     @backend.host = '127.0.0.1'
     @backend.socket
-  end  
+  end
 
   def test_collect_respects_sampling_rate
     @socket.expects(:send).once.returns(1)
@@ -35,13 +35,13 @@ class UDPBackendTest < Minitest::Test
     @backend.collect_metric(metric)
 
     @backend.stubs(:rand).returns(0.6)
-    @backend.collect_metric(metric)    
+    @backend.collect_metric(metric)
   end
 
   def test_support_counter_syntax
     @backend.expects(:write_packet).with('counter:1|c').once
     StatsD.increment('counter', sample_rate: 1.0)
-    
+
     @backend.expects(:write_packet).with('counter:1|c|@0.5').once
     StatsD.increment('counter', sample_rate: 0.5)
   end
@@ -100,7 +100,7 @@ class UDPBackendTest < Minitest::Test
     @backend.expects(:write_packet).never
     @logger.expects(:warn)
     StatsD.key_value('fookv', 3.33)
-  end  
+  end
 
   def test_support_tags_syntax_on_datadog
     @backend.implementation = :datadog
@@ -116,7 +116,7 @@ class UDPBackendTest < Minitest::Test
   end
 
   def test_socket_error_should_not_raise_but_log
-    @socket.stubs(:connect).raises(SocketError)    
+    @socket.stubs(:connect).raises(SocketError)
     @logger.expects(:error)
     StatsD.increment('fail')
   end
@@ -131,5 +131,17 @@ class UDPBackendTest < Minitest::Test
     @socket.stubs(:send).raises(IOError)
     @logger.expects(:error)
     StatsD.increment('fail')
+  end
+
+  def test_thread_error_does_not_raise
+    pid = fork do
+      Signal.trap('TERM') do
+        StatsD.increment('exiting')
+      end
+
+      sleep 100
+    end
+
+    Process.kill('TERM', pid)
   end
 end

--- a/test/udp_backend_test.rb
+++ b/test/udp_backend_test.rb
@@ -138,8 +138,7 @@ class UDPBackendTest < Minitest::Test
       Signal.trap('TERM') do
         $sent_packet = false
 
-        socket = @backend.socket
-        class << socket
+        class << @backend.socket
           def send(command, *args)
             $sent_packet = true if command == 'exiting:1|c'
             command.length


### PR DESCRIPTION
This is a different approach to tackling the thread safety issue we've had earlier.

Instead of removing it altogether, we rescue ThreadError which will be raised by `synchronize` when the program is exiting, and attempt to send the stat without synchronization.

cc. @fw42 @csfrancis @Shopify/observability