### PR TITLE
fix performance regression from PR #109

### DIFF
--- a/test/benchmark/metrics.rb
+++ b/test/benchmark/metrics.rb
@@ -1,0 +1,38 @@
+require 'statsd-instrument'
+require 'benchmark/ips'
+
+def helperFunction()
+    a = 10
+    a += a
+    a -= a
+    a *= a
+end
+
+Benchmark.ips do |bench|
+  bench.report("increment metric benchmark") do
+    StatsD.increment('GoogleBase.insert', 10)
+  end
+
+  bench.report("measure metric benchmark") do
+    StatsD.measure('helperFunction') do
+        helperFunction()
+    end
+  end
+
+  bench.report("gauge metric benchmark") do
+    StatsD.gauge('GoogleBase.insert', 12)
+  end
+
+  bench.report("set metric benchmark") do
+    StatsD.set('GoogleBase.customers', "12345", sample_rate: 1.0)
+  end
+
+  bench.report("event metric benchmark") do
+    StatsD.event('Event Title', "12345")
+  end
+
+  bench.report("service check metric benchmark") do
+    StatsD.service_check('shipit.redis_connection', 'ok')
+  end
+
+end


### PR DESCRIPTION
The PR switches to hash data structure from array for storing supported metric types per implementation. I don't know the details of hash table implementation in Ruby but considering there are not many entries lookup should be O(1) versus O(n) when it was array.

I have not done the actual benchmarking yet - so it's only theory at this point. I'll wait for @fmejia97 to publish his benchmarking script first.

/cc @Shopify/edgescale 