### PR TITLE
Added cloudwatch instrument support

### DIFF
--- a/lib/statsd/instrument/backends/udp_backend.rb
+++ b/lib/statsd/instrument/backends/udp_backend.rb
@@ -74,6 +74,17 @@ module StatsD::Instrument::Backends
       end
     end
 
+    class CloudWatchStatsDProtocol
+      SUPPORTED_METRIC_TYPES = BASE_SUPPORTED_METRIC_TYPES
+
+      def generate_packet(metric)
+        packet = "#{metric.name}:#{metric.value}|#{metric.type}"
+        packet << "|@#{metric.sample_rate}" if metric.sample_rate < 1
+        packet << "|##{metric.tags.join(',')}" if metric.tags
+        packet
+      end
+    end
+
     DEFAULT_IMPLEMENTATION = :statsd
 
     include MonitorMixin
@@ -92,6 +103,8 @@ module StatsD::Instrument::Backends
           DogStatsDProtocol.new
         when :statsite
           StatsiteStatsDProtocol.new
+        when :cloudwatch
+          CloudWatchStatsDProtocol.new
         else
           StatsDProtocol.new
         end

--- a/test/udp_backend_test.rb
+++ b/test/udp_backend_test.rb
@@ -165,6 +165,12 @@ class UDPBackendTest < Minitest::Test
     StatsD.increment('fooc', 3, tags: ['topic:foo', 'bar'])
   end
 
+  def test_support_tags_syntax_on_cloudwatch
+    @backend.implementation = :cloudwatch
+    @backend.expects(:write_packet).with("fooc:3|c|#topic:foo,bar")
+    StatsD.increment('fooc', 3, tags: ['topic:foo', 'bar'])
+  end
+
   def test_socket_error_should_not_raise_but_log
     @socket.stubs(:connect).raises(SocketError)
     @logger.expects(:error)


### PR DESCRIPTION
## Description
Add support for `cloudwatch` instrument. Cloudwatch now accepts [statsd protocol](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-custom-metrics-statsd.html). It also has the ability to add `tags`

## TODO
Updated README to include cloudwatch