### PR TITLE
attempt to correct invalid metric names

### DIFF
--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -46,6 +46,7 @@ class StatsD::Instrument::Metric
   def initialize(options = {})
     @type = options[:type] or raise ArgumentError, "Metric :type is required."
     @name = options[:name] or raise ArgumentError, "Metric :name is required."
+    @name = StatsD::Instrument::Metric.normalize_name(@name)
     @name = StatsD.prefix ? "#{StatsD.prefix}.#{@name}" : @name unless options[:no_prefix]
 
     @value       = options[:value] || default_value
@@ -92,6 +93,14 @@ class StatsD::Instrument::Metric
     kv: 'key/value',
     s:  'set',
   }
+
+  # Strip metric names of special characters used by StatsD line protocol, replace with underscore
+  #
+  # @param name [String]
+  # @return [String]
+  def self.normalize_name(name)
+    name.gsub(%r{[:|]}, '_')
+  end
 
   # Utility function to convert tags to the canonical form.
   #

--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -99,7 +99,7 @@ class StatsD::Instrument::Metric
   # @param name [String]
   # @return [String]
   def self.normalize_name(name)
-    name.gsub(%r{[:|]}, '_')
+    name.tr(':|', '_')
   end
 
   # Utility function to convert tags to the canonical form.

--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -46,7 +46,7 @@ class StatsD::Instrument::Metric
   def initialize(options = {})
     @type = options[:type] or raise ArgumentError, "Metric :type is required."
     @name = options[:name] or raise ArgumentError, "Metric :name is required."
-    @name = StatsD::Instrument::Metric.normalize_name(@name)
+    @name = normalize_name(@name)
     @name = StatsD.prefix ? "#{StatsD.prefix}.#{@name}" : @name unless options[:no_prefix]
 
     @value       = options[:value] || default_value
@@ -98,8 +98,8 @@ class StatsD::Instrument::Metric
   #
   # @param name [String]
   # @return [String]
-  def self.normalize_name(name)
-    name.tr(':|', '_')
+  def normalize_name(name)
+    name.tr(':|@'.freeze, '_')
   end
 
   # Utility function to convert tags to the canonical form.

--- a/test/benchmark/metric_name.rb
+++ b/test/benchmark/metric_name.rb
@@ -1,8 +1,0 @@
-require 'statsd-instrument'
-require 'benchmark/ips'
-
-Benchmark.ips do |bench|
-  bench.report("normalize name") do
-    StatsD::Instrument::Metric.normalize_name('metric::naaaaame')
-  end
-end

--- a/test/benchmark/metric_name.rb
+++ b/test/benchmark/metric_name.rb
@@ -1,0 +1,8 @@
+require 'statsd-instrument'
+require 'benchmark/ips'
+
+Benchmark.ips do |bench|
+  bench.report("normalize name") do
+    StatsD::Instrument::Metric.normalize_name('metric::naaaaame')
+  end
+end

--- a/test/metric_test.rb
+++ b/test/metric_test.rb
@@ -25,11 +25,12 @@ class MetricTest < Minitest::Test
   end
 
   def test_bad_metric_name
-    assert_equal 'my_metric', StatsD::Instrument::Metric.normalize_name('my:metric')
-    assert_equal 'my_metric', StatsD::Instrument::Metric.normalize_name('my|metric')
-
-    m = StatsD::Instrument::Metric.new(type: :c, name: 'lol::class')
-    assert_equal 'lol__class', m.name
+    m = StatsD::Instrument::Metric.new(type: :c, name: 'my:metric', no_prefix: true)
+    assert_equal 'my_metric', m.name
+    m = StatsD::Instrument::Metric.new(type: :c, name: 'my|metric', no_prefix: true)
+    assert_equal 'my_metric', m.name
+    m = StatsD::Instrument::Metric.new(type: :c, name: 'my@metric', no_prefix: true)
+    assert_equal 'my_metric', m.name
   end
 
   def test_handle_bad_tags

--- a/test/metric_test.rb
+++ b/test/metric_test.rb
@@ -24,6 +24,14 @@ class MetricTest < Minitest::Test
     assert_equal 'counter', m.name
   end
 
+  def test_bad_metric_name
+    assert_equal 'my_metric', StatsD::Instrument::Metric.normalize_name('my:metric')
+    assert_equal 'my_metric', StatsD::Instrument::Metric.normalize_name('my|metric')
+
+    m = StatsD::Instrument::Metric.new(type: :c, name: 'lol::class')
+    assert_equal 'lol__class', m.name
+  end
+
   def test_handle_bad_tags
     assert_equal ['ignored'], StatsD::Instrument::Metric.normalize_tags(['igno|red'])
     assert_equal ['lol::class:omg::lol'], StatsD::Instrument::Metric.normalize_tags({ :"lol::class" => "omg::lol" })


### PR DESCRIPTION
Attempt to correct an invalid name for a metric. Today it tries to send along to upstream StatsD server as-is which will reject the metric.