### PR TITLE
Updates measure to allow submission as a distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ StatsD.set('GoogleBase.customers', "12345", sample_rate: 1.0)
 
 Because you are counting unique values, the results of using a sampling value less than 1.0 can lead to unexpected, hard to interpret results.
 
+#### StatsD.distribution
+
+A modified gauge that submits a distribution of values over a sample period. Arithmetic and statistical calculations (percetiles, average, etc.) on the data set are peformed server side rather than client side like a histogram.
+
+```ruby
+StatsD.distribution('shipit.redis_connection', 3)
+```
+
+*Note: This is only supported by the beta datadog implementatation.*
+
 #### StatsD.event
 
 An event is a (title, text) tuple that can be used to correlate metrics with something that occured within the system.

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -263,6 +263,8 @@ module StatsD
   #   @param key [String] The name of the metric.
   #   @param value [Float] The measured duration in milliseconds
   #   @param metric_options [Hash] Options for the metric
+  #     the key :as_dist will submit the value as a distribution instead of a timing
+  #     (only supported by DataDog's implementation)
   #   @return [StatsD::Instrument::Metric] The metric that was sent to the backend.
   #
   # @overload measure(key, metric_options = {}, &block)
@@ -270,6 +272,8 @@ module StatsD
   #   block passed to this method.
   #   @param key [String] The name of the metric.
   #   @param metric_options [Hash] Options for the metric
+  #     the key :as_dist sets the metric type to a 'distribution' instead of a 'timing'
+  #     (only supported by DataDog's implementation)
   #   @yield The method will yield the block that was passed to this method to measure its duration.
   #   @return The value that was returns by the block passed to this method.
   #

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -270,7 +270,7 @@ module StatsD
   #   block passed to this method.
   #   @param key [String] The name of the metric.
   #   @param metric_options [Hash] Options for the metric
-  #   @yield The method will yield the block that was passed to this emthod to measure its duration.
+  #   @yield The method will yield the block that was passed to this method to measure its duration.
   #   @return The value that was returns by the block passed to this method.
   #
   #   @example
@@ -282,10 +282,11 @@ module StatsD
       metric_options = [value]
       value = value.fetch(:value, nil)
     end
+    type = (!metric_options.empty? && metric_options.first[:as_dist] ? :d : :ms)
 
     result = nil
     value  = 1000 * StatsD::Instrument.duration { result = block.call } if block_given?
-    metric = collect_metric(hash_argument(metric_options).merge(type: :ms, name: key, value: value))
+    metric = collect_metric(hash_argument(metric_options).merge(type: type, name: key, value: value))
     result = metric unless block_given?
     result
   end
@@ -339,7 +340,7 @@ module StatsD
     collect_metric(hash_argument(metric_options).merge(type: :h, name: key, value: value))
   end
 
-   # Emits a distribution metric.
+  # Emits a distribution metric.
   # @param key [String] The name of the metric.
   # @param value [Numeric] The value to record.
   # @param metric_options [Hash] (default: {}) Metric options

--- a/lib/statsd/instrument/version.rb
+++ b/lib/statsd/instrument/version.rb
@@ -1,5 +1,5 @@
 module StatsD
   module Instrument
-    VERSION = "2.3.0.beta"
+    VERSION = "2.3.0.beta2"
   end
 end

--- a/test/statsd_test.rb
+++ b/test/statsd_test.rb
@@ -17,6 +17,11 @@ class StatsDTest < Minitest::Test
     assert_equal :ms, metric.type
   end
 
+  def test_statsd_measure_with_explicit_value_and_distribution_override
+    metric = capture_statsd_call { result = StatsD.measure('values.foobar', 42, as_dist: true) }
+    assert_equal :d, metric.type
+  end
+
   def test_statsd_measure_with_explicit_value_as_keyword_argument
     result = nil
     metric = capture_statsd_call { result = StatsD.measure('values.foobar', value: 42) }
@@ -24,6 +29,11 @@ class StatsDTest < Minitest::Test
     assert_equal 'values.foobar', metric.name
     assert_equal 42, metric.value
     assert_equal :ms, metric.type
+  end
+
+  def test_statsd_measure_with_explicit_value_keyword_and_distribution_override
+    metric = capture_statsd_call { result = StatsD.measure('values.foobar', value: 42, as_dist: true) }
+    assert_equal :d, metric.type
   end
 
   def test_statsd_measure_without_value_or_block
@@ -41,6 +51,13 @@ class StatsDTest < Minitest::Test
       StatsD.measure('values.foobar') { 'foo' }
     end
     assert_equal 1120.0, metric.value
+  end
+
+  def test_statsd_measure_use_distribution_override_for_a_block
+    metric = capture_statsd_call do
+      StatsD.measure('values.foobar', as_dist: true) { 'foo' }
+    end
+    assert_equal :d, metric.type
   end
 
   def test_statsd_measure_returns_return_value_of_block


### PR DESCRIPTION
Adds the ability to tell the `measure` method to store its result as a distribution. By default, this method stores as a timing type (`ms`) which is the current behaviour. 