### PR TITLE
Fix statsd_measure assigning value as option

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -82,7 +82,7 @@ module StatsD
     def statsd_measure(method, name, *metric_options)
       add_to_method(method, name, :measure) do
         define_method(method) do |*args, &block|
-          StatsD.measure(StatsD::Instrument.generate_metric_name(name, self, *args), nil, *metric_options) { super(*args, &block) }
+          StatsD.measure(StatsD::Instrument.generate_metric_name(name, self, *args), *metric_options) { super(*args, &block) }
         end
       end
     end

--- a/lib/statsd/instrument/version.rb
+++ b/lib/statsd/instrument/version.rb
@@ -1,5 +1,5 @@
 module StatsD
   module Instrument
-    VERSION = "2.3.0.beta2"
+    VERSION = "2.3.0.beta3"
   end
 end

--- a/test/statsd_instrumentation_test.rb
+++ b/test/statsd_instrumentation_test.rb
@@ -245,6 +245,26 @@ class StatsDInstrumentationTest < Minitest::Test
     ActiveMerchant::UniqueGateway.statsd_remove_measure :ssl_post, 'ActiveMerchant.Gateway.ssl_post'
   end
 
+  def test_statsd_measure_with_value_and_distribution
+    ActiveMerchant::UniqueGateway.statsd_measure :ssl_post, 'ActiveMerchant.Gateway.ssl_post', 1, as_dist: true
+
+    assert_statsd_distribution('ActiveMerchant.Gateway.ssl_post') do
+      ActiveMerchant::UniqueGateway.new.purchase(true)
+    end
+  ensure
+    ActiveMerchant::UniqueGateway.statsd_remove_measure :ssl_post, 'ActiveMerchant.Gateway.ssl_post'
+  end
+
+  def test_statsd_measure_without_value_as_distribution
+    ActiveMerchant::UniqueGateway.statsd_measure :ssl_post, 'ActiveMerchant.Gateway.ssl_post', as_dist: true
+
+    assert_statsd_distribution('ActiveMerchant.Gateway.ssl_post') do
+      ActiveMerchant::UniqueGateway.new.purchase(true)
+    end
+  ensure
+    ActiveMerchant::UniqueGateway.statsd_remove_measure :ssl_post, 'ActiveMerchant.Gateway.ssl_post'
+  end
+
   def test_instrumenting_class_method
     ActiveMerchant::Gateway.singleton_class.extend StatsD::Instrument
     ActiveMerchant::Gateway.singleton_class.statsd_count :sync, 'ActiveMerchant.Gateway.sync'

--- a/test/statsd_instrumentation_test.rb
+++ b/test/statsd_instrumentation_test.rb
@@ -225,6 +225,26 @@ class StatsDInstrumentationTest < Minitest::Test
     ActiveMerchant::Base.statsd_remove_measure :post_with_block, 'ActiveMerchant.Base.post_with_block'
   end
 
+  def test_statsd_measure_with_value
+    ActiveMerchant::UniqueGateway.statsd_measure :ssl_post, 'ActiveMerchant.Gateway.ssl_post', 1
+
+    assert_statsd_measure('ActiveMerchant.Gateway.ssl_post') do
+      ActiveMerchant::UniqueGateway.new.purchase(true)
+    end
+  ensure
+    ActiveMerchant::UniqueGateway.statsd_remove_measure :ssl_post, 'ActiveMerchant.Gateway.ssl_post'
+  end
+
+  def test_statsd_measure_with_value_and_options
+    ActiveMerchant::UniqueGateway.statsd_measure :ssl_post, 'ActiveMerchant.Gateway.ssl_post', 1, sample_rate: 0.45
+
+    assert_statsd_measure('ActiveMerchant.Gateway.ssl_post', sample_rate: 0.45) do
+      ActiveMerchant::UniqueGateway.new.purchase(true)
+    end
+  ensure
+    ActiveMerchant::UniqueGateway.statsd_remove_measure :ssl_post, 'ActiveMerchant.Gateway.ssl_post'
+  end
+
   def test_instrumenting_class_method
     ActiveMerchant::Gateway.singleton_class.extend StatsD::Instrument
     ActiveMerchant::Gateway.singleton_class.statsd_count :sync, 'ActiveMerchant.Gateway.sync'


### PR DESCRIPTION
https://github.com/Shopify/statsd-instrument/pull/129 allows passing a `as_dist` option to `measure` but the class-level `statsd_measure` method is not forwarding parameters correctly.

The `value` parameter is being sent as part of the `metric_options`, which causes issue for the metric type detection.

There is already code in place to detect if the `value` is actually the `metric_options`: 
https://github.com/Shopify/statsd-instrument/blob/0bf49e028159b69885a063b3ece5a26ac90ea684/lib/statsd/instrument.rb#L285-L288

```
class Something
   def hello
   end
   statsd_measure :hello, 'Hello.execution', 1
end
```

Results in:
```
TypeError: no implicit conversion of Symbol into Integer
    statsd-instrument/lib/statsd/instrument.rb:289:in `[]'
    statsd-instrument/lib/statsd/instrument.rb:289:in `measure'
```

```
[1] pry(StatsD)> metric_options
=> [1]
[2] pry(StatsD)> value
=> nil
[3] pry(StatsD)> key
=> "Hello.execution"
```
