### PR TITLE
Add Datadog beta support for distribution metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ please at an entry to the "unreleased changes" section below.
 
 ### Unreleased changes
 
+- Add support for beta, datadog specifc distribution metrics
+
 ### Version 2.2.0
 
 - Add support for two new datadog specific metric types: events and service checks.

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -339,6 +339,21 @@ module StatsD
     collect_metric(hash_argument(metric_options).merge(type: :h, name: key, value: value))
   end
 
+   # Emits a distribution metric.
+  # @param key [String] The name of the metric.
+  # @param value [Numeric] The value to record.
+  # @param metric_options [Hash] (default: {}) Metric options
+  # @return (see #collect_metric)
+  # @note Supported by the datadog implementation only (in beta)
+  def distribution(key, value, *metric_options)
+    if value.is_a?(Hash) && metric_options.empty?
+      metric_options = [value]
+      value = value.fetch(:value, nil)
+    end
+
+    collect_metric(hash_argument(metric_options).merge(type: :d, name: key, value: value))
+  end
+
   # Emits a key/value metric.
   # @param key [String] The name of the metric.
   # @param value [Numeric] The value to record.

--- a/lib/statsd/instrument/assertions.rb
+++ b/lib/statsd/instrument/assertions.rb
@@ -23,6 +23,10 @@ module StatsD::Instrument::Assertions
     assert_statsd_call(:h, metric_name, options, &block)
   end
 
+  def assert_statsd_distribution(metric_name, options = {}, &block)
+    assert_statsd_call(:d, metric_name, options, &block)
+  end
+
   def assert_statsd_set(metric_name, options = {}, &block)
     assert_statsd_call(:s, metric_name, options, &block)
   end

--- a/lib/statsd/instrument/backends/udp_backend.rb
+++ b/lib/statsd/instrument/backends/udp_backend.rb
@@ -20,7 +20,7 @@ module StatsD::Instrument::Backends
       }
 
       def supported?(metric)
-        [:c, :ms, :g, :h, :s, :_e, :_sc].include?(metric.type)
+        [:c, :ms, :g, :h, :d, :s, :_e, :_sc].include?(metric.type)
       end
 
       def generate_packet(metric)

--- a/lib/statsd/instrument/matchers.rb
+++ b/lib/statsd/instrument/matchers.rb
@@ -7,6 +7,7 @@ module StatsD::Instrument::Matchers
     measure: :ms,
     gauge: :g,
     histogram: :h,
+    distribution: :d,
     set: :s,
     key_value: :kv
   }

--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -91,6 +91,7 @@ class StatsD::Instrument::Metric
     ms: 'measure',
     g:  'gauge',
     h:  'histogram',
+    d:  'distribution',
     kv: 'key/value',
     s:  'set',
   }

--- a/lib/statsd/instrument/metric_expectation.rb
+++ b/lib/statsd/instrument/metric_expectation.rb
@@ -49,6 +49,7 @@ class StatsD::Instrument::MetricExpectation
       ms: 'measure',
       g:  'gauge',
       h:  'histogram',
+      d:  'distribution',
       kv: 'key/value',
       s:  'set',
   }

--- a/test/statsd_test.rb
+++ b/test/statsd_test.rb
@@ -117,6 +117,15 @@ class StatsDTest < Minitest::Test
     assert_equal 42, metric.value
   end
 
+  def test_statsd_distribution
+    result = nil
+    metric = capture_statsd_call { result = StatsD.distribution('values.foobar', 42) }
+    assert_equal metric, result
+    assert_equal :d, metric.type
+    assert_equal 'values.foobar', metric.name
+    assert_equal 42, metric.value
+  end
+
   def test_statsd_key_value
     result = nil
     metric = capture_statsd_call { result = StatsD.key_value('values.foobar', 42) }

--- a/test/udp_backend_test.rb
+++ b/test/udp_backend_test.rb
@@ -76,6 +76,12 @@ class UDPBackendTest < Minitest::Test
     StatsD.histogram('fooh', 42.4)
   end
 
+   def test_distribution_syntax_on_datadog
+    @backend.implementation = :datadog
+    @backend.expects(:write_packet).with('fooh:42.4|d')
+    StatsD.distribution('fooh', 42.4)
+  end
+
   def test_event_on_datadog
     @backend.implementation = :datadog
     @backend.expects(:write_packet).with('_e{4,3}:fooh|baz|h:localhost:3000|@0.01|#foo')
@@ -125,6 +131,13 @@ class UDPBackendTest < Minitest::Test
     @backend.expects(:write_packet).never
     @logger.expects(:warn)
     StatsD.histogram('fooh', 42.4)
+  end
+
+  def test_distribution_warns_if_not_using_datadog
+    @backend.implementation = :other
+    @backend.expects(:write_packet).never
+    @logger.expects(:warn)
+    StatsD.distribution('fooh', 42.4)
   end
 
   def test_supports_key_value_syntax_on_statsite


### PR DESCRIPTION
Quick PR to add support for distribution metrics (identical to histograms except :h => :d)