### PR TITLE
Handle exceptions +when capturing statsd packets properly

### DIFF
--- a/lib/statsd/instrument/backends/capture_backend.rb
+++ b/lib/statsd/instrument/backends/capture_backend.rb
@@ -9,6 +9,7 @@ module StatsD::Instrument::Backends
   # @see StatsD::Instrument::Assertions
   class CaptureBackend < StatsD::Instrument::Backend
     attr_reader :collected_metrics
+    attr_accessor :parent
 
     def initialize
       reset
@@ -18,6 +19,7 @@ module StatsD::Instrument::Backends
     # @param metric [StatsD::Instrument::Metric]  The metric to collect.
     # @return [void]
     def collect_metric(metric)
+      parent&.collect_metric(metric)
       @collected_metrics << metric
     end
 

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -315,6 +315,42 @@ class AssertionsTest < Minitest::Test
     end
   end
 
+  def test_assertion_with_exceptions
+    assert_no_assertion_triggered do
+      @test_case.assert_raises(RuntimeError) do
+        @test_case.assert_statsd_increment('counter') do
+          StatsD.increment('counter')
+          raise "foo"
+        end
+      end
+    end
+
+    assert_no_assertion_triggered do
+      @test_case.assert_statsd_increment('counter') do
+        @test_case.assert_raises(RuntimeError) do
+          StatsD.increment('counter')
+          raise "foo"
+        end
+      end
+    end
+
+    assert_assertion_triggered do
+      @test_case.assert_statsd_increment('counter') do
+        @test_case.assert_raises(RuntimeError) do
+          raise "foo"
+        end
+      end
+    end
+
+    assert_assertion_triggered do
+      @test_case.assert_raises(RuntimeError) do
+        @test_case.assert_statsd_increment('counter') do
+          raise "foo"
+        end
+      end
+    end
+  end
+
   private
 
   def assert_no_assertion_triggered(&block)


### PR DESCRIPTION
Fixes #103.

In #103, @fw42 brought to light that the following test passes, while it really shouldn't:

``` ruby
test "foo" do
  assert_raises(RuntimeError) do
    assert_statsd_increment("blabla") do
      raise "hello"
    end
  end
end
```

This is because the `assert_statsd_increment` gets short-circuited when an exception happens, and we never assert the metrics.

The first commit adds a test that shows that this behavior is indeed broken. The second commit fixes it, by doing the metric assertions in an `ensure` block.