### PR TITLE
Add default_tags attribute to StatsD module

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -284,8 +284,13 @@ module StatsD
     end
   end
 
-  attr_accessor :logger, :default_sample_rate, :prefix, :default_tags
+  attr_accessor :logger, :default_sample_rate, :prefix
   attr_writer :backend
+  attr_reader :default_tags
+
+  def default_tags=(tags)
+    @default_tags = StatsD::Instrument::Metric.normalize_tags(tags)
+  end
 
   def backend
     @backend ||= StatsD::Instrument::Environment.default_backend

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -28,6 +28,10 @@ require 'logger'
 #   The logger to use in case of any errors. The logger is also used as default logger
 #   for the LoggerBackend (although this can be overwritten).
 #
+# @!attribute default_tags
+#   The tags to apply to all metrics.
+#   @return [Array<String>, Hash<String, String>, nil] The default tags, or <tt>nil</tt> when no default tags is used
+#
 #   @see StatsD::Instrument::Backends::LoggerBackend
 #   @return [Logger]
 #
@@ -280,7 +284,7 @@ module StatsD
     end
   end
 
-  attr_accessor :logger, :default_sample_rate, :prefix
+  attr_accessor :logger, :default_sample_rate, :prefix, :default_tags
   attr_writer :backend
 
   def backend

--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -72,7 +72,7 @@ class StatsD::Instrument::Metric
     @sample_rate = options[:sample_rate] || StatsD.default_sample_rate
     @tags = StatsD::Instrument::Metric.normalize_tags(options[:tags])
     if StatsD.default_tags
-      @tags = Array(@tags) | StatsD.default_tags
+      @tags = Array(@tags) + StatsD.default_tags
     end
     @metadata = options.reject { |k, _| [:type, :name, :value, :sample_rate, :tags].include?(k) }
   end

--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -62,7 +62,7 @@ class StatsD::Instrument::Metric
     @sample_rate = options[:sample_rate] || StatsD.default_sample_rate
     @tags        = StatsD::Instrument::Metric.normalize_tags(options[:tags])
     if StatsD.default_tags
-      @tags      = Array(@tags) | StatsD::Instrument::Metric.normalize_tags(StatsD.default_tags)
+      @tags      = Array(@tags) | StatsD.default_tags
     end
     @metadata    = options.reject { |k, _| [:type, :name, :value, :sample_rate, :tags].include?(k) }
   end

--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -61,6 +61,9 @@ class StatsD::Instrument::Metric
     @value       = options[:value] || default_value
     @sample_rate = options[:sample_rate] || StatsD.default_sample_rate
     @tags        = StatsD::Instrument::Metric.normalize_tags(options[:tags])
+    if StatsD.default_tags
+      @tags      = Array(@tags) | StatsD::Instrument::Metric.normalize_tags(StatsD.default_tags)
+    end
     @metadata    = options.reject { |k, _| [:type, :name, :value, :sample_rate, :tags].include?(k) }
   end
 

--- a/test/benchmark/default_tags.rb
+++ b/test/benchmark/default_tags.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'statsd-instrument'
 require 'benchmark/ips'
 
@@ -6,19 +8,15 @@ StatsD.logger = Logger.new('/dev/null')
 class Suite
   def warming(*args)
     StatsD.default_tags = if args[0] == "with default tags"
-                            {:first_tag => 'first_value', :second_tag => 'second_value'}
-                          else
-                            nil
-                          end
+      { first_tag: 'first_value', second_tag: 'second_value' }
+    end
     puts "warming with default tags: #{StatsD.default_tags}"
   end
 
   def running(*args)
     StatsD.default_tags = if args[0] == "with default tags"
-                            {:first_tag => 'first_value', :second_tag => 'second_value'}
-                          else
-                            nil
-                          end
+      { first_tag: 'first_value', second_tag: 'second_value' }
+    end
     puts "running with default tags: #{StatsD.default_tags}"
   end
 
@@ -32,13 +30,17 @@ end
 suite = Suite.new
 
 Benchmark.ips do |bench|
-  bench.config(:suite => suite)
+  bench.config(suite: suite)
   bench.report("without default tags") do
-    StatsD.increment('GoogleBase.insert', tags: { :first_tag => 'first_value', :second_tag => 'second_value', :third_tag => 'third_value' })
+    StatsD.increment('GoogleBase.insert', tags: {
+      first_tag: 'first_value',
+      second_tag: 'second_value',
+      third_tag: 'third_value',
+    })
   end
 
   bench.report("with default tags") do
-    StatsD.increment('GoogleBase.insert', tags: { :third_tag => 'third_value' })
+    StatsD.increment('GoogleBase.insert', tags: { third_tag: 'third_value' })
   end
 
   bench.compare!

--- a/test/benchmark/default_tags.rb
+++ b/test/benchmark/default_tags.rb
@@ -1,0 +1,45 @@
+require 'statsd-instrument'
+require 'benchmark/ips'
+
+StatsD.logger = Logger.new('/dev/null')
+
+class Suite
+  def warming(*args)
+    StatsD.default_tags = if args[0] == "with default tags"
+                            {:first_tag => 'first_value', :second_tag => 'second_value'}
+                          else
+                            nil
+                          end
+    puts "warming with default tags: #{StatsD.default_tags}"
+  end
+
+  def running(*args)
+    StatsD.default_tags = if args[0] == "with default tags"
+                            {:first_tag => 'first_value', :second_tag => 'second_value'}
+                          else
+                            nil
+                          end
+    puts "running with default tags: #{StatsD.default_tags}"
+  end
+
+  def warmup_stats(*)
+  end
+
+  def add_report(*)
+  end
+end
+
+suite = Suite.new
+
+Benchmark.ips do |bench|
+  bench.config(:suite => suite)
+  bench.report("without default tags") do
+    StatsD.increment('GoogleBase.insert', tags: { :first_tag => 'first_value', :second_tag => 'second_value', :third_tag => 'third_value' })
+  end
+
+  bench.report("with default tags") do
+    StatsD.increment('GoogleBase.insert', tags: { :third_tag => 'third_value' })
+  end
+
+  bench.compare!
+end

--- a/test/metric_test.rb
+++ b/test/metric_test.rb
@@ -50,13 +50,11 @@ class MetricTest < Minitest::Test
   end
 
   def test_default_tags
-    StatsD.stubs(:default_tags).returns(['default_tag'])
-    m = StatsD::Instrument::Metric.new(type: :c, name: 'counter', tags: {:tag => 'value'})
-    assert_equal ['tag:value', 'default_tag'], m.tags
-    StatsD.stubs(:default_tags).returns({:default_tag => 'default_value'})
+    StatsD.stubs(:default_tags).returns(['default_tag:default_value'])
     m = StatsD::Instrument::Metric.new(type: :c, name: 'counter', tags: {:tag => 'value'})
     assert_equal ['tag:value', 'default_tag:default_value'], m.tags
-    StatsD.stubs(:default_tags).returns({:tag => 'value'})
+
+    StatsD.stubs(:default_tags).returns(['tag:value'])
     m = StatsD::Instrument::Metric.new(type: :c, name: 'counter', tags: {:tag => 'value'})
     assert_equal ['tag:value'], m.tags
   end

--- a/test/metric_test.rb
+++ b/test/metric_test.rb
@@ -52,11 +52,11 @@ class MetricTest < Minitest::Test
 
   def test_default_tags
     StatsD.stubs(:default_tags).returns(['default_tag:default_value'])
-    m = StatsD::Instrument::Metric.new(type: :c, name: 'counter', tags: {:tag => 'value'})
+    m = StatsD::Instrument::Metric.new(type: :c, name: 'counter', tags: { tag: 'value' })
     assert_equal ['tag:value', 'default_tag:default_value'], m.tags
 
     StatsD.stubs(:default_tags).returns(['tag:value'])
-    m = StatsD::Instrument::Metric.new(type: :c, name: 'counter', tags: {:tag => 'value'})
+    m = StatsD::Instrument::Metric.new(type: :c, name: 'counter', tags: { tag: 'value' })
     assert_equal ['tag:value'], m.tags
   end
 end

--- a/test/metric_test.rb
+++ b/test/metric_test.rb
@@ -57,6 +57,6 @@ class MetricTest < Minitest::Test
 
     StatsD.stubs(:default_tags).returns(['tag:value'])
     m = StatsD::Instrument::Metric.new(type: :c, name: 'counter', tags: { tag: 'value' })
-    assert_equal ['tag:value'], m.tags
+    assert_equal ['tag:value', 'tag:value'], m.tags # we don't care about duplicates
   end
 end

--- a/test/metric_test.rb
+++ b/test/metric_test.rb
@@ -48,4 +48,16 @@ class MetricTest < Minitest::Test
     assert_equal ['tag:value'], StatsD::Instrument::Metric.normalize_tags(:tag => 'value')
     assert_equal ['tag:value', 'tag2:value2'], StatsD::Instrument::Metric.normalize_tags(:tag => 'value', :tag2 => 'value2')
   end
+
+  def test_default_tags
+    StatsD.stubs(:default_tags).returns(['default_tag'])
+    m = StatsD::Instrument::Metric.new(type: :c, name: 'counter', tags: {:tag => 'value'})
+    assert_equal ['tag:value', 'default_tag'], m.tags
+    StatsD.stubs(:default_tags).returns({:default_tag => 'default_value'})
+    m = StatsD::Instrument::Metric.new(type: :c, name: 'counter', tags: {:tag => 'value'})
+    assert_equal ['tag:value', 'default_tag:default_value'], m.tags
+    StatsD.stubs(:default_tags).returns({:tag => 'value'})
+    m = StatsD::Instrument::Metric.new(type: :c, name: 'counter', tags: {:tag => 'value'})
+    assert_equal ['tag:value'], m.tags
+  end
 end

--- a/test/statsd_test.rb
+++ b/test/statsd_test.rb
@@ -273,7 +273,7 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_default_tags_get_normalized
-    StatsD.default_tags = {:first_tag => 'first_value', :second_tag => 'second_value'}
+    StatsD.default_tags = { first_tag: 'first_value', second_tag: 'second_value' }
     assert_equal ['first_tag:first_value', 'second_tag:second_value'], StatsD.default_tags
   end
 

--- a/test/statsd_test.rb
+++ b/test/statsd_test.rb
@@ -3,6 +3,10 @@ require 'test_helper'
 class StatsDTest < Minitest::Test
   include StatsD::Instrument::Assertions
 
+  def teardown
+    StatsD.default_tags = nil
+  end
+
   def test_statsd_passed_collections_to_backend
     StatsD.backend.expects(:collect_metric).with(instance_of(StatsD::Instrument::Metric))
     StatsD.increment('test')
@@ -266,6 +270,11 @@ class StatsDTest < Minitest::Test
     assert_raises(RuntimeError) do
       StatsD::Instrument.duration { raise "Foo" }
     end
+  end
+
+  def test_statsd_default_tags_get_normalized
+    StatsD.default_tags = {:first_tag => 'first_value', :second_tag => 'second_value'}
+    assert_equal ['first_tag:first_value', 'second_tag:second_value'], StatsD.default_tags
   end
 
   protected


### PR DESCRIPTION
Implements: #155 

Adds new attribute to `StatsD` module allowing to specify default tags that will be applied to all metrics.