### PR TITLE
Add statsd event & service checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ please at an entry to the "unreleased changes" section below.
 
 ### Unreleased changes
 
+- Add support for two new datadog specific metric types: events and service checks.
+
 ### Version 2.1.3
 
 - The `assert_statsd_calls` test helper will now raise an exception whenever a block isn't passed.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,33 @@ StatsD.set('GoogleBase.customers', "12345", sample_rate: 1.0)
 
 Because you are counting unique values, the results of using a sampling value less than 1.0 can lead to unexpected, hard to interpret results.
 
+#### StatsD.event
+
+An event is a (title, text) tuple that can be used to correlate metrics with something that occured within the system.
+This is a good fit for instance to correlate response time variation with a deploy of the new code.
+
+```ruby
+StatsD.event('shipit.deploy', 'started', sample_rate: 1.0)
+```
+
+*Note: This is only supported by the [datadog implementatation](https://docs.datadoghq.com/guides/dogstatsd/#events).*
+
+Events support additional metadata such as `date_happened`, `hostname`, `aggregation_key`, `priority`, `source_type_name`, `alert_type`.
+
+#### StatsD.service_check
+
+An event is a (title, text) tuple that can be used to correlate metrics with something that occured within the system.
+This is a good fit for instance to correlate response time variation with a deploy of the new code.
+
+```ruby
+StatsD.service_check('shipit.redis_connection', 'ok')
+```
+
+*Note: This is only supported by the [datadog implementatation](https://docs.datadoghq.com/guides/dogstatsd/#service-checks).*
+
+Service checks support additional metadata such as `timestamp`, `hostname`, `message`.
+
+
 ### Metaprogramming Methods
 
 As mentioned, it's most common to use the provided metaprogramming methods. This lets you define all of your instrumentation in one file and not litter your code with instrumentation details. You should enable a class for instrumentation by extending it with the `StatsD::Instrument` class.

--- a/README.md
+++ b/README.md
@@ -121,8 +121,7 @@ Events support additional metadata such as `date_happened`, `hostname`, `aggrega
 
 #### StatsD.service_check
 
-An event is a (title, text) tuple that can be used to correlate metrics with something that occured within the system.
-This is a good fit for instance to correlate response time variation with a deploy of the new code.
+An event is a (check_name, status) tuple that can be used to monitor the status of services your application depends on.
 
 ```ruby
 StatsD.service_check('shipit.redis_connection', 'ok')

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -369,6 +369,36 @@ module StatsD
     collect_metric(hash_argument(metric_options).merge(type: :s, name: key, value: value))
   end
 
+  # Emits an event metric.
+  # @param title [String] Title of the event.
+  # @param text [String] Body of the event.
+  # @param metric_options [Hash] (default: {}) Metric options
+  # @return (see #collect_metric)
+  # @note Supported by the datadog implementation only.
+  def event(title, text, *metric_options)
+    if text.is_a?(Hash) && metric_options.empty?
+      metric_options = [text]
+      text = text.fetch(:text, nil)
+    end
+
+    collect_metric(hash_argument(metric_options).merge(type: :_e, name: title, value: text))
+  end
+
+  # Emits a service check metric.
+  # @param title [String] Title of the event.
+  # @param text [String] Body of the event.
+  # @param metric_options [Hash] (default: {}) Metric options
+  # @return (see #collect_metric)
+  # @note Supported by the datadog implementation only.
+  def service_check(name, status, *metric_options)
+    if status.is_a?(Hash) && metric_options.empty?
+      metric_options = [status]
+      status = status.fetch(:status, nil)
+    end
+
+    collect_metric(hash_argument(metric_options).merge(type: :_sc, name: name, value: status))
+  end
+
   private
 
   # Converts old-style ordered arguments in an argument hash for backwards compatibility.

--- a/lib/statsd/instrument/backends/udp_backend.rb
+++ b/lib/statsd/instrument/backends/udp_backend.rb
@@ -3,7 +3,7 @@ require 'monitor'
 module StatsD::Instrument::Backends
   class UDPBackend < StatsD::Instrument::Backend
 
-    class DatadogStatsDProtocol
+    class DogStatsDProtocol
       EVENT_OPTIONS = {
         date_happened: 'd',
         hostname: 'h',
@@ -91,10 +91,9 @@ module StatsD::Instrument::Backends
     end
 
     def implementation=(value)
-      @packet_factory =
-        case value
+      @packet_factory = case value
         when :datadog
-          DatadogStatsDProtocol.new
+          DogStatsDProtocol.new
         when :statsite
           StatsiteStatsDProtocol.new
         else

--- a/lib/statsd/instrument/backends/udp_backend.rb
+++ b/lib/statsd/instrument/backends/udp_backend.rb
@@ -3,12 +3,86 @@ require 'monitor'
 module StatsD::Instrument::Backends
   class UDPBackend < StatsD::Instrument::Backend
 
+    class DatadogStatsDProtocol
+      EVENT_OPTIONS = {
+        date_happened: 'd',
+        hostname: 'h',
+        aggregation_key: 'k',
+        priority: 'p',
+        source_type_name: 's',
+        alert_type: 't',
+      }
+
+      SERVICE_CHECK_OPTIONS = {
+        timestamp: 'd',
+        hostname: 'h',
+        message: 'm',
+      }
+
+      def supported?(metric)
+        [:c, :ms, :g, :h, :s, :_e, :_sc].include?(metric.type)
+      end
+
+      def generate_packet(metric)
+        packet = ""
+
+        if metric.type == :_e
+          escaped_title = metric.name.tr('\n', '\\n')
+          escaped_text = metric.value.tr('\n', '\\n')
+
+          packet << "_e{#{escaped_title.size},#{escaped_text.size}}:#{escaped_title}|#{escaped_text}"
+          packet << generate_metadata(metric, EVENT_OPTIONS)
+        elsif metric.type == :_sc
+          packet << "_sc|#{metric.name}|#{metric.value}"
+          packet << generate_metadata(metric, SERVICE_CHECK_OPTIONS)
+        else
+          packet << "#{metric.name}:#{metric.value}|#{metric.type}"
+        end
+
+        packet << "|@#{metric.sample_rate}" if metric.sample_rate < 1
+        packet << "|##{metric.tags.join(',')}" if metric.tags
+        packet
+      end
+
+      private
+
+      def generate_metadata(metric, options)
+        (metric.metadata.keys & options.keys).map do |key|
+          "|#{options[key]}:#{metric.metadata[key]}"
+        end.join
+      end
+    end
+
+    class StatsiteStatsDProtocol
+      def supported?(metric)
+        [:c, :ms, :g, :s, :kv].include?(metric.type)
+      end
+
+      def generate_packet(metric)
+        packet = "#{metric.name}:#{metric.value}|#{metric.type}"
+        packet << "|@#{metric.sample_rate}" unless metric.sample_rate == 1
+        packet << "\n"
+        packet
+      end
+    end
+
+    class StatsDProtocol
+      def supported?(metric)
+        [:c, :ms, :g, :s].include?(metric.type)
+      end
+
+      def generate_packet(metric)
+        packet = "#{metric.name}:#{metric.value}|#{metric.type}"
+        packet << "|@#{metric.sample_rate}" if metric.sample_rate < 1
+        packet
+      end
+    end
+
     DEFAULT_IMPLEMENTATION = :statsd
 
     include MonitorMixin
 
-    attr_reader :host, :port
-    attr_accessor :implementation
+    attr_reader :host, :port, :implementation
 
     def initialize(server = nil, implementation = nil)
       super()
@@ -16,8 +90,21 @@ module StatsD::Instrument::Backends
       self.implementation = (implementation || DEFAULT_IMPLEMENTATION).to_sym
     end
 
+    def implementation=(value)
+      @packet_factory =
+        case value
+        when :datadog
+          DatadogStatsDProtocol.new
+        when :statsite
+          StatsiteStatsDProtocol.new
+        else
+          StatsDProtocol.new
+        end
+      @implementation = value
+    end
+
     def collect_metric(metric)
-      unless implementation_supports_metric_type?(metric.type)
+      unless @packet_factory.supported?(metric)
         StatsD.logger.warn("[StatsD] Metric type #{metric.type.inspect} not supported on #{implementation} implementation.")
         return false
       end
@@ -26,20 +113,12 @@ module StatsD::Instrument::Backends
         return false
       end
 
-      write_packet(generate_packet(metric))
-    end
-
-    def implementation_supports_metric_type?(type)
-      case type
-        when :h;  implementation == :datadog
-        when :kv; implementation == :statsite
-        else true
-      end
+      write_packet(@packet_factory.generate_packet(metric))
     end
 
     def server=(connection_string)
-      self.host, port = connection_string.split(':', 2)
-      self.port = port.to_i
+      @host, @port = connection_string.split(':', 2)
+      @port = @port.to_i
       invalidate_socket
     end
 
@@ -59,25 +138,6 @@ module StatsD::Instrument::Backends
         @socket.connect(host, port)
       end
       @socket
-    end
-
-    def generate_packet(metric)
-      command = "#{metric.name}:#{metric.value}|#{metric.type}"
-      command << "|@#{metric.sample_rate}" if metric.sample_rate < 1 || (implementation == :statsite && metric.sample_rate > 1)
-      if metric.tags
-        if tags_supported?
-          command << "|##{metric.tags.join(',')}"
-        else
-          StatsD.logger.warn("[StatsD] Tags are only supported on Datadog implementation.")
-        end
-      end
-
-      command << "\n" if implementation == :statsite
-      command
-    end
-
-    def tags_supported?
-      implementation == :datadog
     end
 
     def write_packet(command)

--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -28,7 +28,7 @@
 #
 class StatsD::Instrument::Metric
 
-  attr_accessor :type, :name, :value, :sample_rate, :tags
+  attr_accessor :type, :name, :value, :sample_rate, :tags, :metadata
 
   # Initializes a new metric instance.
   # Normally, you don't want to call this method directly, but use one of the metric collection
@@ -51,6 +51,7 @@ class StatsD::Instrument::Metric
     @value       = options[:value] || default_value
     @sample_rate = options[:sample_rate] || StatsD.default_sample_rate
     @tags        = StatsD::Instrument::Metric.normalize_tags(options[:tags])
+    @metadata    = options.reject { |k, _| [:type, :name, :value, :sample_rate, :tags].include?(k) }
   end
 
   # The default value for this metric, which will be used if it is not set.


### PR DESCRIPTION
Fixes https://github.com/Shopify/statsd-instrument/issues/89

This exposes 2 datadog specific metric types: [event](https://docs.datadoghq.com/guides/dogstatsd/#events) and [service checks](https://docs.datadoghq.com/guides/dogstatsd/#service-checks).

Few questions before I proceed with this:

Do we mind keeping `UdpBackend.new("localhost:1234", :datadog)`? Because I would change this public api to expose directly the protocol supported. E.g.

```
# before
StatsD.backend = UdpBackend.new("localhost:1234", :datadog)

# after
StatsD.backend = UdpBackend.new("localhost:1234", UdpBackend::DatadogStatsDProtocol.new)
```

This way, it's easier to define what a specific implementation can and can't do.

@wvanbergen WDYT?
