### PR TITLE
Update instrument version to 2.2.0  and update change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ please at an entry to the "unreleased changes" section below.
 
 ### Unreleased changes
 
-### Version 2.2.4
+### Version 2.2.0
 
 - Add support for two new datadog specific metric types: events and service checks.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ please at an entry to the "unreleased changes" section below.
 
 ### Unreleased changes
 
+### Version 2.2.4
+
 - Add support for two new datadog specific metric types: events and service checks.
 
 ### Version 2.1.3

--- a/lib/statsd/instrument/version.rb
+++ b/lib/statsd/instrument/version.rb
@@ -1,5 +1,5 @@
 module StatsD
   module Instrument
-    VERSION = "2.1.4"
+    VERSION = "2.2.4"
   end
 end

--- a/lib/statsd/instrument/version.rb
+++ b/lib/statsd/instrument/version.rb
@@ -1,5 +1,5 @@
 module StatsD
   module Instrument
-    VERSION = "2.2.4"
+    VERSION = "2.2.0"
   end
 end


### PR DESCRIPTION
This PR updates instrument version to 2.2.0 and moves unreleased changes documentation to the released changes section.