### PR TITLE
Only use the default backend for an environment if it wasn't already …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file documents the changes between releases of this library. When creating 
 please at an entry to the "unreleased changes" section below.
 
 ### Unreleased changes
+- Only rely on the default backend for an environment if one was not already declared.
 
 ### Version 2.1.3
 

--- a/lib/statsd/instrument/railtie.rb
+++ b/lib/statsd/instrument/railtie.rb
@@ -9,6 +9,6 @@ class StatsD::Instrument::Railtie < Rails::Railtie
   end
 
   initializer 'statsd-instrument.setup_backend', after: 'statsd-instrument.use_rails_logger' do
-    ::StatsD.backend = ::StatsD::Instrument::Environment.default_backend
+    ::StatsD.backend ||= ::StatsD::Instrument::Environment.default_backend
   end
 end


### PR DESCRIPTION
…set.

This is in reference to #116 .

This pull request makes it so that the StatsD railtie initializer does not overwrite the StatsD backend if there was one already declared by the application.

Note: I'm not sure how to write a test for a railtie initializer.  I'm happy to write it if we think this is necessary and someone wants to give me a little guidance.

Pinging @jstorimer and @wvanbergen (as per contributing guidelines)