### PR TITLE
Collect measure and distribution metrics even on return or exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ please at an entry to the "unreleased changes" section below.
 
 ### Unreleased changes
 
+## Version 2.3.3
+
+- Capture measure and distribution metrics on exception and early return (#134)
+
+NOTE: Now that exceptions are measured statistics may behave differently. An exception example:
+```
+StatsD.measure('myhttpcall') do
+  my_http_object.invoke
+end
+```
+Version 2.3.2 and below did not track metrics whenever a HTTP Timeout exception was raised.
+2.3.3 and above will include those metrics which may increase the values included.
+
+A return example:
+```
+StatsD.measure('myexpensivecalculation') do
+  return if expensive_calculation_disabled?
+  expensive_calculation
+end
+```
+If `expensive_calculation_disabled?` is true 50% of the time version 2.3.2 will drop the
+average metric considerably.
+
 ## Version 2.3.2
 
 - Add option to override global prefix for metrics (#148)

--- a/lib/statsd/instrument/version.rb
+++ b/lib/statsd/instrument/version.rb
@@ -1,5 +1,5 @@
 module StatsD
   module Instrument
-    VERSION = "2.3.2"
+    VERSION = "2.3.3"
   end
 end


### PR DESCRIPTION
Duplicate of https://github.com/Shopify/statsd-instrument/pull/111 (except no conflicts) and fixes https://github.com/Shopify/statsd-instrument/issues/133

This is a fix for when doing a return inside a `StatsD.measure` or `StatsD.distribution` call, where the metrics would not be collected.

Note that as discussed in https://github.com/Shopify/statsd-instrument/pull/111 if exceptions happen you will likely get a different distribution of performance. At the very least we should consider documenting this behaviour.

Keen to get this merged as I lost a day to this problem (existing code using a return, and I added a block to measure performance).