### PR TITLE
Use the Shopify style guide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,13 @@ jobs:
         version: ${{ matrix.ruby }}
         architecture: 'x64'
 
-    - name: Run test suite
+    - name: Install dependencies
       run: |
         gem install bundler
         bundle install --jobs 4 --retry 3
-        bundle exec rake
+
+    - name: Run test suite
+      run: bundle exec rake
+
+    - name: Run Rubocop
+      run: bundle exec rubocop

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ doc
 Gemfile.lock
 pkg/*
 vendor/
+tmp/*

--- a/.rubocop-https---shopify-github-io-ruby-style-guide-rubocop-yml
+++ b/.rubocop-https---shopify-github-io-ruby-style-guide-rubocop-yml
@@ -1,0 +1,1027 @@
+AllCops:
+  Exclude:
+  - 'db/schema.rb'
+  DisabledByDefault: true
+  StyleGuideBaseURL: https://shopify.github.io/ruby-style-guide/
+
+Lint/AssignmentInCondition:
+  Enabled: true
+
+Layout/AccessModifierIndentation:
+  EnforcedStyle: indent
+  SupportedStyles:
+  - outdent
+  - indent
+  IndentationWidth:
+
+Style/Alias:
+  EnforcedStyle: prefer_alias_method
+  SupportedStyles:
+  - prefer_alias
+  - prefer_alias_method
+
+Layout/AlignHash:
+  EnforcedHashRocketStyle: key
+  EnforcedColonStyle: key
+  EnforcedLastArgumentHashStyle: ignore_implicit
+  SupportedLastArgumentHashStyles:
+  - always_inspect
+  - always_ignore
+  - ignore_implicit
+  - ignore_explicit
+
+Layout/AlignParameters:
+  EnforcedStyle: with_fixed_indentation
+  SupportedStyles:
+  - with_first_parameter
+  - with_fixed_indentation
+  IndentationWidth:
+
+Style/AndOr:
+  EnforcedStyle: always
+  SupportedStyles:
+  - always
+  - conditionals
+
+Style/BarePercentLiterals:
+  EnforcedStyle: bare_percent
+  SupportedStyles:
+  - percent_q
+  - bare_percent
+
+Style/BlockDelimiters:
+  EnforcedStyle: line_count_based
+  SupportedStyles:
+  - line_count_based
+  - semantic
+  - braces_for_chaining
+  ProceduralMethods:
+  - benchmark
+  - bm
+  - bmbm
+  - create
+  - each_with_object
+  - measure
+  - new
+  - realtime
+  - tap
+  - with_object
+  FunctionalMethods:
+  - let
+  - let!
+  - subject
+  - watch
+  IgnoredMethods:
+  - lambda
+  - proc
+  - it
+
+Style/BracesAroundHashParameters:
+  EnforcedStyle: no_braces
+  SupportedStyles:
+  - braces
+  - no_braces
+  - context_dependent
+
+Layout/CaseIndentation:
+  EnforcedStyle: end
+  SupportedStyles:
+  - case
+  - end
+  IndentOneStep: false
+  IndentationWidth:
+
+Style/ClassAndModuleChildren:
+  EnforcedStyle: nested
+  SupportedStyles:
+  - nested
+  - compact
+
+Style/ClassCheck:
+  EnforcedStyle: is_a?
+  SupportedStyles:
+  - is_a?
+  - kind_of?
+
+Style/CommandLiteral:
+  EnforcedStyle: percent_x
+  SupportedStyles:
+  - backticks
+  - percent_x
+  - mixed
+  AllowInnerBackticks: false
+
+Style/CommentAnnotation:
+  Keywords:
+  - TODO
+  - FIXME
+  - OPTIMIZE
+  - HACK
+  - REVIEW
+
+Style/ConditionalAssignment:
+  EnforcedStyle: assign_to_condition
+  SupportedStyles:
+  - assign_to_condition
+  - assign_inside_condition
+  SingleLineConditionsOnly: true
+
+Layout/DotPosition:
+  EnforcedStyle: leading
+  SupportedStyles:
+  - leading
+  - trailing
+
+Style/EmptyElse:
+  EnforcedStyle: both
+  SupportedStyles:
+  - empty
+  - nil
+  - both
+
+Layout/EmptyLineBetweenDefs:
+  AllowAdjacentOneLineDefs: false
+
+Layout/EmptyLinesAroundBlockBody:
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+  - empty_lines
+  - no_empty_lines
+
+Layout/EmptyLinesAroundClassBody:
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+  - empty_lines
+  - empty_lines_except_namespace
+  - no_empty_lines
+
+Layout/EmptyLinesAroundModuleBody:
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+  - empty_lines
+  - empty_lines_except_namespace
+  - no_empty_lines
+
+Layout/ExtraSpacing:
+  AllowForAlignment: true
+  ForceEqualSignAlignment: false
+
+Naming/FileName:
+  Exclude: []
+  ExpectMatchingDefinition: false
+  Regex:
+  IgnoreExecutableScripts: true
+
+Layout/IndentFirstArgument:
+  EnforcedStyle: consistent
+  SupportedStyles:
+  - consistent
+  - special_for_inner_method_call
+  - special_for_inner_method_call_in_parentheses
+  IndentationWidth:
+
+Style/For:
+  EnforcedStyle: each
+  SupportedStyles:
+  - for
+  - each
+
+Style/FormatString:
+  EnforcedStyle: format
+  SupportedStyles:
+  - format
+  - sprintf
+  - percent
+
+Style/FrozenStringLiteralComment:
+  Details: >-
+    Add `# frozen_string_literal: true` to the top of the file. Frozen string
+    literals will become the default in a future Ruby version, and we want to
+    make sure we're ready.
+  EnforcedStyle: always
+  SupportedStyles:
+    - always
+    - never
+
+Style/GlobalVars:
+  AllowedVariables: []
+
+Style/HashSyntax:
+  EnforcedStyle: ruby19
+  SupportedStyles:
+  - ruby19
+  - hash_rockets
+  - no_mixed_keys
+  - ruby19_no_mixed_keys
+  UseHashRocketsWithSymbolValues: false
+  PreferHashRocketsForNonAlnumEndingSymbols: false
+
+Layout/IndentationConsistency:
+  EnforcedStyle: normal
+  SupportedStyles:
+  - normal
+  - rails
+
+Layout/IndentationWidth:
+  Width: 2
+
+Layout/IndentFirstArrayElement:
+  EnforcedStyle: consistent
+  SupportedStyles:
+  - special_inside_parentheses
+  - consistent
+  - align_brackets
+  IndentationWidth:
+
+Layout/IndentAssignment:
+  IndentationWidth:
+
+Layout/IndentFirstHashElement:
+  EnforcedStyle: consistent
+  SupportedStyles:
+  - special_inside_parentheses
+  - consistent
+  - align_braces
+  IndentationWidth:
+
+Style/LambdaCall:
+  EnforcedStyle: call
+  SupportedStyles:
+  - call
+  - braces
+
+Style/Next:
+  EnforcedStyle: skip_modifier_ifs
+  MinBodyLength: 3
+  SupportedStyles:
+  - skip_modifier_ifs
+  - always
+
+Style/NonNilCheck:
+  IncludeSemanticChanges: false
+
+Style/MethodCallWithArgsParentheses:
+  Enabled: true
+  IgnoreMacros: true
+  IgnoredMethods:
+  - require
+  - require_relative
+  - require_dependency
+  - yield
+  - raise
+  - puts
+  Exclude:
+  - Gemfile
+
+Style/MethodDefParentheses:
+  EnforcedStyle: require_parentheses
+  SupportedStyles:
+  - require_parentheses
+  - require_no_parentheses
+  - require_no_parentheses_except_multiline
+
+Naming/MethodName:
+  EnforcedStyle: snake_case
+  SupportedStyles:
+  - snake_case
+  - camelCase
+
+Layout/MultilineArrayBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+  - symmetrical
+  - new_line
+  - same_line
+
+Layout/MultilineHashBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+  - symmetrical
+  - new_line
+  - same_line
+
+Layout/MultilineMethodCallBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+  - symmetrical
+  - new_line
+  - same_line
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+  SupportedStyles:
+  - aligned
+  - indented
+  - indented_relative_to_receiver
+  IndentationWidth: 2
+
+Layout/MultilineMethodDefinitionBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+  - symmetrical
+  - new_line
+  - same_line
+
+Style/NumericLiteralPrefix:
+  EnforcedOctalStyle: zero_only
+  SupportedOctalStyles:
+  - zero_with_o
+  - zero_only
+
+Style/ParenthesesAroundCondition:
+  AllowSafeAssignment: true
+
+Style/PercentQLiterals:
+  EnforcedStyle: lower_case_q
+  SupportedStyles:
+  - lower_case_q
+  - upper_case_q
+
+Naming/PredicateName:
+  NamePrefix:
+  - is_
+  NamePrefixBlacklist:
+  - is_
+  NameWhitelist:
+  - is_a?
+  Exclude:
+  - 'spec/**/*'
+
+Style/PreferredHashMethods:
+  EnforcedStyle: short
+  SupportedStyles:
+  - short
+  - verbose
+
+Style/RaiseArgs:
+  EnforcedStyle: exploded
+  SupportedStyles:
+  - compact
+  - exploded
+
+Style/RedundantReturn:
+  AllowMultipleReturnValues: false
+
+Style/RegexpLiteral:
+  EnforcedStyle: mixed
+  SupportedStyles:
+  - slashes
+  - percent_r
+  - mixed
+  AllowInnerSlashes: false
+
+Style/SafeNavigation:
+  ConvertCodeThatCanStartToReturnNil: false
+  Enabled: true
+
+Lint/SafeNavigationChain:
+  Enabled: true
+
+Style/Semicolon:
+  AllowAsExpressionSeparator: false
+
+Style/SignalException:
+  EnforcedStyle: only_raise
+  SupportedStyles:
+  - only_raise
+  - only_fail
+  - semantic
+
+Style/SingleLineMethods:
+  AllowIfMethodIsEmpty: true
+
+Layout/SpaceBeforeFirstArg:
+  AllowForAlignment: true
+
+Style/SpecialGlobalVars:
+  EnforcedStyle: use_english_names
+  SupportedStyles:
+  - use_perl_names
+  - use_english_names
+
+Style/StabbyLambdaParentheses:
+  EnforcedStyle: require_parentheses
+  SupportedStyles:
+  - require_parentheses
+  - require_no_parentheses
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: single_quotes
+  SupportedStyles:
+  - single_quotes
+  - double_quotes
+
+Layout/SpaceAroundBlockParameters:
+  EnforcedStyleInsidePipes: no_space
+  SupportedStylesInsidePipes:
+  - space
+  - no_space
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  EnforcedStyle: space
+  SupportedStyles:
+  - space
+  - no_space
+
+Layout/SpaceAroundOperators:
+  AllowForAlignment: true
+
+Layout/SpaceBeforeBlockBraces:
+  EnforcedStyle: space
+  EnforcedStyleForEmptyBraces: space
+  SupportedStyles:
+  - space
+  - no_space
+
+Layout/SpaceInsideBlockBraces:
+  EnforcedStyle: space
+  SupportedStyles:
+  - space
+  - no_space
+  EnforcedStyleForEmptyBraces: no_space
+  SpaceBeforeBlockParameters: true
+
+Layout/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: space
+  EnforcedStyleForEmptyBraces: no_space
+  SupportedStyles:
+  - space
+  - no_space
+  - compact
+
+Layout/SpaceInsideStringInterpolation:
+  EnforcedStyle: no_space
+  SupportedStyles:
+  - space
+  - no_space
+
+Style/SymbolProc:
+  IgnoredMethods:
+  - respond_to
+  - define_method
+
+Style/TernaryParentheses:
+  EnforcedStyle: require_no_parentheses
+  SupportedStyles:
+  - require_parentheses
+  - require_no_parentheses
+  AllowSafeAssignment: true
+
+Layout/TrailingBlankLines:
+  EnforcedStyle: final_newline
+  SupportedStyles:
+  - final_newline
+  - final_blank_line
+
+Style/TrivialAccessors:
+  ExactNameMatch: true
+  AllowPredicates: true
+  AllowDSLWriters: false
+  IgnoreClassMethods: false
+  Whitelist:
+  - to_ary
+  - to_a
+  - to_c
+  - to_enum
+  - to_h
+  - to_hash
+  - to_i
+  - to_int
+  - to_io
+  - to_open
+  - to_path
+  - to_proc
+  - to_r
+  - to_regexp
+  - to_str
+  - to_s
+  - to_sym
+
+Naming/VariableName:
+  EnforcedStyle: snake_case
+  SupportedStyles:
+  - snake_case
+  - camelCase
+
+Style/WhileUntilModifier:
+  Enabled: true
+
+Metrics/BlockNesting:
+  Max: 3
+
+Metrics/LineLength:
+  Max: 120
+  AllowHeredoc: true
+  AllowURI: true
+  URISchemes:
+  - http
+  - https
+  IgnoreCopDirectives: false
+  IgnoredPatterns:
+  - '\A\s*(remote_)?test(_\w+)?\s.*(do|->)(\s|\Z)'
+
+Metrics/ParameterLists:
+  Max: 5
+  CountKeywordArgs: false
+
+Layout/BlockAlignment:
+  EnforcedStyleAlignWith: either
+  SupportedStylesAlignWith:
+  - either
+  - start_of_block
+  - start_of_line
+
+Layout/EndAlignment:
+  EnforcedStyleAlignWith: variable
+  SupportedStylesAlignWith:
+  - keyword
+  - variable
+  - start_of_line
+
+Layout/DefEndAlignment:
+  EnforcedStyleAlignWith: start_of_line
+  SupportedStylesAlignWith:
+  - start_of_line
+  - def
+
+Lint/InheritException:
+  EnforcedStyle: runtime_error
+  SupportedStyles:
+  - runtime_error
+  - standard_error
+
+Lint/UnusedBlockArgument:
+  IgnoreEmptyBlocks: true
+  AllowUnusedKeywordArguments: false
+
+Lint/UnusedMethodArgument:
+  AllowUnusedKeywordArguments: false
+  IgnoreEmptyMethods: true
+
+Naming/AccessorMethodName:
+  Enabled: true
+
+Layout/AlignArray:
+  Enabled: true
+
+Style/ArrayJoin:
+  Enabled: true
+
+Naming/AsciiIdentifiers:
+  Enabled: true
+
+Style/Attr:
+  Enabled: true
+
+Style/BeginBlock:
+  Enabled: true
+
+Style/BlockComments:
+  Enabled: true
+
+Layout/BlockEndNewline:
+  Enabled: true
+
+Style/CaseEquality:
+  Enabled: true
+
+Style/CharacterLiteral:
+  Enabled: true
+
+Naming/ClassAndModuleCamelCase:
+  Enabled: true
+
+Style/ClassMethods:
+  Enabled: true
+
+Style/ClassVars:
+  Enabled: true
+
+Layout/ClosingParenthesisIndentation:
+  Enabled: true
+
+Style/ColonMethodCall:
+  Enabled: true
+
+Layout/CommentIndentation:
+  Enabled: true
+
+Naming/ConstantName:
+  Enabled: true
+
+Style/DateTime:
+  Enabled: true
+
+Style/DefWithParentheses:
+  Enabled: true
+
+Style/EachForSimpleLoop:
+  Enabled: true
+
+Style/EachWithObject:
+  Enabled: true
+
+Layout/ElseAlignment:
+  Enabled: true
+
+Style/EmptyCaseCondition:
+  Enabled: true
+
+Layout/EmptyLines:
+  Enabled: true
+
+Layout/EmptyLinesAroundAccessModifier:
+  Enabled: true
+
+Layout/EmptyLinesAroundMethodBody:
+  Enabled: true
+
+Style/EmptyLiteral:
+  Enabled: true
+
+Style/EndBlock:
+  Enabled: true
+
+Layout/EndOfLine:
+  Enabled: true
+
+Style/EvenOdd:
+  Enabled: true
+
+Layout/InitialIndentation:
+  Enabled: true
+
+Lint/FlipFlop:
+  Enabled: true
+
+Style/IfInsideElse:
+  Enabled: true
+
+Style/IfUnlessModifierOfIfUnless:
+  Enabled: true
+
+Style/IfWithSemicolon:
+  Enabled: true
+
+Style/IdenticalConditionalBranches:
+  Enabled: true
+
+Style/InfiniteLoop:
+  Enabled: true
+
+Layout/LeadingCommentSpace:
+  Enabled: true
+
+Style/LineEndConcatenation:
+  Enabled: true
+
+Style/MethodCallWithoutArgsParentheses:
+  Enabled: true
+
+Style/MethodMissingSuper:
+  Enabled: true
+
+Style/MissingRespondToMissing:
+  Enabled: true
+
+Layout/MultilineBlockLayout:
+  Enabled: true
+
+Style/MultilineIfThen:
+  Enabled: true
+
+Style/MultilineMemoization:
+  Enabled: true
+
+Style/MultilineTernaryOperator:
+  Enabled: true
+
+Style/NegatedIf:
+  Enabled: true
+
+Style/NegatedWhile:
+  Enabled: true
+
+Style/NestedModifier:
+  Enabled: true
+
+Style/NestedParenthesizedCalls:
+  Enabled: true
+
+Style/NestedTernaryOperator:
+  Enabled: true
+
+Style/NilComparison:
+  Enabled: true
+
+Style/Not:
+  Enabled: true
+
+Style/OneLineConditional:
+  Enabled: true
+
+Naming/BinaryOperatorParameterName:
+  Enabled: true
+
+Style/OptionalArguments:
+  Enabled: true
+
+Style/ParallelAssignment:
+  Enabled: true
+
+Style/PerlBackrefs:
+  Enabled: true
+
+Style/Proc:
+  Enabled: true
+
+Style/RedundantBegin:
+  Enabled: true
+
+Style/RedundantException:
+  Enabled: true
+
+Style/RedundantFreeze:
+  Enabled: true
+
+Style/RedundantParentheses:
+  Enabled: true
+
+Style/RedundantSelf:
+  Enabled: true
+
+Style/RedundantSortBy:
+  Enabled: true
+
+Layout/RescueEnsureAlignment:
+  Enabled: true
+
+Style/RescueModifier:
+  Enabled: true
+
+Style/Sample:
+  Enabled: true
+
+Style/SelfAssignment:
+  Enabled: true
+
+Layout/SpaceAfterColon:
+  Enabled: true
+
+Layout/SpaceAfterComma:
+  Enabled: true
+
+Layout/SpaceAfterMethodName:
+  Enabled: true
+
+Layout/SpaceAfterNot:
+  Enabled: true
+
+Layout/SpaceAfterSemicolon:
+  Enabled: true
+
+Layout/SpaceBeforeComma:
+  Enabled: true
+
+Layout/SpaceBeforeComment:
+  Enabled: true
+
+Layout/SpaceBeforeSemicolon:
+  Enabled: true
+
+Layout/SpaceAroundKeyword:
+  Enabled: true
+
+Layout/SpaceInsideArrayPercentLiteral:
+  Enabled: true
+
+Layout/SpaceInsidePercentLiteralDelimiters:
+  Enabled: true
+
+Layout/SpaceInsideArrayLiteralBrackets:
+  Enabled: true
+
+Layout/SpaceInsideParens:
+  Enabled: true
+
+Layout/SpaceInsideRangeLiteral:
+  Enabled: true
+
+Style/SymbolLiteral:
+  Enabled: true
+
+Layout/Tab:
+  Enabled: true
+
+Layout/TrailingWhitespace:
+  Enabled: true
+
+Style/UnlessElse:
+  Enabled: true
+
+Style/UnneededCapitalW:
+  Enabled: true
+
+Style/UnneededInterpolation:
+  Enabled: true
+
+Style/UnneededPercentQ:
+  Enabled: true
+
+Style/VariableInterpolation:
+  Enabled: true
+
+Style/WhenThen:
+  Enabled: true
+
+Style/WhileUntilDo:
+  Enabled: true
+
+Style/ZeroLengthPredicate:
+  Enabled: true
+
+Layout/IndentHeredoc:
+  EnforcedStyle: squiggly
+
+Lint/AmbiguousOperator:
+  Enabled: true
+
+Lint/AmbiguousRegexpLiteral:
+  Enabled: true
+
+Lint/CircularArgumentReference:
+  Enabled: true
+
+Layout/ConditionPosition:
+  Enabled: true
+
+Lint/Debugger:
+  Enabled: true
+
+Lint/DeprecatedClassMethods:
+  Enabled: true
+
+Lint/DuplicateMethods:
+  Enabled: true
+
+Lint/DuplicatedKey:
+  Enabled: true
+
+Lint/EachWithObjectArgument:
+  Enabled: true
+
+Lint/ElseLayout:
+  Enabled: true
+
+Lint/EmptyEnsure:
+  Enabled: true
+
+Lint/EmptyInterpolation:
+  Enabled: true
+
+Lint/EndInMethod:
+  Enabled: true
+
+Lint/EnsureReturn:
+  Enabled: true
+
+Lint/FloatOutOfRange:
+  Enabled: true
+
+Lint/FormatParameterMismatch:
+  Enabled: true
+
+Lint/HandleExceptions:
+  Enabled: true
+
+Lint/ImplicitStringConcatenation:
+  Description: Checks for adjacent string literals on the same line, which could
+    better be represented as a single string literal.
+
+Lint/IneffectiveAccessModifier:
+  Description: Checks for attempts to use `private` or `protected` to set the visibility
+    of a class method, which does not work.
+
+Lint/LiteralAsCondition:
+  Enabled: true
+
+Lint/LiteralInInterpolation:
+  Enabled: true
+
+Lint/Loop:
+  Description: Use Kernel#loop with break rather than begin/end/until or begin/end/while
+    for post-loop tests.
+
+Lint/NestedMethodDefinition:
+  Enabled: true
+
+Lint/NextWithoutAccumulator:
+  Description: Do not omit the accumulator when calling `next` in a `reduce`/`inject`
+    block.
+
+Lint/NonLocalExitFromIterator:
+  Enabled: true
+
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: true
+
+Lint/PercentStringArray:
+  Enabled: true
+
+Lint/PercentSymbolArray:
+  Enabled: true
+
+Lint/RandOne:
+  Description: Checks for `rand(1)` calls. Such calls always return `0` and most
+    likely a mistake.
+
+Lint/RequireParentheses:
+  Enabled: true
+
+Lint/RescueException:
+  Enabled: true
+
+Lint/ShadowedException:
+  Enabled: true
+
+Lint/ShadowingOuterLocalVariable:
+  Enabled: true
+
+Lint/StringConversionInInterpolation:
+  Enabled: true
+
+Lint/UnderscorePrefixedVariableName:
+  Enabled: true
+
+Lint/UnifiedInteger:
+  Enabled: true
+
+Lint/UnneededCopDisableDirective:
+  Enabled: true
+
+Lint/UnneededCopEnableDirective:
+  Enabled: true
+
+Lint/UnneededSplatExpansion:
+  Enabled: true
+
+Lint/UnreachableCode:
+  Enabled: true
+
+Lint/UselessAccessModifier:
+  ContextCreatingMethods: []
+
+Lint/UselessAssignment:
+  Enabled: true
+
+Lint/UselessComparison:
+  Enabled: true
+
+Lint/UselessElseWithoutRescue:
+  Enabled: true
+
+Lint/UselessSetterCall:
+  Enabled: true
+
+Lint/Void:
+  Enabled: true
+
+Security/Eval:
+  Enabled: true
+
+Security/JSONLoad:
+  Enabled: true
+
+Security/Open:
+  Enabled: true
+
+Lint/BigDecimalNew:
+  Enabled: true
+
+Style/Strip:
+  Enabled: true
+
+Style/TrailingBodyOnClass:
+  Enabled: true
+
+Style/TrailingBodyOnModule:
+  Enabled: true
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+  Enabled: true
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma
+  Enabled: true
+
+Layout/SpaceInsideReferenceBrackets:
+  EnforcedStyle: no_space
+  EnforcedStyleForEmptyBrackets: no_space
+  Enabled: true
+
+Style/ModuleFunction:
+  EnforcedStyle: extend_self
+
+Lint/OrderedMagicComments:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,12 @@
+inherit_from:
+  - https://shopify.github.io/ruby-style-guide/rubocop.yml
+
+AllCops:
+  TargetRubyVersion: 2.3
+  UseCache: true
+  CacheRootDirectory: tmp/rubocop
+
+Naming/FileName:
+  Enabled: true
+  Exclude:
+    - lib/statsd-instrument.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,8 +5,17 @@ AllCops:
   TargetRubyVersion: 2.3
   UseCache: true
   CacheRootDirectory: tmp/rubocop
+  Exclude:
+    - statsd-instrument.gemspec
 
 Naming/FileName:
   Enabled: true
   Exclude:
     - lib/statsd-instrument.rb
+
+Style/ClassAndModuleChildren:
+  Enabled: false # TODO: enable later
+
+
+Style/MethodCallWithArgsParentheses:
+  Enabled: false # TODO: enable later

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 
@@ -7,4 +9,4 @@ Rake::TestTask.new('test') do |t|
   t.test_files = FileList['test/*.rb']
 end
 
-task :default => :test
+task default: :test

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -384,7 +384,7 @@ module StatsD
   #      http_response = StatsD.distribution('HTTP.call.duration') do
   #        HTTP.get(url)
   #      end
-  def distribution(key, value=nil, *metric_options, &block)
+  def distribution(key, value = nil, *metric_options, &block)
     value, metric_options = parse_options(value, metric_options)
 
     return collect_metric(:d, key, value, metric_options) unless block_given?

--- a/lib/statsd/instrument/assertions.rb
+++ b/lib/statsd/instrument/assertions.rb
@@ -6,7 +6,7 @@ module StatsD::Instrument::Assertions
   def assert_no_statsd_calls(metric_name = nil, &block)
     metrics = capture_statsd_calls(&block)
     metrics.select! { |m| m.name == metric_name } if metric_name
-    assert metrics.empty?, "No StatsD calls for metric #{metrics.map(&:name).join(', ')} expected."
+    assert(metrics.empty?, "No StatsD calls for metric #{metrics.map(&:name).join(', ')} expected.")
   end
 
   def assert_statsd_increment(metric_name, options = {}, &block)
@@ -50,32 +50,34 @@ module StatsD::Instrument::Assertions
       expected_metric_times = expected_metric.times
       expected_metric_times_remaining = expected_metric.times
       filtered_metrics = metrics.select { |m| m.type == expected_metric.type && m.name == expected_metric.name }
-      assert filtered_metrics.length > 0,
-        "No StatsD calls for metric #{expected_metric.name} of type #{expected_metric.type} were made."
+      refute(filtered_metrics.empty?,
+        "No StatsD calls for metric #{expected_metric.name} of type #{expected_metric.type} were made.")
 
       filtered_metrics.each do |metric|
+        next unless expected_metric.matches(metric)
+
         assert within_numeric_range?(metric.sample_rate),
           "Unexpected sample rate type for metric #{metric.name}, must be numeric"
-        if expected_metric.matches(metric)
-          assert expected_metric_times_remaining > 0,
-            "Unexpected StatsD call; number of times this metric was expected exceeded: #{expected_metric.inspect}"
-          expected_metric_times_remaining -= 1
-          metrics.delete(metric)
-          if expected_metric_times_remaining == 0
-            matched_expected_metrics << expected_metric
-          end
+
+        assert(expected_metric_times_remaining > 0,
+          "Unexpected StatsD call; number of times this metric was expected exceeded: #{expected_metric.inspect}")
+
+        expected_metric_times_remaining -= 1
+        metrics.delete(metric)
+        if expected_metric_times_remaining == 0
+          matched_expected_metrics << expected_metric
         end
       end
 
-      assert expected_metric_times_remaining == 0,
+      assert(expected_metric_times_remaining == 0,
         "Metric expected #{expected_metric_times} times but seen " \
         "#{expected_metric_times - expected_metric_times_remaining} " \
-        "times: #{expected_metric.inspect}"
+        "times: #{expected_metric.inspect}")
     end
     expected_metrics -= matched_expected_metrics
 
-    assert expected_metrics.empty?,
-      "Unexpected StatsD calls; the following metric expectations were not satisfied: #{expected_metrics.inspect}"
+    assert(expected_metrics.empty?,
+      "Unexpected StatsD calls; the following metric expectations were not satisfied: #{expected_metrics.inspect}")
   end
 
   private
@@ -89,6 +91,6 @@ module StatsD::Instrument::Assertions
   end
 
   def within_numeric_range?(object)
-    object.kind_of?(Numeric) && (0.0..1.0).cover?(object)
+    object.is_a?(Numeric) && (0.0..1.0).cover?(object)
   end
 end

--- a/lib/statsd/instrument/assertions.rb
+++ b/lib/statsd/instrument/assertions.rb
@@ -68,9 +68,9 @@ module StatsD::Instrument::Assertions
       end
 
       assert expected_metric_times_remaining == 0,
-          "Metric expected #{expected_metric_times} times but seen"\
-          " #{expected_metric_times-expected_metric_times_remaining}"\
-          " times: #{expected_metric.inspect}"
+        "Metric expected #{expected_metric_times} times but seen " \
+        "#{expected_metric_times - expected_metric_times_remaining} " \
+        "times: #{expected_metric.inspect}"
     end
     expected_metrics -= matched_expected_metrics
 

--- a/lib/statsd/instrument/backend.rb
+++ b/lib/statsd/instrument/backend.rb
@@ -3,7 +3,6 @@
 # This abstract class specifies the interface a backend implementation should conform to.
 # @abstract
 class StatsD::Instrument::Backend
-
   # Collects a metric.
   #
   # @param metric [StatsD::Instrument::Metric] The metric to collect

--- a/lib/statsd/instrument/backend.rb
+++ b/lib/statsd/instrument/backend.rb
@@ -7,7 +7,7 @@ class StatsD::Instrument::Backend
   #
   # @param metric [StatsD::Instrument::Metric] The metric to collect
   # @return [void]
-  def collect_metric(metric)
+  def collect_metric(_metric)
     raise NotImplementedError, "Use a concerete backend implementation"
   end
 end

--- a/lib/statsd/instrument/backends/capture_backend.rb
+++ b/lib/statsd/instrument/backends/capture_backend.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 module StatsD::Instrument::Backends
-
   # The capture backend is used to capture the metrics that are collected, so you can
   # run assertions on them.
   #

--- a/lib/statsd/instrument/backends/logger_backend.rb
+++ b/lib/statsd/instrument/backends/logger_backend.rb
@@ -14,7 +14,7 @@ module StatsD::Instrument::Backends
     # @param metric [StatsD::Instrument::Metric]
     # @return [void]
     def collect_metric(metric)
-      logger.info "[StatsD] #{metric}"
+      logger.info("[StatsD] #{metric}")
     end
   end
 end

--- a/lib/statsd/instrument/backends/logger_backend.rb
+++ b/lib/statsd/instrument/backends/logger_backend.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
 module StatsD::Instrument::Backends
-
   # The logger backend simply logs every metric to a logger
   # @!attribute logger
   #    @return [Logger]
   class LoggerBackend < StatsD::Instrument::Backend
-
     attr_accessor :logger
 
     def initialize(logger)

--- a/lib/statsd/instrument/backends/udp_backend.rb
+++ b/lib/statsd/instrument/backends/udp_backend.rb
@@ -4,7 +4,6 @@ require 'monitor'
 
 module StatsD::Instrument::Backends
   class UDPBackend < StatsD::Instrument::Backend
-
     BASE_SUPPORTED_METRIC_TYPES = { c: true, ms: true, g: true, s: true }
 
     class DogStatsDProtocol
@@ -91,13 +90,13 @@ module StatsD::Instrument::Backends
 
     def implementation=(value)
       @packet_factory = case value
-        when :datadog
-          DogStatsDProtocol.new
-        when :statsite
-          StatsiteStatsDProtocol.new
-        else
-          StatsDProtocol.new
-        end
+      when :datadog
+        DogStatsDProtocol.new
+      when :statsite
+        StatsiteStatsDProtocol.new
+      else
+        StatsDProtocol.new
+      end
       @implementation = value
     end
 

--- a/lib/statsd/instrument/backends/udp_backend.rb
+++ b/lib/statsd/instrument/backends/udp_backend.rb
@@ -102,7 +102,8 @@ module StatsD::Instrument::Backends
 
     def collect_metric(metric)
       unless @packet_factory.class::SUPPORTED_METRIC_TYPES[metric.type]
-        StatsD.logger.warn("[StatsD] Metric type #{metric.type.inspect} not supported on #{implementation} implementation.")
+        StatsD.logger.warn("[StatsD] Metric type #{metric.type.inspect} is not supported " \
+          "on #{implementation} implementation.")
         return false
       end
 
@@ -141,13 +142,13 @@ module StatsD::Instrument::Backends
       synchronize do
         socket.send(command, 0) > 0
       end
-    rescue ThreadError => e
+    rescue ThreadError
       # In cases where a TERM or KILL signal has been sent, and we send stats as
       # part of a signal handler, locks cannot be acquired, so we do our best
       # to try and send the command without a lock.
       socket.send(command, 0) > 0
-    rescue SocketError, IOError, SystemCallError, Errno::ECONNREFUSED => e
-      StatsD.logger.error "[StatsD] #{e.class.name}: #{e.message}"
+    rescue SocketError, IOError, SystemCallError => e
+      StatsD.logger.error("[StatsD] #{e.class.name}: #{e.message}")
       invalidate_socket
     end
 

--- a/lib/statsd/instrument/helpers.rb
+++ b/lib/statsd/instrument/helpers.rb
@@ -3,11 +3,13 @@
 module StatsD::Instrument::Helpers
   def capture_statsd_calls(&block)
     mock_backend = StatsD::Instrument::Backends::CaptureBackend.new
-    old_backend, StatsD.backend = StatsD.backend, mock_backend
+    old_backend = StatsD.backend
+    StatsD.backend = mock_backend
+
     block.call
     mock_backend.collected_metrics
   ensure
-    if old_backend.kind_of?(StatsD::Instrument::Backends::CaptureBackend)
+    if old_backend.is_a?(StatsD::Instrument::Backends::CaptureBackend)
       old_backend.collected_metrics.concat(mock_backend.collected_metrics)
     end
 

--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -31,7 +31,6 @@
 # @see StatsD::Instrument::Backend A StatsD::Instrument::Backend is used to collect metrics.
 #
 class StatsD::Instrument::Metric
-
   attr_accessor :type, :name, :value, :sample_rate, :tags, :metadata
 
   # Initializes a new metric instance.
@@ -60,10 +59,10 @@ class StatsD::Instrument::Metric
       end
     end
 
-    @value       = options[:value] || default_value
+    @value = options[:value] || default_value
     @sample_rate = options[:sample_rate] || StatsD.default_sample_rate
-    @tags        = StatsD::Instrument::Metric.normalize_tags(options[:tags])
-    @metadata    = options.reject { |k, _| [:type, :name, :value, :sample_rate, :tags].include?(k) }
+    @tags = StatsD::Instrument::Metric.normalize_tags(options[:tags])
+    @metadata = options.reject { |k, _| [:type, :name, :value, :sample_rate, :tags].include?(k) }
   end
 
   # The default value for this metric, which will be used if it is not set.
@@ -98,13 +97,13 @@ class StatsD::Instrument::Metric
   # The metric types that are supported by this library. Note that every StatsD server
   # implementation only supports a subset of them.
   TYPES = {
-    c:  'increment',
+    c: 'increment',
     ms: 'measure',
-    g:  'gauge',
-    h:  'histogram',
-    d:  'distribution',
+    g: 'gauge',
+    h: 'histogram',
+    d: 'distribution',
     kv: 'key/value',
-    s:  'set',
+    s: 'set',
   }
 
   # Strip metric names of special characters used by StatsD line protocol, replace with underscore

--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -48,9 +48,18 @@ class StatsD::Instrument::Metric
   # @option options [Array<String>, Hash<String, String>, nil] :tags The tags to apply to this metric.
   #   See {.normalize_tags} for more information.
   def initialize(options = {})
-    @type = options[:type] or raise ArgumentError, "Metric :type is required."
-    @name = options[:name] or raise ArgumentError, "Metric :name is required."
-    @name = normalize_name(@name)
+    if options[:type]
+      @type = options[:type]
+    else
+      raise ArgumentError, "Metric :type is required."
+    end
+
+    if options[:name]
+      @name = normalize_name(options[:name])
+    else
+      raise ArgumentError, "Metric :name is required."
+    end
+
     unless options[:no_prefix]
       @name = if options[:prefix]
         "#{options[:prefix]}.#{@name}"
@@ -74,8 +83,8 @@ class StatsD::Instrument::Metric
   # @raise ArgumentError if the metric type doesn't have a default value
   def default_value
     case type
-      when :c; 1
-      else raise ArgumentError, "A value is required for metric type #{type.inspect}."
+    when :c then 1
+    else raise ArgumentError, "A value is required for metric type #{type.inspect}."
     end
   end
 
@@ -84,14 +93,14 @@ class StatsD::Instrument::Metric
   def to_s
     str = +"#{TYPES[type]} #{name}:#{value}"
     str << " @#{sample_rate}" if sample_rate != 1.0
-    tags.each { |tag| str << " ##{tag}" } if tags
+    tags&.each { |tag| str << " ##{tag}" }
     str
   end
 
   # @private
   # @return [String]
   def inspect
-    "#<StatsD::Instrument::Metric #{self.to_s}>"
+    "#<StatsD::Instrument::Metric #{self}>"
   end
 
   # The metric types that are supported by this library. Note that every StatsD server

--- a/lib/statsd/instrument/metric_expectation.rb
+++ b/lib/statsd/instrument/metric_expectation.rb
@@ -2,7 +2,6 @@
 
 # @private
 class StatsD::Instrument::MetricExpectation
-
   attr_accessor :times, :type, :name, :value, :sample_rate, :tags
   attr_reader :ignore_tags
 
@@ -31,7 +30,7 @@ class StatsD::Instrument::MetricExpectation
         actual_tags -= ignored_tags
 
         if ignore_tags.is_a?(Array)
-          actual_tags.delete_if{ |key| ignore_tags.include?(key.split(":").first) }
+          actual_tags.delete_if { |key| ignore_tags.include?(key.split(":").first) }
         end
       end
 
@@ -47,19 +46,19 @@ class StatsD::Instrument::MetricExpectation
   end
 
   TYPES = {
-      c:  'increment',
-      ms: 'measure',
-      g:  'gauge',
-      h:  'histogram',
-      d:  'distribution',
-      kv: 'key/value',
-      s:  'set',
+    c: 'increment',
+    ms: 'measure',
+    g: 'gauge',
+    h: 'histogram',
+    d: 'distribution',
+    kv: 'key/value',
+    s: 'set',
   }
 
   def to_s
     str = +"#{TYPES[type]} #{name}:#{value}"
     str << " @#{sample_rate}" if sample_rate != 1.0
-    str << " " << tags.map { |t| "##{t}"}.join(' ') if tags
+    str << " " << tags.map { |t| "##{t}" }.join(' ') if tags
     str << " times:#{times}" if times > 1
     str
   end

--- a/lib/statsd/instrument/metric_expectation.rb
+++ b/lib/statsd/instrument/metric_expectation.rb
@@ -6,11 +6,26 @@ class StatsD::Instrument::MetricExpectation
   attr_reader :ignore_tags
 
   def initialize(options = {})
-    @type = options[:type] or raise ArgumentError, "Metric :type is required."
-    @name = options[:name] or raise ArgumentError, "Metric :name is required."
+    if options[:type]
+      @type = options[:type]
+    else
+      raise ArgumentError, "Metric :type is required."
+    end
+
+    if options[:name]
+      @name = options[:name]
+    else
+      raise ArgumentError, "Metric :name is required."
+    end
+
+    if options[:times]
+      @times = options[:times]
+    else
+      raise ArgumentError, "Metric :times is required."
+    end
+
     @name = StatsD.prefix ? "#{StatsD.prefix}.#{@name}" : @name unless options[:no_prefix]
     @tags = StatsD::Instrument::Metric.normalize_tags(options[:tags])
-    @times = options[:times] or raise ArgumentError, "Metric :times is required."
     @sample_rate = options[:sample_rate]
     @value = options[:value]
     @ignore_tags = StatsD::Instrument::Metric.normalize_tags(options[:ignore_tags])
@@ -40,9 +55,7 @@ class StatsD::Instrument::MetricExpectation
   end
 
   def default_value
-    case type
-      when :c; 1
-    end
+    1 if type == :c
   end
 
   TYPES = {
@@ -64,6 +77,6 @@ class StatsD::Instrument::MetricExpectation
   end
 
   def inspect
-    "#<StatsD::Instrument::MetricExpectation #{self.to_s}>"
+    "#<StatsD::Instrument::MetricExpectation #{self}>"
   end
 end

--- a/lib/statsd/instrument/railtie.rb
+++ b/lib/statsd/instrument/railtie.rb
@@ -5,7 +5,6 @@
 #
 # @see StatsD::Instrument::Environment
 class StatsD::Instrument::Railtie < Rails::Railtie
-
   initializer 'statsd-instrument.use_rails_logger' do
     ::StatsD.logger = Rails.logger
   end

--- a/statsd-instrument.gemspec
+++ b/statsd-instrument.gemspec
@@ -1,21 +1,23 @@
+# frozen-string-literal: true
 # encoding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'statsd/instrument/version'
 
 Gem::Specification.new do |spec|
-  spec.name        = "statsd-instrument"
-  spec.version     = StatsD::Instrument::VERSION
-  spec.authors     = ["Jesse Storimer", "Tobias Lutke", "Willem van Bergen"]
-  spec.email       = ["jesse@shopify.com"]
-  spec.homepage    = "https://github.com/Shopify/statsd-instrument"
-  spec.summary     = %q{A StatsD client for Ruby apps}
+  spec.name = "statsd-instrument"
+  spec.version = StatsD::Instrument::VERSION
+  spec.authors = ["Jesse Storimer", "Tobias Lutke", "Willem van Bergen"]
+  spec.email = ["jesse@shopify.com"]
+  spec.homepage = "https://github.com/Shopify/statsd-instrument"
+  spec.summary = %q{A StatsD client for Ruby apps}
   spec.description = %q{A StatsD client for Ruby apps. Provides metaprogramming methods to inject StatsD instrumentation into your code.}
-  spec.license     = "MIT"
+  spec.license = "MIT"
 
-  spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.files = `git ls-files`.split($/)
+  spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency 'rake'

--- a/statsd-instrument.gemspec
+++ b/statsd-instrument.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'mocha'
   spec.add_development_dependency 'yard'
+  spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'benchmark-ips'
 end

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -264,7 +264,7 @@ class AssertionsTest < Minitest::Test
   def test_assert_statsd_call_with_wrong_sample_rate_type
     assert_assertion_triggered "Unexpected sample rate type for metric counter, must be numeric" do
       @test_case.assert_statsd_increment('counter', tags: ['a', 'b']) do
-        StatsD.increment('counter', sample_rate: 'abc', tags:  ['a', 'b'])
+        StatsD.increment('counter', sample_rate: 'abc', tags: ['a', 'b'])
       end
     end
   end

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -311,7 +311,7 @@ class AssertionsTest < Minitest::Test
   def assert_no_assertion_triggered(&block)
     block.call
   rescue MiniTest::Assertion => assertion
-    flunk "No assertion trigger expected, but one was triggered with message #{assertion.message}."
+    flunk("No assertion trigger expected, but one was triggered with message #{assertion.message}.")
   else
     pass
   end
@@ -320,12 +320,12 @@ class AssertionsTest < Minitest::Test
     block.call
   rescue MiniTest::Assertion => assertion
     if message
-      assert_equal message, assertion.message, "Assertion triggered, but message was not what was expected."
+      assert_equal(message, assertion.message, "Assertion triggered, but message was not what was expected.")
     else
       pass
     end
     assertion
   else
-    flunk "No assertion was triggered, but one was expected."
+    flunk("No assertion was triggered, but one was expected.")
   end
 end

--- a/test/benchmark/metrics.rb
+++ b/test/benchmark/metrics.rb
@@ -3,11 +3,11 @@
 require 'statsd-instrument'
 require 'benchmark/ips'
 
-def helperFunction()
-    a = 10
-    a += a
-    a -= a
-    a *= a
+def helper_function
+  a = 10
+  a += a
+  a -= a
+  a *= a
 end
 
 Benchmark.ips do |bench|
@@ -16,8 +16,8 @@ Benchmark.ips do |bench|
   end
 
   bench.report("measure metric benchmark") do
-    StatsD.measure('helperFunction') do
-        helperFunction()
+    StatsD.measure('helper_function') do
+      helper_function
     end
   end
 
@@ -36,5 +36,4 @@ Benchmark.ips do |bench|
   bench.report("service check metric benchmark") do
     StatsD.service_check('shipit.redis_connection', 'ok')
   end
-
 end

--- a/test/benchmark/metrics.rb
+++ b/test/benchmark/metrics.rb
@@ -7,7 +7,7 @@ def helper_function
   a = 10
   a += a
   a -= a
-  a *= a
+  a * a
 end
 
 Benchmark.ips do |bench|

--- a/test/benchmark/tags.rb
+++ b/test/benchmark/tags.rb
@@ -5,7 +5,7 @@ require 'benchmark/ips'
 
 Benchmark.ips do |bench|
   bench.report("normalized tags with simple hash") do
-    StatsD::Instrument::Metric.normalize_tags(:tag => 'value')
+    StatsD::Instrument::Metric.normalize_tags(tag: 'value')
   end
 
   bench.report("normalized tags with simple array") do
@@ -13,14 +13,14 @@ Benchmark.ips do |bench|
   end
 
   bench.report("normalized tags with large hash") do
-    StatsD::Instrument::Metric.normalize_tags({
+    StatsD::Instrument::Metric.normalize_tags(
       mobile: true,
       pod: "1",
       protocol: "https",
       country: "Langbortistan",
       complete: true,
       shop: "omg shop that has a longer name",
-    })
+    )
   end
 
   bench.report("normalized tags with large array") do

--- a/test/capture_backend_test.rb
+++ b/test/capture_backend_test.rb
@@ -5,8 +5,8 @@ require 'test_helper'
 class CaptureBackendTest < Minitest::Test
   def setup
     @backend = StatsD::Instrument::Backends::CaptureBackend.new
-    @metric1 = StatsD::Instrument::Metric::new(type: :c, name: 'mock.counter')
-    @metric2 = StatsD::Instrument::Metric::new(type: :ms, name: 'mock.measure', value: 123)
+    @metric1 = StatsD::Instrument::Metric.new(type: :c, name: 'mock.counter')
+    @metric2 = StatsD::Instrument::Metric.new(type: :ms, name: 'mock.measure', value: 123)
   end
 
   def test_collecting_metric

--- a/test/environment_test.rb
+++ b/test/environment_test.rb
@@ -5,7 +5,6 @@ require 'test_helper'
 module Rails; end
 
 class EnvironmentTest < Minitest::Test
-
   def setup
     ENV['STATSD_ADDR'] = nil
     ENV['IMPLEMENTATION'] = nil

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -23,4 +23,3 @@ class HelpersTest < Minitest::Test
     assert_equal 12, metrics[1].value
   end
 end
-

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -4,18 +4,37 @@ require 'test_helper'
 
 class IntegrationTest < Minitest::Test
   def setup
-    @old_backend, StatsD.backend = StatsD.backend, StatsD::Instrument::Backends::UDPBackend.new("localhost:31798")
+    @server = UDPSocket.new
+    @server.bind('localhost', 0)
+    port = @server.addr[1]
+
+    @old_backend = StatsD.backend
+    StatsD.backend = StatsD::Instrument::Backends::UDPBackend.new("localhost:#{port}")
   end
 
   def teardown
+    @server.close
     StatsD.backend = @old_backend
   end
 
   def test_live_local_udp_socket
-    server = UDPSocket.new
-    server.bind('localhost', 31798)
-
     StatsD.increment('counter')
-    assert_equal "counter:1|c", server.recvfrom(100).first
+    assert_equal "counter:1|c", @server.recvfrom(100).first
+  end
+
+  def test_synchronize_in_exit_handler_handles_thread_error_and_exits_cleanly
+    pid = fork do
+      Signal.trap('TERM') do
+        StatsD.increment('exiting')
+        Process.exit!(0)
+      end
+
+      sleep 100
+    end
+
+    Process.kill('TERM', pid)
+    Process.waitpid(pid)
+
+    assert_equal "exiting:1|c", @server.recvfrom(100).first
   end
 end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -3,7 +3,6 @@
 require 'test_helper'
 
 class IntegrationTest < Minitest::Test
-
   def setup
     @old_backend, StatsD.backend = StatsD.backend, StatsD::Instrument::Backends::UDPBackend.new("localhost:31798")
   end

--- a/test/logger_backend_test.rb
+++ b/test/logger_backend_test.rb
@@ -7,8 +7,8 @@ class LoggerBackendTest < Minitest::Test
     logger = Logger.new(@io = StringIO.new)
     logger.formatter = lambda { |_, _, _, msg| "#{msg}\n" }
     @backend = StatsD::Instrument::Backends::LoggerBackend.new(logger)
-    @metric1 = StatsD::Instrument::Metric::new(type: :c, name: 'mock.counter', tags: { a: 'b', c: 'd' })
-    @metric2 = StatsD::Instrument::Metric::new(type: :ms, name: 'mock.measure', value: 123, sample_rate: 0.3)
+    @metric1 = StatsD::Instrument::Metric.new(type: :c, name: 'mock.counter', tags: { a: 'b', c: 'd' })
+    @metric2 = StatsD::Instrument::Metric.new(type: :ms, name: 'mock.measure', value: 123, sample_rate: 0.3)
   end
 
   def test_logs_metrics

--- a/test/logger_backend_test.rb
+++ b/test/logger_backend_test.rb
@@ -5,9 +5,9 @@ require 'test_helper'
 class LoggerBackendTest < Minitest::Test
   def setup
     logger = Logger.new(@io = StringIO.new)
-    logger.formatter = lambda { |_,_,_, msg| "#{msg}\n" }
+    logger.formatter = lambda { |_, _, _, msg| "#{msg}\n" }
     @backend = StatsD::Instrument::Backends::LoggerBackend.new(logger)
-    @metric1 = StatsD::Instrument::Metric::new(type: :c, name: 'mock.counter', tags: { a: 'b', c: 'd'})
+    @metric1 = StatsD::Instrument::Metric::new(type: :c, name: 'mock.counter', tags: { a: 'b', c: 'd' })
     @metric2 = StatsD::Instrument::Metric::new(type: :ms, name: 'mock.measure', value: 123, sample_rate: 0.3)
   end
 

--- a/test/matchers_test.rb
+++ b/test/matchers_test.rb
@@ -5,11 +5,13 @@ require 'statsd/instrument/matchers'
 
 class MatchersTest < Minitest::Test
   def test_statsd_increment_matched
-    assert StatsD::Instrument::Matchers::Increment.new(:c, 'counter', {}).matches? lambda { StatsD.increment('counter') }
+    assert StatsD::Instrument::Matchers::Increment.new(:c, 'counter', {})
+      .matches?(lambda { StatsD.increment('counter') })
   end
 
   def test_statsd_increment_not_matched
-    refute StatsD::Instrument::Matchers::Increment.new(:c, 'counter', {}).matches? lambda { StatsD.increment('not_counter') }
+    refute StatsD::Instrument::Matchers::Increment.new(:c, 'counter', {})
+      .matches?(lambda { StatsD.increment('not_counter') })
   end
 
   def test_statsd_increment_compound_matched
@@ -33,72 +35,82 @@ class MatchersTest < Minitest::Test
   end
 
   def test_statsd_increment_with_times_matched
-    assert StatsD::Instrument::Matchers::Increment.new(:c, 'counter', times: 1).matches? lambda { StatsD.increment('counter') }
+    assert StatsD::Instrument::Matchers::Increment.new(:c, 'counter', times: 1)
+      .matches?(lambda { StatsD.increment('counter') })
   end
 
   def test_statsd_increment_with_times_not_matched
-    refute StatsD::Instrument::Matchers::Increment.new(:c, 'counter', times: 2).matches? lambda { StatsD.increment('counter', times: 3) }
+    refute StatsD::Instrument::Matchers::Increment.new(:c, 'counter', times: 2)
+      .matches?(lambda { StatsD.increment('counter', times: 3) })
   end
 
   def test_statsd_increment_with_sample_rate_matched
-    assert StatsD::Instrument::Matchers::Increment.new(:c, 'counter', sample_rate: 0.5).matches? lambda { StatsD.increment('counter', sample_rate: 0.5) }
+    assert StatsD::Instrument::Matchers::Increment.new(:c, 'counter', sample_rate: 0.5)
+      .matches?(lambda { StatsD.increment('counter', sample_rate: 0.5) })
   end
 
   def test_statsd_increment_with_sample_rate_not_matched
-    refute StatsD::Instrument::Matchers::Increment.new(:c, 'counter', sample_rate: 0.5).matches? lambda { StatsD.increment('counter', sample_rate: 0.7) }
+    refute StatsD::Instrument::Matchers::Increment.new(:c, 'counter', sample_rate: 0.5)
+      .matches?(lambda { StatsD.increment('counter', sample_rate: 0.7) })
   end
 
   def test_statsd_increment_with_value_matched
-    assert StatsD::Instrument::Matchers::Increment.new(:c, 'counter', value: 1).matches? lambda { StatsD.increment('counter') }
+    assert StatsD::Instrument::Matchers::Increment.new(:c, 'counter', value: 1)
+      .matches?(lambda { StatsD.increment('counter') })
   end
 
   def test_statsd_increment_with_value_matched_when_multiple_metrics
-    assert StatsD::Instrument::Matchers::Increment.new(:c, 'counter', value: 1).matches? lambda {
+    assert StatsD::Instrument::Matchers::Increment.new(:c, 'counter', value: 1).matches?(lambda {
       StatsD.increment('counter', value: 2)
       StatsD.increment('counter', value: 1)
-    }
+    })
   end
 
   def test_statsd_increment_with_value_not_matched_when_multiple_metrics
-    refute StatsD::Instrument::Matchers::Increment.new(:c, 'counter', value: 1).matches? lambda {
+    refute StatsD::Instrument::Matchers::Increment.new(:c, 'counter', value: 1).matches?(lambda {
       StatsD.increment('counter', value: 2)
       StatsD.increment('counter', value: 3)
-    }
+    })
   end
 
   def test_statsd_increment_with_value_not_matched
-    refute StatsD::Instrument::Matchers::Increment.new(:c, 'counter', value: 3).matches? lambda { StatsD.increment('counter') }
+    refute StatsD::Instrument::Matchers::Increment.new(:c, 'counter', value: 3)
+      .matches?(lambda { StatsD.increment('counter') })
   end
 
   def test_statsd_increment_with_tags_matched
-    assert StatsD::Instrument::Matchers::Increment.new(:c, 'counter', tags: ['a', 'b']).matches? lambda { StatsD.increment('counter', tags: ['a', 'b']) }
+    assert StatsD::Instrument::Matchers::Increment.new(:c, 'counter', tags: ['a', 'b'])
+      .matches?(lambda { StatsD.increment('counter', tags: ['a', 'b']) })
   end
 
   def test_statsd_increment_with_tags_not_matched
-    refute StatsD::Instrument::Matchers::Increment.new(:c, 'counter', tags: ['a', 'b']).matches? lambda { StatsD.increment('counter', tags: ['c']) }
+    refute StatsD::Instrument::Matchers::Increment.new(:c, 'counter', tags: ['a', 'b'])
+      .matches?(lambda { StatsD.increment('counter', tags: ['c']) })
   end
 
   def test_statsd_increment_with_times_and_value_matched
-    assert StatsD::Instrument::Matchers::Increment.new(:c, 'counter', times: 2, value: 1).matches? lambda {
+    assert StatsD::Instrument::Matchers::Increment.new(:c, 'counter', times: 2, value: 1).matches?(lambda {
       StatsD.increment('counter', value: 1)
       StatsD.increment('counter', value: 1)
-    }
+    })
   end
 
   def test_statsd_increment_with_times_and_value_not_matched
-    refute StatsD::Instrument::Matchers::Increment.new(:c, 'counter', times: 2, value: 1).matches? lambda {
+    refute StatsD::Instrument::Matchers::Increment.new(:c, 'counter', times: 2, value: 1).matches?(lambda {
       StatsD.increment('counter', value: 1)
       StatsD.increment('counter', value: 2)
-    }
+    })
   end
 
   def test_statsd_increment_with_sample_rate_and_argument_matcher_matched
     between_matcher = RSpec::Matchers::BuiltIn::BeBetween.new(0.4, 0.6).inclusive
-    assert StatsD::Instrument::Matchers::Increment.new(:c, 'counter', sample_rate: between_matcher).matches? lambda { StatsD.increment('counter', sample_rate: 0.5) }
+    assert StatsD::Instrument::Matchers::Increment.new(:c, 'counter', sample_rate: between_matcher)
+      .matches?(lambda { StatsD.increment('counter', sample_rate: 0.5) })
   end
 
   def test_statsd_increment_with_sample_rate_and_argument_matcher_not_matched
     between_matcher = RSpec::Matchers::BuiltIn::BeBetween.new(0.4, 0.6).inclusive
-    refute StatsD::Instrument::Matchers::Increment.new(:c, 'counter', sample_rate: between_matcher).matches? lambda { StatsD.increment('counter', sample_rate: 0.7) }
+    refute StatsD::Instrument::Matchers::Increment.new(:c, 'counter', sample_rate: between_matcher)
+      .matches?(lambda { StatsD.increment('counter', sample_rate: 0.7) })
   end
 end

--- a/test/metric_test.rb
+++ b/test/metric_test.rb
@@ -3,7 +3,6 @@
 require 'test_helper'
 
 class MetricTest < Minitest::Test
-
   def test_required_arguments
     assert_raises(ArgumentError) { StatsD::Instrument::Metric.new(type: :c) }
     assert_raises(ArgumentError) { StatsD::Instrument::Metric.new(name: 'test') }
@@ -43,7 +42,7 @@ class MetricTest < Minitest::Test
 
   def test_handle_bad_tags
     assert_equal ['ignored'], StatsD::Instrument::Metric.normalize_tags(['igno|red'])
-    assert_equal ['lol::class:omg::lol'], StatsD::Instrument::Metric.normalize_tags({ :"lol::class" => "omg::lol" })
+    assert_equal ['lol::class:omg::lol'], StatsD::Instrument::Metric.normalize_tags(:"lol::class" => "omg::lol")
   end
 
   def test_rewrite_tags_provided_as_hash

--- a/test/metric_test.rb
+++ b/test/metric_test.rb
@@ -42,11 +42,11 @@ class MetricTest < Minitest::Test
 
   def test_handle_bad_tags
     assert_equal ['ignored'], StatsD::Instrument::Metric.normalize_tags(['igno|red'])
-    assert_equal ['lol::class:omg::lol'], StatsD::Instrument::Metric.normalize_tags(:"lol::class" => "omg::lol")
+    assert_equal ['lol::class:omg::lol'], StatsD::Instrument::Metric.normalize_tags("lol::class" => "omg::lol")
   end
 
   def test_rewrite_tags_provided_as_hash
-    assert_equal ['tag:value'], StatsD::Instrument::Metric.normalize_tags(:tag => 'value')
-    assert_equal ['tag:value', 'tag2:value2'], StatsD::Instrument::Metric.normalize_tags(:tag => 'value', :tag2 => 'value2')
+    assert_equal ['tag:value'], StatsD::Instrument::Metric.normalize_tags(tag: 'value')
+    assert_equal ['tag1:v1', 'tag2:v2'], StatsD::Instrument::Metric.normalize_tags(tag1: 'v1', tag2: 'v2')
   end
 end

--- a/test/statsd_instrumentation_test.rb
+++ b/test/statsd_instrumentation_test.rb
@@ -13,7 +13,7 @@ class ActiveMerchant::Base
   end
 
   def post_with_block(&block)
-    yield if block_given?
+    block.call if block_given?
   end
 end
 
@@ -36,7 +36,7 @@ end
 
 class ActiveMerchant::UniqueGateway < ActiveMerchant::Base
   def ssl_post(arg)
-    { :success => arg }
+    { success: arg }
   end
 
   def purchase(arg)
@@ -413,10 +413,9 @@ class StatsDInstrumentationTest < Minitest::Test
   private
 
   def assert_scope(klass, method, expected_scope)
-    method_scope = case
-    when klass.private_method_defined?(method)
+    method_scope = if klass.private_method_defined?(method)
       :private
-    when klass.protected_method_defined?(method)
+    elsif klass.protected_method_defined?(method)
       :protected
     else
       :public

--- a/test/statsd_instrumentation_test.rb
+++ b/test/statsd_instrumentation_test.rb
@@ -36,7 +36,7 @@ end
 
 class ActiveMerchant::UniqueGateway < ActiveMerchant::Base
   def ssl_post(arg)
-    {:success => arg}
+    { :success => arg }
   end
 
   def purchase(arg)
@@ -89,7 +89,7 @@ class StatsDInstrumentationTest < Minitest::Test
     end
 
     assert_statsd_increment('ActiveMerchant.Base.post_with_block') do
-      assert_equal 'true',  ActiveMerchant::Base.new.post_with_block { 'true' }
+      assert_equal 'true', ActiveMerchant::Base.new.post_with_block { 'true' }
       assert_equal 'false', ActiveMerchant::Base.new.post_with_block { 'false' }
     end
   ensure
@@ -266,7 +266,6 @@ class StatsDInstrumentationTest < Minitest::Test
   ensure
     ActiveMerchant::UniqueGateway.statsd_remove_measure :ssl_post, 'ActiveMerchant.Gateway.ssl_post'
   end
-
 
   def test_statsd_distribution
     ActiveMerchant::UniqueGateway.statsd_distribution :ssl_post, 'ActiveMerchant.Gateway.ssl_post', sample_rate: 0.3

--- a/test/statsd_test.rb
+++ b/test/statsd_test.rb
@@ -43,7 +43,7 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_measure_with_explicit_value_and_sample_rate
-    metric = capture_statsd_call { StatsD.measure('values.foobar', 42, :sample_rate => 0.1) }
+    metric = capture_statsd_call { StatsD.measure('values.foobar', 42, sample_rate: 0.1) }
     assert_equal 0.1, metric.sample_rate
   end
 
@@ -97,7 +97,7 @@ class StatsDTest < Minitest::Test
 
       begin
         result = lambda.call
-      rescue
+      rescue # rubocop:disable Lint/HandleExceptions:
       end
     end
 
@@ -115,14 +115,14 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_increment_with_hash_argument
-    metric = capture_statsd_call { StatsD.increment('values.foobar', :tags => ['test']) }
+    metric = capture_statsd_call { StatsD.increment('values.foobar', tags: ['test']) }
     assert_equal StatsD.default_sample_rate, metric.sample_rate
     assert_equal ['test'], metric.tags
     assert_equal 1, metric.value
   end
 
   def test_statsd_increment_with_value_as_keyword_argument
-    metric = capture_statsd_call { StatsD.increment('values.foobar', :value => 2) }
+    metric = capture_statsd_call { StatsD.increment('values.foobar', value: 2) }
     assert_equal StatsD.default_sample_rate, metric.sample_rate
     assert_equal 2, metric.value
   end
@@ -218,7 +218,7 @@ class StatsDTest < Minitest::Test
 
       begin
         result = lambda.call
-      rescue
+      rescue # rubocop:disable Lint/HandleExceptions
       end
     end
 
@@ -230,7 +230,7 @@ class StatsDTest < Minitest::Test
   def test_statsd_distribution_with_block_and_options
     StatsD::Instrument.stubs(:current_timestamp).returns(5.0, 5.0 + 1.12)
     metric = capture_statsd_call do
-      StatsD.distribution('values.foobar', :tags => ['test'], :sample_rate => 0.9) { 'foo' }
+      StatsD.distribution('values.foobar', tags: ['test'], sample_rate: 0.9) { 'foo' }
     end
     assert_equal 1120.0, metric.value
     assert_equal 'values.foobar', metric.name

--- a/test/statsd_test.rb
+++ b/test/statsd_test.rb
@@ -77,7 +77,7 @@ class StatsDTest < Minitest::Test
     result = nil
     metric = capture_statsd_call do
       lambda = -> do
-        StatsD.measure('values.foobar') { return 'from lambda'}
+        StatsD.measure('values.foobar') { return 'from lambda' }
       end
 
       result = lambda.call
@@ -92,14 +92,13 @@ class StatsDTest < Minitest::Test
     result = nil
     metric = capture_statsd_call do
       lambda = -> do
-        StatsD.measure('values.foobar') { raise 'from lambda'}
+        StatsD.measure('values.foobar') { raise 'from lambda' }
       end
 
       begin
         result = lambda.call
       rescue
       end
-
     end
 
     assert_nil result
@@ -198,7 +197,7 @@ class StatsDTest < Minitest::Test
     result = nil
     metric = capture_statsd_call do
       lambda = -> do
-        StatsD.distribution('values.foobar') { return 'from lambda'}
+        StatsD.distribution('values.foobar') { return 'from lambda' }
       end
 
       result = lambda.call
@@ -214,14 +213,13 @@ class StatsDTest < Minitest::Test
     result = nil
     metric = capture_statsd_call do
       lambda = -> do
-        StatsD.distribution('values.foobar') { raise 'from lambda'}
+        StatsD.distribution('values.foobar') { raise 'from lambda' }
       end
 
       begin
         result = lambda.call
       rescue
       end
-
     end
 
     assert_nil result

--- a/test/udp_backend_test.rb
+++ b/test/udp_backend_test.rb
@@ -185,31 +185,6 @@ class UDPBackendTest < Minitest::Test
     StatsD.increment('fail')
   end
 
-  def test_synchronize_in_exit_handler_handles_thread_error_and_exits_cleanly
-    pid = fork do
-      Signal.trap('TERM') do
-        $sent_packet = false
-
-        class << @backend.socket
-          def send(command, *args)
-            $sent_packet = true if command == 'exiting:1|c'
-            command.length
-          end
-        end
-
-        StatsD.increment('exiting')
-        Process.exit!($sent_packet)
-      end
-
-      sleep 100
-    end
-
-    Process.kill('TERM', pid)
-    Process.waitpid(pid)
-
-    assert $?.success?, 'socket did not write on exit'
-  end
-
   def test_socket_error_should_invalidate_socket
     seq = sequence('fail_then_succeed')
 


### PR DESCRIPTION
This sets up the Shopify Ruby style guide, verified by Rubocop.

- Add Rubocop as a dependency
- Run Rubocop in CI.
- Address many style issues, but also disable some rules for now.