### PR TITLE
Clean up & optimize duration calculations

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -357,7 +357,7 @@ module StatsD
       block.call
     ensure
       # Ensure catches both a raised exception and a return in the invoked block
-      value = 1000 * (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start)
+      value = 1000.0 * (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start)
       collect_metric(type, key, value, metric_options)
     end
   end
@@ -425,7 +425,7 @@ module StatsD
     begin
       block.call
     ensure
-      value = 1000 * (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start)
+      value = 1000.0 * (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start)
       collect_metric(:d, key, value, metric_options)
     end
   end

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -62,26 +62,26 @@ module StatsD
       metric_name.respond_to?(:call) ? metric_name.call(callee, args).gsub('::', '.') : metric_name.gsub('::', '.')
     end
 
-    if Process.respond_to?(:clock_gettime)
-      # @private
-      def self.current_timestamp
-        Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      end
-    else
-      # @private
-      def self.current_timestamp
-        Time.now
-      end
+    # Even though this method is considered private, and is no longer used internally,
+    # applications in the wild rely on it. As a result, we cannot remove this method
+    # until the next major version.
+    #
+    # @deprecated Use Process.clock_gettime(Process::CLOCK_MONOTONIC) instead.
+    def self.current_timestamp
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
 
     # Even though this method is considered private, and is no longer used internally,
     # applications in the wild rely on it. As a result, we cannot remove this method
     # until the next major version.
-    # @private
+    #
+    # @deprecated You can implement similar functionality yourself using
+    #   `Process.clock_gettime(Process::CLOCK_MONOTONIC)`. Think about what will
+    #   happen if an exception happens during the block execution though.
     def self.duration
-      start = current_timestamp
+      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       yield
-      current_timestamp - start
+      Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
     end
 
     # Adds execution duration instrumentation to a method as a timing.
@@ -352,12 +352,12 @@ module StatsD
 
     return collect_metric(type, key, value, metric_options) unless block_given?
 
-    start = StatsD::Instrument.current_timestamp
+    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     begin
       block.call
     ensure
       # Ensure catches both a raised exception and a return in the invoked block
-      value = 1000 * (StatsD::Instrument.current_timestamp - start)
+      value = 1000 * (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start)
       collect_metric(type, key, value, metric_options)
     end
   end
@@ -421,11 +421,11 @@ module StatsD
 
     return collect_metric(:d, key, value, metric_options) unless block_given?
 
-    start = StatsD::Instrument.current_timestamp
+    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     begin
       block.call
     ensure
-      value = 1000 * (StatsD::Instrument.current_timestamp - start)
+      value = 1000 * (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start)
       collect_metric(:d, key, value, metric_options)
     end
   end

--- a/test/benchmark/clock_gettime.rb
+++ b/test/benchmark/clock_gettime.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'benchmark/ips'
+
+Benchmark.ips do |bench|
+  bench.report("Process.clock_gettime in milliseconds (int)") do
+    Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
+  end
+
+  bench.report("Process.clock_gettime in milliseconds (float)") do
+    Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
+  end
+
+  bench.report("Process.clock_gettime in seconds (float), multiplied by 1000") do
+    1000 * Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  end
+
+  bench.report("Process.clock_gettime in seconds (float), multiplied by 1000.0") do
+    1000.0 * Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  end
+
+  bench.report("Time.now, multiplied by 1000") do
+    1000 * Time.now.to_f
+  end
+
+  bench.compare!
+end

--- a/test/statsd_test.rb
+++ b/test/statsd_test.rb
@@ -52,7 +52,7 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_measure_with_benchmarked_block_duration
-    StatsD::Instrument.stubs(:current_timestamp).returns(5.0, 5.0 + 1.12)
+    Process.stubs(:clock_gettime).returns(5.0, 5.0 + 1.12)
     metric = capture_statsd_call do
       StatsD.measure('values.foobar') { 'foo' }
     end
@@ -77,7 +77,7 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_measure_with_return_in_block_still_captures
-    StatsD::Instrument.stubs(:current_timestamp).returns(5.0, 6.12)
+    Process.stubs(:clock_gettime).returns(5.0, 6.12)
     result = nil
     metric = capture_statsd_call do
       lambda = -> do
@@ -92,7 +92,7 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_measure_with_exception_in_block_still_captures
-    StatsD::Instrument.stubs(:current_timestamp).returns(5.0, 6.12)
+    Process.stubs(:clock_gettime).returns(5.0, 6.12)
     result = nil
     metric = capture_statsd_call do
       lambda = -> do
@@ -188,7 +188,7 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_distribution_with_benchmarked_block_duration
-    StatsD::Instrument.stubs(:current_timestamp).returns(5.0, 5.0 + 1.12)
+    Process.stubs(:clock_gettime).returns(5.0, 5.0 + 1.12)
     metric = capture_statsd_call do
       StatsD.distribution('values.foobar') { 'foo' }
     end
@@ -197,7 +197,7 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_distribution_with_return_in_block_still_captures
-    StatsD::Instrument.stubs(:current_timestamp).returns(5.0, 5.0 + 1.12)
+    Process.stubs(:clock_gettime).returns(5.0, 5.0 + 1.12)
     result = nil
     metric = capture_statsd_call do
       lambda = -> do
@@ -213,7 +213,7 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_distribution_with_exception_in_block_still_captures
-    StatsD::Instrument.stubs(:current_timestamp).returns(5.0, 5.0 + 1.12)
+    Process.stubs(:clock_gettime).returns(5.0, 5.0 + 1.12)
     result = nil
     metric = capture_statsd_call do
       lambda = -> do
@@ -232,7 +232,7 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_distribution_with_block_and_options
-    StatsD::Instrument.stubs(:current_timestamp).returns(5.0, 5.0 + 1.12)
+    Process.stubs(:clock_gettime).returns(5.0, 5.0 + 1.12)
     metric = capture_statsd_call do
       StatsD.distribution('values.foobar', tags: ['test'], sample_rate: 0.9) { 'foo' }
     end


### PR DESCRIPTION
`Process.clock_gettime(Process::CLOCK_MONOTONIC)` is now supported on all platforms and ruby versions we care about. We don’t need a fallback anymore as a result.

### Performance

I've also looked into using `Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)` to obtain timestamps in the correct unit directly, so we don't have to do the conversion from seconds ourselves. I've added a benchmark script that gives us several ways to get a timestamp in milliseconds, which is what we need for our duration measurements:

```
Calculating -------------------------------------
Process.clock_gettime in milliseconds (int)
                          4.174M (± 1.8%) i/s -     20.966M in   5.024129s
Process.clock_gettime in milliseconds (float)
                          4.393M (± 2.9%) i/s -     22.114M in   5.038199s
Process.clock_gettime in seconds (float), multiplied by 1000
                          4.526M (± 2.1%) i/s -     22.780M in   5.035625s
Process.clock_gettime in seconds (float), multiplied by 1000.0
                          4.867M (± 2.1%) i/s -     24.461M in   5.028644s
Time.now, multiplied by 1000
                          1.791M (± 1.8%) i/s -      9.045M in   5.051360s

Comparison:
Process.clock_gettime in seconds (float), multiplied by 1000.0:  4866582.5 i/s
Process.clock_gettime in seconds (float), multiplied by 1000:  4525763.2 i/s - 1.08x  slower
Process.clock_gettime in milliseconds (float):  4393428.5 i/s - 1.11x  slower
Process.clock_gettime in milliseconds (int):  4174452.2 i/s - 1.17x  slower
Time.now, multiplied by 1000:  1791272.0 i/s - 2.72x  slower
```

Observations:
- `Time.now` is very slow compared to `clock_gettime`.
- Interestingly, converting ourselves from seconds is slightly faster than asking for the timestamps in milliseconds directly. I was not expecting this
- We can even get a small performance boost to make sure our conversion is Float x Float, rather than Int x Float, by converting our `1000` constant to `1000.0`

I've updated out conversions to use a float constant (`1000.0`).