### PR TITLE
Changelog + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ please at an entry to the "unreleased changes" section below.
 
 ### Unreleased changes
 
+## Version 2.3.2
+
+- Add option to override global prefix for metrics (#148)
+
+## Version 2.3.1
+
+- Add mutex around UDP socket invalidation (#147)
+
 ### Version 2.3.0
 
 - No changes from `beta6`, distribtions are GA at DataDog so making the distribution changes GA in gem

--- a/lib/statsd/instrument/version.rb
+++ b/lib/statsd/instrument/version.rb
@@ -1,5 +1,5 @@
 module StatsD
   module Instrument
-    VERSION = "2.3.1"
+    VERSION = "2.3.2"
   end
 end


### PR DESCRIPTION
Fills in the changelog with 2.3.1 (mutex for socket invalidation) and 2.3.2 (option for `:prefix`) and bumps version to 2.3.2.