### PR TITLE
Add event and service check metric type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ please at an entry to the "unreleased changes" section below.
 
 ### Unreleased changes
 
+- Add support for two new datadog specific metric types: events and service checks.
+
 ### Version 2.1.3
 
 - The `assert_statsd_calls` test helper will now raise an exception whenever a block isn't passed.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,31 @@ StatsD.set('GoogleBase.customers', "12345", sample_rate: 1.0)
 
 Because you are counting unique values, the results of using a sampling value less than 1.0 can lead to unexpected, hard to interpret results.
 
+#### StatsD.event
+
+An event is a (title, text) tuple that can be used to correlate metrics with something that occured within the system.
+This is a good fit for instance to correlate response time variation with a deploy of the new code.
+
+```ruby
+StatsD.event('shipit.deploy', 'started', sample_rate: 1.0)
+```
+
+*Note: This is only supported by the [datadog implementatation](https://docs.datadoghq.com/guides/dogstatsd/#events).*
+
+Events support additional metadata such as `date_happened`, `hostname`, `aggregation_key`, `priority`, `source_type_name`, `alert_type`.
+
+#### StatsD.service_check
+
+An event is a (check_name, status) tuple that can be used to monitor the status of services your application depends on.
+
+```ruby
+StatsD.service_check('shipit.redis_connection', 'ok')
+```
+
+*Note: This is only supported by the [datadog implementatation](https://docs.datadoghq.com/guides/dogstatsd/#service-checks).*
+
+Service checks support additional metadata such as `timestamp`, `hostname`, `message`.
+
 ### Metaprogramming Methods
 
 As mentioned, it's most common to use the provided metaprogramming methods. This lets you define all of your instrumentation in one file and not litter your code with instrumentation details. You should enable a class for instrumentation by extending it with the `StatsD::Instrument` class.

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -369,6 +369,36 @@ module StatsD
     collect_metric(hash_argument(metric_options).merge(type: :s, name: key, value: value))
   end
 
+  # Emits an event metric.
+  # @param title [String] Title of the event.
+  # @param text [String] Body of the event.
+  # @param metric_options [Hash] (default: {}) Metric options
+  # @return (see #collect_metric)
+  # @note Supported by the datadog implementation only.
+  def event(title, text, *metric_options)
+    if text.is_a?(Hash) && metric_options.empty?
+      metric_options = [text]
+      text = text.fetch(:text, nil)
+    end
+
+    collect_metric(hash_argument(metric_options).merge(type: :_e, name: title, value: text))
+  end
+
+  # Emits a service check metric.
+  # @param title [String] Title of the event.
+  # @param text [String] Body of the event.
+  # @param metric_options [Hash] (default: {}) Metric options
+  # @return (see #collect_metric)
+  # @note Supported by the datadog implementation only.
+  def service_check(name, status, *metric_options)
+    if status.is_a?(Hash) && metric_options.empty?
+      metric_options = [status]
+      status = status.fetch(:status, nil)
+    end
+
+    collect_metric(hash_argument(metric_options).merge(type: :_sc, name: name, value: status))
+  end
+
   private
 
   # Converts old-style ordered arguments in an argument hash for backwards compatibility.

--- a/lib/statsd/instrument/matchers.rb
+++ b/lib/statsd/instrument/matchers.rb
@@ -8,7 +8,9 @@ module StatsD::Instrument::Matchers
     gauge: :g,
     histogram: :h,
     set: :s,
-    key_value: :kv
+    key_value: :kv,
+    event: :_e,
+    service_check: :_sc
   }
 
   class Matcher

--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -28,7 +28,7 @@
 #
 class StatsD::Instrument::Metric
 
-  attr_accessor :type, :name, :value, :sample_rate, :tags
+  attr_accessor :type, :name, :value, :sample_rate, :tags, :metadata
 
   # Initializes a new metric instance.
   # Normally, you don't want to call this method directly, but use one of the metric collection
@@ -52,6 +52,8 @@ class StatsD::Instrument::Metric
     @value       = options[:value] || default_value
     @sample_rate = options[:sample_rate] || StatsD.default_sample_rate
     @tags        = StatsD::Instrument::Metric.normalize_tags(options[:tags])
+    @metadata    = options.reject { |k, _| [:type, :name, :value, :sample_rate, :tags].include?(k) }
+
   end
 
   # The default value for this metric, which will be used if it is not set.
@@ -92,6 +94,8 @@ class StatsD::Instrument::Metric
     h:  'histogram',
     kv: 'key/value',
     s:  'set',
+    _e: 'event',
+    _sc: 'service_check',
   }
 
   # Strip metric names of special characters used by StatsD line protocol, replace with underscore


### PR DESCRIPTION
This PR provides the same functionality as https://github.com/Shopify/statsd-instrument/pull/109 , but without the refactor. The aim is to see if we can reduce the 16% performance hit from the previous PR.