### PR TITLE
Allow Distribution to accept a block

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -72,7 +72,7 @@ module StatsD
       end
     end
 
-    # Adds execution duration instrumentation to a method.
+    # Adds execution duration instrumentation to a method as a timing.
     #
     # @param method [Symbol] The name of the method to instrument.
     # @param name [String, #call] The name of the metric to use. You can also pass in a
@@ -83,6 +83,22 @@ module StatsD
       add_to_method(method, name, :measure) do
         define_method(method) do |*args, &block|
           StatsD.measure(StatsD::Instrument.generate_metric_name(name, self, *args), *metric_options) { super(*args, &block) }
+        end
+      end
+    end
+
+    # Adds execution duration instrumentation to a method as a distribution.
+    #
+    # @param method [Symbol] The name of the method to instrument.
+    # @param name [String, #call] The name of the metric to use. You can also pass in a
+    #    callable to dynamically generate a metric name
+    # @param metric_options (see StatsD#measure)
+    # @return [void]
+    # @note Supported by the datadog implementation only (in beta)
+    def statsd_distribution(method, name, *metric_options)
+      add_to_method(method, name, :distribution) do
+        define_method(method) do |*args, &block|
+          StatsD.distribution(StatsD::Instrument.generate_metric_name(name, self, *args), *metric_options) { super(*args, &block) }
         end
       end
     end
@@ -204,6 +220,15 @@ module StatsD
     # @see #statsd_measure
     def statsd_remove_measure(method, name)
       remove_from_method(method, name, :measure)
+    end
+
+    # Removes StatsD distribution instrumentation from a method
+    # @param method (see #statsd_remove_count)
+    # @param name (see #statsd_remove_count)
+    # @return [void]
+    # @see #statsd_measure
+    def statsd_remove_distribution(method, name)
+      remove_from_method(method, name, :distribution)
     end
 
     private

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -331,6 +331,20 @@ module StatsD
   # @param metric_options [Hash] (default: {}) Metric options
   # @return (see #collect_metric)
   # @note Supported by the datadog implementation only (in beta)
+  #
+  # @overload distribution(key, metric_options = {}, &block)
+  #   Emits a distribution metric, after measuring the execution duration of the
+  #   block passed to this method.
+  #   @param key [String] The name of the metric.
+  #   @param metric_options [Hash] Options for the metric
+  #   @yield The method will yield the block that was passed to this method to measure its duration.
+  #   @return The value that was returns by the block passed to this method.
+  #   @note Supported by the datadog implementation only.
+  #
+  #   @example
+  #      http_response = StatsD.distribution('HTTP.call.duration') do
+  #        HTTP.get(url)
+  #      end
   def distribution(key, value=nil, *metric_options, &block)
     value, metric_options = parse_options(value, metric_options)
     result = nil

--- a/lib/statsd/instrument/version.rb
+++ b/lib/statsd/instrument/version.rb
@@ -1,5 +1,5 @@
 module StatsD
   module Instrument
-    VERSION = "2.3.0.beta3"
+    VERSION = "2.3.0.beta4"
   end
 end


### PR DESCRIPTION
This updates the `distribution` metric type to accept a block that is very similar to how `measure` works. It also refactors the instrumentation methods to make them more DRY.

