### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ please at an entry to the "unreleased changes" section below.
 
 - Improve performance of `Metric#to_s` (#152)
 - Fix bug in escaping newlines for events with Datadog Backend (#153)
+- **Breaking change:** Remove `StatsD::Instrument#duration`
 
 ## Version 2.3.3
 


### PR DESCRIPTION
I was reviewing [a PR](https://github.com/Shopify/search-tools/pull/134) that upgrades `statsd-instrument` from 2.3.2 to 2.3.4 and [failed CI](https://buildkite.com/shopify/search-tools/builds/414#97d1024c-ee62-4241-b1dd-19a1e12a5c0d) due to

 > undefined method `duration' for StatsD::Instrument:Module

I wanted to make sure that the CHANGELOG accurately reflects breaking changes