### PR TITLE
Make statsd-instrument frozen-string-literal compatible.

### DIFF
--- a/lib/statsd-instrument.rb
+++ b/lib/statsd-instrument.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require 'statsd/instrument'

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'socket'
 require 'logger'
 

--- a/lib/statsd/instrument/assertions.rb
+++ b/lib/statsd/instrument/assertions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module StatsD::Instrument::Assertions
   include StatsD::Instrument::Helpers
 

--- a/lib/statsd/instrument/backend.rb
+++ b/lib/statsd/instrument/backend.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This abstract class specifies the interface a backend implementation should conform to.
 # @abstract
 class StatsD::Instrument::Backend

--- a/lib/statsd/instrument/backends/capture_backend.rb
+++ b/lib/statsd/instrument/backends/capture_backend.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module StatsD::Instrument::Backends
 
   # The capture backend is used to capture the metrics that are collected, so you can

--- a/lib/statsd/instrument/backends/logger_backend.rb
+++ b/lib/statsd/instrument/backends/logger_backend.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module StatsD::Instrument::Backends
 
   # The logger backend simply logs every metric to a logger

--- a/lib/statsd/instrument/backends/null_backend.rb
+++ b/lib/statsd/instrument/backends/null_backend.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module StatsD::Instrument::Backends
   # The null backend does nothing when receiving a metric, effectively disabling the gem completely.
   class NullBackend < StatsD::Instrument::Backend

--- a/lib/statsd/instrument/backends/udp_backend.rb
+++ b/lib/statsd/instrument/backends/udp_backend.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'monitor'
 
 module StatsD::Instrument::Backends
@@ -24,7 +26,7 @@ module StatsD::Instrument::Backends
       SUPPORTED_METRIC_TYPES = BASE_SUPPORTED_METRIC_TYPES.merge(h: true, _e: true, _sc: true, d: true)
 
       def generate_packet(metric)
-        packet = ""
+        packet = StringIO.new
 
         if metric.type == :_e
           escaped_title = metric.name.gsub("\n", "\\n")
@@ -41,7 +43,7 @@ module StatsD::Instrument::Backends
 
         packet << "|@#{metric.sample_rate}" if metric.sample_rate < 1
         packet << "|##{metric.tags.join(',')}" if metric.tags
-        packet
+        packet.string
       end
 
       private
@@ -57,10 +59,11 @@ module StatsD::Instrument::Backends
       SUPPORTED_METRIC_TYPES = BASE_SUPPORTED_METRIC_TYPES.merge(kv: true)
 
       def generate_packet(metric)
-        packet = "#{metric.name}:#{metric.value}|#{metric.type}"
+        packet = StringIO.new
+        packet << "#{metric.name}:#{metric.value}|#{metric.type}"
         packet << "|@#{metric.sample_rate}" unless metric.sample_rate == 1
         packet << "\n"
-        packet
+        packet.string
       end
     end
 
@@ -68,9 +71,10 @@ module StatsD::Instrument::Backends
       SUPPORTED_METRIC_TYPES = BASE_SUPPORTED_METRIC_TYPES
 
       def generate_packet(metric)
-        packet = "#{metric.name}:#{metric.value}|#{metric.type}"
+        packet = StringIO.new
+        packet << "#{metric.name}:#{metric.value}|#{metric.type}"
         packet << "|@#{metric.sample_rate}" if metric.sample_rate < 1
-        packet
+        packet.string
       end
     end
 

--- a/lib/statsd/instrument/backends/udp_backend.rb
+++ b/lib/statsd/instrument/backends/udp_backend.rb
@@ -26,7 +26,7 @@ module StatsD::Instrument::Backends
       SUPPORTED_METRIC_TYPES = BASE_SUPPORTED_METRIC_TYPES.merge(h: true, _e: true, _sc: true, d: true)
 
       def generate_packet(metric)
-        packet = StringIO.new
+        packet = +""
 
         if metric.type == :_e
           escaped_title = metric.name.gsub("\n", "\\n")
@@ -43,7 +43,8 @@ module StatsD::Instrument::Backends
 
         packet << "|@#{metric.sample_rate}" if metric.sample_rate < 1
         packet << "|##{metric.tags.join(',')}" if metric.tags
-        packet.string
+
+        packet
       end
 
       private
@@ -59,11 +60,10 @@ module StatsD::Instrument::Backends
       SUPPORTED_METRIC_TYPES = BASE_SUPPORTED_METRIC_TYPES.merge(kv: true)
 
       def generate_packet(metric)
-        packet = StringIO.new
-        packet << "#{metric.name}:#{metric.value}|#{metric.type}"
+        packet = +"#{metric.name}:#{metric.value}|#{metric.type}"
         packet << "|@#{metric.sample_rate}" unless metric.sample_rate == 1
         packet << "\n"
-        packet.string
+        packet
       end
     end
 
@@ -71,10 +71,9 @@ module StatsD::Instrument::Backends
       SUPPORTED_METRIC_TYPES = BASE_SUPPORTED_METRIC_TYPES
 
       def generate_packet(metric)
-        packet = StringIO.new
-        packet << "#{metric.name}:#{metric.value}|#{metric.type}"
+        packet = +"#{metric.name}:#{metric.value}|#{metric.type}"
         packet << "|@#{metric.sample_rate}" if metric.sample_rate < 1
-        packet.string
+        packet
       end
     end
 

--- a/lib/statsd/instrument/environment.rb
+++ b/lib/statsd/instrument/environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'logger'
 
 # The environment module is used to detect, and initialize the environment in

--- a/lib/statsd/instrument/helpers.rb
+++ b/lib/statsd/instrument/helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module StatsD::Instrument::Helpers
   def capture_statsd_calls(&block)
     mock_backend = StatsD::Instrument::Backends::CaptureBackend.new

--- a/lib/statsd/instrument/matchers.rb
+++ b/lib/statsd/instrument/matchers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rspec/expectations'
 require 'rspec/core/version'
 

--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -83,11 +83,10 @@ class StatsD::Instrument::Metric
   # @private
   # @return [String]
   def to_s
-    str = StringIO.new
-    str << "#{TYPES[type]} #{name}:#{value}"
+    str = +"#{TYPES[type]} #{name}:#{value}"
     str << " @#{sample_rate}" if sample_rate != 1.0
     tags.each { |tag| str << " ##{tag}" } if tags
-    str.string
+    str
   end
 
   # @private

--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 # The Metric class represents a metric sample to be send by a backend.
 #
 # @!attribute type
 #   @return [Symbol] The metric type. Must be one of {StatsD::Instrument::Metric::TYPES}
 # @!attribute name
 #   @return [String] The name of the metric. {StatsD#prefix} will automatically be applied
-#     to the metric in the constructor, unless the <tt>:no_prefix</tt> option is set or is 
+#     to the metric in the constructor, unless the <tt>:no_prefix</tt> option is set or is
 #     overridden by the <tt>:prefix</tt> option. Note that <tt>:no_prefix</tt> has greater
 #     precedence than <tt>:prefix</tt>.
 # @!attribute value
@@ -81,10 +83,11 @@ class StatsD::Instrument::Metric
   # @private
   # @return [String]
   def to_s
-    str = "#{TYPES[type]} #{name}:#{value}"
+    str = StringIO.new
+    str << "#{TYPES[type]} #{name}:#{value}"
     str << " @#{sample_rate}" if sample_rate != 1.0
     tags.each { |tag| str << " ##{tag}" } if tags
-    str
+    str.string
   end
 
   # @private

--- a/lib/statsd/instrument/metric_expectation.rb
+++ b/lib/statsd/instrument/metric_expectation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # @private
 class StatsD::Instrument::MetricExpectation
 
@@ -55,11 +57,12 @@ class StatsD::Instrument::MetricExpectation
   }
 
   def to_s
-    str = "#{TYPES[type]} #{name}:#{value}"
+    str = StringIO.new
+    str << "#{TYPES[type]} #{name}:#{value}"
     str << " @#{sample_rate}" if sample_rate != 1.0
     str << " " << tags.map { |t| "##{t}"}.join(' ') if tags
     str << " times:#{times}" if times > 1
-    str
+    str.string
   end
 
   def inspect

--- a/lib/statsd/instrument/metric_expectation.rb
+++ b/lib/statsd/instrument/metric_expectation.rb
@@ -57,12 +57,11 @@ class StatsD::Instrument::MetricExpectation
   }
 
   def to_s
-    str = StringIO.new
-    str << "#{TYPES[type]} #{name}:#{value}"
+    str = +"#{TYPES[type]} #{name}:#{value}"
     str << " @#{sample_rate}" if sample_rate != 1.0
     str << " " << tags.map { |t| "##{t}"}.join(' ') if tags
     str << " times:#{times}" if times > 1
-    str.string
+    str
   end
 
   def inspect

--- a/lib/statsd/instrument/railtie.rb
+++ b/lib/statsd/instrument/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This Railtie runs some initializers that will set the logger to <tt>Rails#logger</tt>,
 # and will initialize the {StatsD#backend} based on the Rails environment.
 #

--- a/lib/statsd/instrument/version.rb
+++ b/lib/statsd/instrument/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module StatsD
   module Instrument
     VERSION = "2.3.5"

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class AssertionsTest < Minitest::Test

--- a/test/benchmark/metrics.rb
+++ b/test/benchmark/metrics.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'statsd-instrument'
 require 'benchmark/ips'
 

--- a/test/benchmark/tags.rb
+++ b/test/benchmark/tags.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'statsd-instrument'
 require 'benchmark/ips'
 

--- a/test/capture_backend_test.rb
+++ b/test/capture_backend_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class CaptureBackendTest < Minitest::Test

--- a/test/environment_test.rb
+++ b/test/environment_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 module Rails; end

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class HelpersTest < Minitest::Test

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class IntegrationTest < Minitest::Test
@@ -5,7 +7,7 @@ class IntegrationTest < Minitest::Test
   def setup
     @old_backend, StatsD.backend = StatsD.backend, StatsD::Instrument::Backends::UDPBackend.new("localhost:31798")
   end
-  
+
   def teardown
     StatsD.backend = @old_backend
   end

--- a/test/logger_backend_test.rb
+++ b/test/logger_backend_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class LoggerBackendTest < Minitest::Test
@@ -11,10 +13,10 @@ class LoggerBackendTest < Minitest::Test
 
   def test_logs_metrics
     @backend.collect_metric(@metric1)
-    assert_equal @io.string, "[StatsD] increment mock.counter:1 #a:b #c:d\n"
-    @io.string = ""
-
     @backend.collect_metric(@metric2)
-    assert_equal @io.string, "[StatsD] measure mock.measure:123 @0.3\n"
+    assert_equal <<~LOG, @io.string
+      [StatsD] increment mock.counter:1 #a:b #c:d
+      [StatsD] measure mock.measure:123 @0.3
+    LOG
   end
 end

--- a/test/matchers_test.rb
+++ b/test/matchers_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'statsd/instrument/matchers'
 

--- a/test/metric_test.rb
+++ b/test/metric_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class MetricTest < Minitest::Test

--- a/test/statsd_instrumentation_test.rb
+++ b/test/statsd_instrumentation_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 module ActiveMerchant; end

--- a/test/statsd_test.rb
+++ b/test/statsd_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class StatsDTest < Minitest::Test

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV['ENV'] = 'test'
 
 require 'minitest/autorun'

--- a/test/udp_backend_test.rb
+++ b/test/udp_backend_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class UDPBackendTest < Minitest::Test


### PR DESCRIPTION
This adds `# frozen_string_literal: true` to the top of every Ruby file, and addresses some incompatibilities that came to light by doing so.