### PR TITLE
Allow :prefix option on metrics creation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require 'bundler/gem_tasks'
 require 'rake/testtask'
 
 Rake::TestTask.new('test') do |t|
-  t.ruby_opts << '-rubygems'
+  t.ruby_opts << '-r rubygems'
   t.libs << 'lib' << 'test'
   t.test_files = FileList['test/*.rb']
 end

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -448,11 +448,16 @@ module StatsD
 
   # Instantiates a metric, and sends it to the backend for further processing.
   # @param options (see StatsD::Instrument::Metric#initialize)
-  # @return [StatsD::Instrument::Metric] The meric that was sent to the backend.
+  # @return [StatsD::Instrument::Metric] The metric that was sent to the backend.
   def collect_metric(type, name, value, metric_options)
     value, metric_options = parse_options(value, metric_options)
-
-    options = hash_argument(metric_options).merge(type: type, name: name, value: value)
+    metric_options = hash_argument(metric_options)
+    options = metric_options.merge(
+      type: type,
+      name: name,
+      value: value,
+      prefix: metric_options[:prefix] || prefix
+    )
     backend.collect_metric(metric = StatsD::Instrument::Metric.new(options))
     metric
   end

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -451,7 +451,7 @@ module StatsD
   # @return [StatsD::Instrument::Metric] The metric that was sent to the backend.
   def collect_metric(type, name, value, metric_options)
     value, metric_options = parse_options(value, metric_options)
-    
+
     options = hash_argument(metric_options).merge(type: type, name: name, value: value)
     backend.collect_metric(metric = StatsD::Instrument::Metric.new(options))
     metric

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -455,8 +455,7 @@ module StatsD
     options = metric_options.merge(
       type: type,
       name: name,
-      value: value,
-      prefix: metric_options[:prefix]
+      value: value
     )
     backend.collect_metric(metric = StatsD::Instrument::Metric.new(options))
     metric

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -456,7 +456,7 @@ module StatsD
       type: type,
       name: name,
       value: value,
-      prefix: metric_options[:prefix] || prefix
+      prefix: metric_options[:prefix]
     )
     backend.collect_metric(metric = StatsD::Instrument::Metric.new(options))
     metric

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -451,6 +451,7 @@ module StatsD
   # @return [StatsD::Instrument::Metric] The metric that was sent to the backend.
   def collect_metric(type, name, value, metric_options)
     value, metric_options = parse_options(value, metric_options)
+    
     options = hash_argument(metric_options).merge(type: type, name: name, value: value)
     backend.collect_metric(metric = StatsD::Instrument::Metric.new(options))
     metric

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -451,12 +451,7 @@ module StatsD
   # @return [StatsD::Instrument::Metric] The metric that was sent to the backend.
   def collect_metric(type, name, value, metric_options)
     value, metric_options = parse_options(value, metric_options)
-    metric_options = hash_argument(metric_options)
-    options = metric_options.merge(
-      type: type,
-      name: name,
-      value: value
-    )
+    options = hash_argument(metric_options).merge(type: type, name: name, value: value)
     backend.collect_metric(metric = StatsD::Instrument::Metric.new(options))
     metric
   end

--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -3,7 +3,7 @@
 # @!attribute type
 #   @return [Symbol] The metric type. Must be one of {StatsD::Instrument::Metric::TYPES}
 # @!attribute name
-#   @return [String] The name of the metric. {StatsD#prefix} will automatically be applied
+#   @return [String] The name of the metric. <tt>:prefix</tt> option will automatically be applied
 #     to the metric in the constructor, unless the <tt>:no_prefix</tt> option is set.
 # @!attribute value
 #   @see #default_value
@@ -36,7 +36,8 @@ class StatsD::Instrument::Metric
   #
   # @option options [Symbol] :type The type of the metric.
   # @option options [String] :name The name of the metric without prefix.
-  # @option options [Boolean] :no_prefix Set to <tt>true</tt> if you don't want to apply {StatsD#prefix}
+  # @option options [String] :prefix The prefix of the metric.
+  # @option options [Boolean] :no_prefix Set to <tt>true</tt> if you don't want to apply prefix
   # @option options [Numeric, String, nil] :value The value to collect for the metric. If set to
   #   <tt>nil>/tt>, {#default_value} will be used.
   # @option options [Numeric, nil] :sample_rate The sample rate to use. If not set, it will use
@@ -47,7 +48,7 @@ class StatsD::Instrument::Metric
     @type = options[:type] or raise ArgumentError, "Metric :type is required."
     @name = options[:name] or raise ArgumentError, "Metric :name is required."
     @name = normalize_name(@name)
-    @name = StatsD.prefix ? "#{StatsD.prefix}.#{@name}" : @name unless options[:no_prefix]
+    @name = options[:prefix] ? "#{options[:prefix]}.#{@name}" : @name unless options[:no_prefix]
 
     @value       = options[:value] || default_value
     @sample_rate = options[:sample_rate] || StatsD.default_sample_rate

--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -52,8 +52,9 @@ class StatsD::Instrument::Metric
     @name = if options[:prefix]
       "#{options[:prefix]}.#{@name}"
     else
-      StatsD.prefix ? "#{StatsD.prefix}.#{@name}" : @name unless options[:no_prefix]
+      StatsD.prefix && !options[:no_prefix] ? "#{StatsD.prefix}.#{@name}" : @name
     end
+
     @value       = options[:value] || default_value
     @sample_rate = options[:sample_rate] || StatsD.default_sample_rate
     @tags        = StatsD::Instrument::Metric.normalize_tags(options[:tags])

--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -3,8 +3,9 @@
 # @!attribute type
 #   @return [Symbol] The metric type. Must be one of {StatsD::Instrument::Metric::TYPES}
 # @!attribute name
-#   @return [String] The name of the metric. <tt>:prefix</tt> option will automatically be applied
-#     to the metric in the constructor, unless the <tt>:no_prefix</tt> option is set.
+#   @return [String] The name of the metric. {StatsD.prefix} will automatically be applied
+#     to the metric in the constructor, unless the <tt>:no_prefix</tt> option is set or is 
+#     overridden by the <tt>:prefix</tt> option.
 # @!attribute value
 #   @see #default_value
 #   @return [Numeric, String] The value to collect for the metric. Depending on the metric
@@ -36,7 +37,7 @@ class StatsD::Instrument::Metric
   #
   # @option options [Symbol] :type The type of the metric.
   # @option options [String] :name The name of the metric without prefix.
-  # @option options [String] :prefix The prefix of the metric.
+  # @option options [String] :prefix Override the default StatsD prefix.
   # @option options [Boolean] :no_prefix Set to <tt>true</tt> if you don't want to apply prefix
   # @option options [Numeric, String, nil] :value The value to collect for the metric. If set to
   #   <tt>nil>/tt>, {#default_value} will be used.
@@ -48,8 +49,11 @@ class StatsD::Instrument::Metric
     @type = options[:type] or raise ArgumentError, "Metric :type is required."
     @name = options[:name] or raise ArgumentError, "Metric :name is required."
     @name = normalize_name(@name)
-    @name = options[:prefix] ? "#{options[:prefix]}.#{@name}" : @name unless options[:no_prefix]
-
+    @name = if options[:prefix]
+      "#{options[:prefix]}.#{@name}"
+    else
+      StatsD.prefix ? "#{StatsD.prefix}.#{@name}" : @name unless options[:no_prefix]
+    end
     @value       = options[:value] || default_value
     @sample_rate = options[:sample_rate] || StatsD.default_sample_rate
     @tags        = StatsD::Instrument::Metric.normalize_tags(options[:tags])

--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -5,7 +5,8 @@
 # @!attribute name
 #   @return [String] The name of the metric. {StatsD.prefix} will automatically be applied
 #     to the metric in the constructor, unless the <tt>:no_prefix</tt> option is set or is 
-#     overridden by the <tt>:prefix</tt> option.
+#     overridden by the <tt>:prefix</tt> option. Note that <tt>:no_prefix</tt> has greater
+#     precedence than <tt>:prefix</tt>.
 # @!attribute value
 #   @see #default_value
 #   @return [Numeric, String] The value to collect for the metric. Depending on the metric
@@ -49,10 +50,12 @@ class StatsD::Instrument::Metric
     @type = options[:type] or raise ArgumentError, "Metric :type is required."
     @name = options[:name] or raise ArgumentError, "Metric :name is required."
     @name = normalize_name(@name)
-    @name = if options[:prefix]
-      "#{options[:prefix]}.#{@name}"
-    else
-      StatsD.prefix && !options[:no_prefix] ? "#{StatsD.prefix}.#{@name}" : @name
+    unless options[:no_prefix]
+      @name = if options[:prefix]
+        "#{options[:prefix]}.#{@name}"
+      else
+        StatsD.prefix ? "#{StatsD.prefix}.#{@name}" : @name
+      end
     end
 
     @value       = options[:value] || default_value

--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -3,7 +3,7 @@
 # @!attribute type
 #   @return [Symbol] The metric type. Must be one of {StatsD::Instrument::Metric::TYPES}
 # @!attribute name
-#   @return [String] The name of the metric. {StatsD.prefix} will automatically be applied
+#   @return [String] The name of the metric. {StatsD#prefix} will automatically be applied
 #     to the metric in the constructor, unless the <tt>:no_prefix</tt> option is set or is 
 #     overridden by the <tt>:prefix</tt> option. Note that <tt>:no_prefix</tt> has greater
 #     precedence than <tt>:prefix</tt>.
@@ -39,7 +39,7 @@ class StatsD::Instrument::Metric
   # @option options [Symbol] :type The type of the metric.
   # @option options [String] :name The name of the metric without prefix.
   # @option options [String] :prefix Override the default StatsD prefix.
-  # @option options [Boolean] :no_prefix Set to <tt>true</tt> if you don't want to apply prefix
+  # @option options [Boolean] :no_prefix Set to <tt>true</tt> if you don't want to apply a prefix.
   # @option options [Numeric, String, nil] :value The value to collect for the metric. If set to
   #   <tt>nil>/tt>, {#default_value} will be used.
   # @option options [Numeric, nil] :sample_rate The sample rate to use. If not set, it will use

--- a/test/metric_test.rb
+++ b/test/metric_test.rb
@@ -22,6 +22,9 @@ class MetricTest < Minitest::Test
 
     m = StatsD::Instrument::Metric.new(type: :c, name: 'counter', no_prefix: true)
     assert_equal 'counter', m.name
+
+    m = StatsD::Instrument::Metric.new(type: :c, name: 'counter', prefix: "foobar")
+    assert_equal 'foobar.counter', m.name
   end
 
   def test_bad_metric_name

--- a/test/metric_test.rb
+++ b/test/metric_test.rb
@@ -25,6 +25,9 @@ class MetricTest < Minitest::Test
 
     m = StatsD::Instrument::Metric.new(type: :c, name: 'counter', prefix: "foobar")
     assert_equal 'foobar.counter', m.name
+
+    m = StatsD::Instrument::Metric.new(type: :c, name: 'counter', prefix: "foobar", no_prefix: true)
+    assert_equal 'counter', m.name
   end
 
   def test_bad_metric_name


### PR DESCRIPTION
Closes #69 

Allows clients to pass in `:prefix` as an option to a metric. This allows classes that extend StatsD to avoid polluting the global namespace. The motivation for this is [KubernetesDeploy #384](https://github.com/Shopify/kubernetes-deploy/pull/384), though it seems it's not the first app to feel the need for this.

The change is backwards compatible and purely opt-in