### PR TITLE
udp: invalidate socket on connectivity issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ please at an entry to the "unreleased changes" section below.
 ### Version 2.3.0.beta
 
 - Add support for beta, datadog specifc distribution metrics
+- Invalidate socket on connectivity issues
 
 ### Version 2.2.1
 

--- a/lib/statsd/instrument/backends/udp_backend.rb
+++ b/lib/statsd/instrument/backends/udp_backend.rb
@@ -146,6 +146,7 @@ module StatsD::Instrument::Backends
       socket.send(command, 0) > 0
     rescue SocketError, IOError, SystemCallError, Errno::ECONNREFUSED => e
       StatsD.logger.error "[StatsD] #{e.class.name}: #{e.message}"
+      invalidate_socket
     end
 
     def invalidate_socket

--- a/lib/statsd/instrument/version.rb
+++ b/lib/statsd/instrument/version.rb
@@ -1,5 +1,5 @@
 module StatsD
   module Instrument
-    VERSION = "2.3.0.beta5"
+    VERSION = "2.3.0.beta6"
   end
 end

--- a/test/udp_backend_test.rb
+++ b/test/udp_backend_test.rb
@@ -207,4 +207,17 @@ class UDPBackendTest < Minitest::Test
 
     assert $?.success?, 'socket did not write on exit'
   end
+
+  def test_socket_error_should_invalidate_socket
+    seq = sequence('fail_then_succeed')
+
+    @socket.expects(:connect).with('localhost', 8125)
+    @socket.expects(:send).raises(Errno::EDESTADDRREQ).in_sequence(seq)
+
+    @socket.expects(:send).returns(1).in_sequence(seq)
+    @logger.expects(:error)
+
+    StatsD.increment('fail')
+    StatsD.increment('succeed')
+  end
 end


### PR DESCRIPTION
We have internal monitors that rely on a master instance reporting whether it's there or not. If this metric is not reported, we assume that something went wrong in the leader election and page an operator. Unfortunately, this is resulting in a fair amount of pages currently.

I pinnged down the master process's hostname and looked at its logs. It looked like it was doing its job, and was running perfectly fine. I digged further into its logs, and noticed this non-innocent looking little line:

```
[StatsD] Errno::EDESTADDRREQ: Destination address required - send(2)	
```

`EDESTADDRREQ` is thrown when [we have not called `connect(2)` on the underlying UDP socket to specify its destination address](https://www.gnu.org/software/libc/manual/html_node/Error-Codes.html). It seems unlikely for it to fail, given no network outside the box happens here..


```ruby
    def socket                                                                                                                                                         
      if @socket.nil?                                                                                                                                                  
        @socket = UDPSocket.new                                                                                                                                        
        @socket.connect(host, port)                                                                                                                                    
      end                                                                                                                                                              
      @socket                                                                                                                                                          
    end
```

That said, it's theoretically possible for this to fail (see [Ruby implementation](https://github.com/ruby/ruby/blob/33dd5d6970489c0aef929880e8730126cc7ad4c6/ext/socket/udpsocket.c#L51-L67))—and we don't check for the error. We could retry in a loop, but you'd probably need this `invalidate_socket` anyway—so it seems to throw the widest net and basically implement a retry mechanism. You can see the [syscalls complete errors here](http://man7.org/linux/man-pages/man2/connect.2.html), but they mostly seem to be related to TCP.

**Discussed this with Flo, and our theory is that if the `host` supplied to `connect(2)` requires DNS, and the DNS lookup fails, the `connect(2)` fails, gets in a bad state, and will throw errors indefinitely since there's no reconnection logic in `statsd-instrument` (prior to this patch).**

That said, I think that on connectivity issues (fairly rare), I don't think it's unreasonable to invalidate the socket. Creating a new socket is essentially free since no handshake needs to incur for UDP sockets. The cost would be the syscall when spinning; however, I'd suspect that's cheaper than the logging already happening in this `rescue`.

@Shopify/job-patterns @hkdsun @fw42 

@pallan if I get this in, can I release it as part of another beta, or are you ready to cut the final 2.3 release? Also would like your 👀 since you've done a lot of work in this gem lately!