### PR TITLE
Re-add `StatsD::Instument.duration`

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -68,6 +68,16 @@ module StatsD
       end
     end
 
+    # Even though this method is considered private, and is no longer used internally,
+    # applications in the wild rely on it. As a result, we cannot remove this method
+    # until the next major version.
+    # @private
+    def self.duration
+      start = current_timestamp
+      yield
+      current_timestamp - start
+    end
+
     # Adds execution duration instrumentation to a method as a timing.
     #
     # @param method [Symbol] The name of the method to instrument.

--- a/test/statsd_test.rb
+++ b/test/statsd_test.rb
@@ -257,6 +257,17 @@ class StatsDTest < Minitest::Test
     assert_equal 42, metric.value
   end
 
+  def test_statsd_durarion_returns_time_in_seconds
+    duration = StatsD::Instrument.duration {}
+    assert_kind_of Float, duration
+  end
+
+  def test_statsd_durarion_does_not_swallow_exceptions
+    assert_raises(RuntimeError) do
+      StatsD::Instrument.duration { raise "Foo" }
+    end
+  end
+
   protected
 
   def capture_statsd_call(&block)


### PR DESCRIPTION
It was removed by mistake in an earlier version. This re-adds the method, adds some basic tests for it, and includes a comment that tells people why it is still there.