### PR TITLE
Fix bug in escaping newlines for events with Datadog Backend

### DIFF
--- a/lib/statsd/instrument/backends/udp_backend.rb
+++ b/lib/statsd/instrument/backends/udp_backend.rb
@@ -27,8 +27,8 @@ module StatsD::Instrument::Backends
         packet = ""
 
         if metric.type == :_e
-          escaped_title = metric.name.tr('\n', '\\n')
-          escaped_text = metric.value.tr('\n', '\\n')
+          escaped_title = metric.name.gsub("\n", "\\n")
+          escaped_text = metric.value.gsub("\n", "\\n")
 
           packet << "_e{#{escaped_title.size},#{escaped_text.size}}:#{escaped_title}|#{escaped_text}"
           packet << generate_metadata(metric, EVENT_OPTIONS)

--- a/test/udp_backend_test.rb
+++ b/test/udp_backend_test.rb
@@ -90,8 +90,8 @@ class UDPBackendTest < Minitest::Test
 
   def test_event_on_datadog_escapes_newlines
     @backend.implementation = :datadog
-    @backend.expects(:write_packet).with('_e{8,5}:fooh\\n\\n|baz\\n')
-    StatsD.event('fooh\n\n', 'baz\n')
+    @backend.expects(:write_packet).with("_e{8,5}:fooh\\n\\n|baz\\n")
+    StatsD.event("fooh\n\n", "baz\n")
   end
 
   def test_event_on_datadog_ignores_invalid_metadata


### PR DESCRIPTION
Ran into this issue where we were sending events with newlines that were
NOT getting properly escaped.

This was due to a few compounding issues:

1. `'\n'` is NOT the same as `"\n"` in Ruby. Single quotes do NOT treat
   `\` special so that first string is 2 chars. While the double quoted
   string takes `\n` to mean the newline character
1. `tr` only ever replaces single characters. The usage of `tr` does not
   appear to be correct. Since the intended behavior is to take a single
   char `\n` (the new line character) and replace it with TWO chars, `\`
   followed by an `n`, or `"\\n"` in Ruby. Since `tr` can only replace
   single chars it does not seem well suited for this problem

This replaces the usage of `tr` with `gsub` which has the right
behavior.

It also updates the tests to use double quotes, since their use of
single quotes appears to be hiding this bug.

Let me know if there is anything else I can do to help get this merged into this Upstream repo! Thanks!