### PR TITLE
Adding synchronize to invalidate_socket

### DIFF
--- a/lib/statsd/instrument/backends/udp_backend.rb
+++ b/lib/statsd/instrument/backends/udp_backend.rb
@@ -150,7 +150,9 @@ module StatsD::Instrument::Backends
     end
 
     def invalidate_socket
-      @socket = nil
+      synchronize do
+        @socket = nil
+      end
     end
   end
 end


### PR DESCRIPTION
Without adding a synchronize block here, if one thread enters the
write_packet synchronize block and calls :socket, it can finish the
@socket.connect(host, port) call then pass control on to another thread,
which may be inside of the subsequent rescue block that calls
:invalidate_socket. When control goes back to the original thread, the
@socket is now nil, but will be returned to the previous frame, causing
the :send method to be called on NilClass, which will convert the
command into a symbol and try calling that as a method on the nil
object. This is avoided in this commit by wrapping the code that sets
@socket to nil in a synchronized block as well to guarantee that @socket
is never set to nil while a thread is executing a synchronize block.

The alternative here would be to wrap the entire begin/rescue block in write_packet in a synchronized block, but technically :invalidate_socket could be called elsewhere, so this made the most sense to me.