### PR TITLE
Run benchmark as part of CI.

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,32 @@
+name: Benchmarks
+
+on: push
+
+jobs:
+  test:
+    name: Send metric over UDP
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Setup Ruby
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6
+
+    - name: Install dependencies
+      run: gem install bundler && bundle install --jobs 4 --retry 3
+
+    - name: Run benchmark on branch
+      run: benchmark/send-metrics-to-local-udp-receiver
+
+    - uses: actions/checkout@v1
+      with:
+        ref: 'master'
+
+    - name: Install dependencies if needed
+      run: bundle check || bundle install --jobs 4 --retry 3
+
+    - name: Run benchmark on master
+      run: benchmark/send-metrics-to-local-udp-receiver


### PR DESCRIPTION
This runs the benchmark script it just added as part of CI on Github Actions.

- Run it on the current sha
- Check out master
- Run it again
- Print comparison.

As a result, we will always have some performance information that we can take into account when evaluating a pull request.