### PR TITLE
Fixes bug in return value for blocks

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -313,7 +313,8 @@ module StatsD
     result = nil
     value  = 1000 * StatsD::Instrument.duration { result = block.call } if block_given?
     metric = collect_metric(type, key, value, metric_options)
-    (result || metric)
+    result = metric unless block_given?
+    result
   end
 
   # Emits a counter metric.

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -376,7 +376,8 @@ module StatsD
     result = nil
     value  = 1000 * StatsD::Instrument.duration { result = block.call } if block_given?
     metric = collect_metric(:d, key, value, metric_options)
-    (result || metric)
+    result = metric unless block_given?
+    result
   end
 
   # Emits a key/value metric.

--- a/lib/statsd/instrument/version.rb
+++ b/lib/statsd/instrument/version.rb
@@ -1,5 +1,5 @@
 module StatsD
   module Instrument
-    VERSION = "2.3.0.beta4"
+    VERSION = "2.3.0.beta5"
   end
 end

--- a/test/statsd_test.rb
+++ b/test/statsd_test.rb
@@ -65,6 +65,11 @@ class StatsDTest < Minitest::Test
     assert_equal 'sarah', return_value
   end
 
+  def test_statsd_measure_returns_return_value_of_block_even_if_nil
+    return_value = StatsD.measure('values.foobar', as_dist: true) { nil }
+    assert_nil return_value
+  end
+
   def test_statsd_increment
     result = nil
     metric = capture_statsd_call { result = StatsD.increment('values.foobar', 3) }

--- a/test/statsd_test.rb
+++ b/test/statsd_test.rb
@@ -173,6 +173,11 @@ class StatsDTest < Minitest::Test
     assert_equal 'sarah', return_value
   end
 
+  def test_statsd_measure_returns_return_value_of_block_even_if_nil
+    return_value = StatsD.distribution('values.foobar') { nil }
+    assert_nil return_value
+  end
+
   def test_statsd_key_value
     result = nil
     metric = capture_statsd_call { result = StatsD.key_value('values.foobar', 42) }


### PR DESCRIPTION
Distributions and Measure are expected to return a value of `nil` if the block passed returns `nil`. That was not the case in the latest refactor.  This PR fixes that bug and bumps the version.
