### PR TITLE
Remove unnecessary array allocation from use of map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ please at an entry to the "unreleased changes" section below.
 
 ### Unreleased changes
 
+- Improve performance of `Metric#to_s`
+
 ## Version 2.3.3
 
 - Capture measure and distribution metrics on exception and early return (#134)

--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -83,7 +83,7 @@ class StatsD::Instrument::Metric
   def to_s
     str = "#{TYPES[type]} #{name}:#{value}"
     str << " @#{sample_rate}" if sample_rate != 1.0
-    str << " " << tags.map { |t| "##{t}"}.join(' ') if tags
+    tags.each { |tag| str << " ##{tag}" } if tags
     str
   end
 


### PR DESCRIPTION
While profiling one of our libraries with stackprof, we noticed a large number of samples ended up in `Metric#to_s`. It was obvious that this is largely due to the array allocation that occurs with `map`. To avoid this allocation, we simply use `each` instead.

My own benchmarks for this function:

```ruby
Warming up --------------------------------------
                to_s    54.756k i/100ms
               to_s2    76.205k i/100ms
Calculating -------------------------------------
                to_s    652.458k (± 1.8%) i/s -      3.285M in   5.037082s
               to_s2    931.104k (± 2.6%) i/s -      4.725M in   5.077774s

Comparison:
               to_s2:   931104.4 i/s
                to_s:   652458.3 i/s - 1.43x  slower
```

where `to_s` is the old implementation and `to_s2` is the new implementation in this PR, the benchmark tested against a metric with two tags.

### Notes

Weirdly enough, the above benchmark looks like we're only shaving off less than a microsecond, which is not really saving much unless this is getting called A LOT in a request lifecycle. I observed some slowness once in my own profiling:

![Screen Shot 2019-08-15 at 4 47 58 PM](https://user-images.githubusercontent.com/833576/63126478-f98b8b80-bf7d-11e9-97ec-2ddff0c9b92d.png)

but I haven't been able to reproduce this slowness though, so it may have been a one-off, and perhaps we can simply ignore this PR.