### PR TITLE
Delegate StatsD singleton methods to a client object

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -2,6 +2,7 @@
 
 require 'socket'
 require 'logger'
+require 'forwardable'
 
 # The StatsD module contains low-level metrics for collecting metrics and sending them to the backend.
 #
@@ -333,16 +334,19 @@ module StatsD
     end
   end
 
-  attr_accessor :logger, :default_sample_rate, :prefix
-  attr_writer :backend, :client
-  attr_reader :default_tags
+  attr_accessor :logger
+  attr_writer :client, :singleton_client
 
-  def default_tags=(tags)
-    @default_tags = StatsD::Instrument::Metric.normalize_tags(tags)
+  extend Forwardable
+
+  # @deprecated
+  def legacy_singleton_client
+    StatsD::Instrument::LegacyClient.singleton
   end
 
-  def backend
-    @backend ||= StatsD::Instrument::Environment.default_backend
+  # @deprecated
+  def singleton_client
+    @singleton_client ||= legacy_singleton_client
   end
 
   def client
@@ -352,290 +356,18 @@ module StatsD
     end
   end
 
-  # @!method measure(name, value = nil, sample_rate: nil, tags: nil, &block)
-  #
-  # Emits a timing metric
-  #
-  # @param [String] key The name of the metric.
-  # @param sample_rate (see #increment)
-  # @param tags (see #increment)
-  #
-  # @example Providing a value directly
-  #    start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
-  #    do_something
-  #    stop = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
-  #    http_response = StatsD.measure('HTTP.call.duration', stop - start)
-  #
-  # @example Providing a block to measure the duration of its execution
-  #    http_response = StatsD.measure('HTTP.call.duration') do
-  #      Net::HTTP.get(url)
-  #    end
-  #
-  # @overload measure(key, value, sample_rate: nil, tags: nil)
-  #   Emits a timing metric, by providing a duration in milliseconds.
-  #
-  #   @param [Float] value The measured duration in milliseconds
-  #   @return [void]
-  #
-  # @overload measure(key, sample_rate: nil, tags: nil, &block)
-  #   Emits a timing metric, after measuring the execution duration of the
-  #   block passed to this method.
-  #
-  #   @yield `StatsD.measure` will yield the block and measure the duration. After the block
-  #     returns, the duration in millisecond will be emitted as metric.
-  #   @return The value that was returned by the block passed through.
-  def measure(
-    key, value_arg = nil, deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,
-    value: value_arg, sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg,
-    prefix: StatsD.prefix, no_prefix: false, as_dist: false,
-    &block
-  )
-    # TODO: in the next version, hardcode this to :ms when the as_dist argument is dropped.
-    type = as_dist ? :d : :ms
-    prefix = nil if no_prefix
-    if block_given?
-      measure_latency(type, key, sample_rate: sample_rate, tags: tags, prefix: prefix, &block)
-    else
-      collect_metric(type, key, value, sample_rate: sample_rate, tags: tags, prefix: prefix)
-    end
-  end
+  # Singleton methods will be delegated to the singleton client.
+  def_delegators :singleton_client, :increment, :gauge, :set, :measure,
+    :histogram, :distribution, :key_value, :event, :service_check
 
-  # @!method increment(name, value = 1, sample_rate: nil, tags: nil)
-  # Emits a counter metric.
-  #
-  # @param key [String] The name of the metric.
-  # @param value [Integer] The value to increment the counter by.
-  #
-  #   You should not compensate for the sample rate using the counter increment. E.g., if
-  #   your sample rate is 0.01, you should <b>not</b> use 100 as increment to compensate for it.
-  #   The sample rate is part of the packet that is being sent to the server, and the server
-  #   should know how to handle it.
-  #
-  # @param sample_rate [Float] (default: `StatsD.default_sample_rate`) The rate at which to sample
-  #   this metric call. This value should be between 0 and 1. This value can be used to reduce
-  #   the amount of network I/O (and CPU cycles) used for very frequent metrics.
-  #
-  #   - A value of `0.1` means that only 1 out of 10 calls will be emitted; the other 9 will
-  #     be short-circuited.
-  #   - When set to `1`, every metric will be emitted.
-  #   - If this parameter is not set, the default sample rate for this client will be used.
-  # @param tags [Array<String>, Hash<Symbol, String>] The tags to associate with this measurement.
-  #   They can be provided as an array of strings, or a hash of key/value pairs.
-  #   _Note:_ Tags are not supported by all implementations.
-  # @return [void]
-  def increment(
-    key, value_arg = 1, deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,
-    value: value_arg, sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg,
-    prefix: StatsD.prefix, no_prefix: false
-  )
-    prefix = nil if no_prefix
-    collect_metric(:c, key, value, sample_rate: sample_rate, tags: tags, prefix: prefix)
-  end
-
-  # @!method gauge(name, value, sample_rate: nil, tags: nil)
-  #
-  # Emits a gauge metric.
-  #
-  # @param key The name of the metric.
-  # @param value [Numeric] The current value to record.
-  # @param sample_rate (see #increment)
-  # @param tags (see #increment)
-  # @return [void]
-  def gauge(
-    key, value_arg = nil, deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,
-    value: value_arg, sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg,
-    prefix: StatsD.prefix, no_prefix: false
-  )
-    prefix = nil if no_prefix
-    collect_metric(:g, key, value, sample_rate: sample_rate, tags: tags, prefix: prefix)
-  end
-
-  # @!method set(name, value, sample_rate: nil, tags: nil)
-  #
-  # Emits a set metric, which counts the number of distinct values that have occurred.
-  #
-  # @example Couning the number of unique visitors
-  #   StatsD.set('visitors.unique', Current.user.id)
-  #
-  # @param key [String] The name of the metric.
-  # @param value [Numeric] The value to record.
-  # @param sample_rate (see #increment)
-  # @param tags (see #increment)
-  # @return [void]
-  def set(
-    key, value_arg = nil, deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,
-    value: value_arg, sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg,
-    prefix: StatsD.prefix, no_prefix: false
-  )
-    prefix = nil if no_prefix
-    collect_metric(:s, key, value, sample_rate: sample_rate, tags: tags, prefix: prefix)
-  end
-
-  # @!method histogram(name, value, sample_rate: nil, tags: nil)
-  #
-  # Emits a histogram metric.
-  #
-  # @param key The name of the metric.
-  # @param value [Numeric] The value to record.
-  # @param sample_rate (see #increment)
-  # @param tags (see #increment)
-  # @return (see #collect_metric)
-  # @note Supported by the datadog implementation only.
-  def histogram(
-    key, value_arg = nil, deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,
-    value: value_arg, sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg,
-    prefix: StatsD.prefix, no_prefix: false
-  )
-    prefix = nil if no_prefix
-    collect_metric(:h, key, value, sample_rate: sample_rate, tags: tags, prefix: prefix)
-  end
-
-  # @!method distribution(name, value = nil, sample_rate: nil, tags: nil, &block)
-  #
-  # Emits a distribution metric.
-  #
-  # @param [String] key The name of the metric.
-  # @param sample_rate (see #increment)
-  # @param tags (see #increment)
-  #
-  # @note Supported by the datadog implementation only.
-  # @example
-  #    http_response = StatsD.distribution('HTTP.call.duration') do
-  #      Net::HTTP.get(url)
-  #    end
-  #
-  # @overload distribution(name, value, sample_rate: nil, tags: nil)
-  #
-  #   Emits a distribution metric, given a provided value to record.
-  #
-  #   @param [Numeric] value The value to record.
-  #   @return [void]
-  #
-  # @overload distribution(key, metric_options = {}, &block)
-  #
-  #   Emits a distribution metric for the duration of the provided block, in milliseconds.
-  #
-  #   @yield `StatsD.distribution` will yield the block and measure the duration. After
-  #     the block returns, the duration in millisecond will be emitted as metric.
-  #   @return The value that was returned by the block passed through.
-  def distribution(
-    key, value_arg = nil, deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,
-    value: value_arg, sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg,
-    prefix: StatsD.prefix, no_prefix: false,
-    &block
-  )
-    prefix = nil if no_prefix
-    if block_given?
-      measure_latency(:d, key, sample_rate: sample_rate, tags: tags, prefix: prefix, &block)
-    else
-      collect_metric(:d, key, value, sample_rate: sample_rate, tags: tags, prefix: prefix)
-    end
-  end
-
-  # @!method key_value(name, value)
-  #
-  # Emits a key/value metric.
-  #
-  # @param key [String] The name of the metric.
-  # @param value [Numeric] The value to record.
-  # @return [void]
-  #
-  # @note Supported by the statsite implementation only.
-  def key_value(
-    key, value_arg = nil, deprecated_sample_rate_arg = nil,
-    value: value_arg, sample_rate: deprecated_sample_rate_arg, no_prefix: false
-  )
-    prefix = nil if no_prefix
-    collect_metric(:kv, key, value, sample_rate: sample_rate, prefix: prefix)
-  end
-
-  # @!method event(title, text, tags: nil, hostname: nil, timestamp: nil, aggregation_key: nil, priority: nil, source_type_name: nil, alert_type: nil) # rubocop:disable Metrics/LineLength
-  #
-  # Emits an event.
-  #
-  # @param title [String] Title of the event. A configured prefix may be applied to this title.
-  # @param text [String] Body of the event. Can contain newlines.
-  # @param [String] hostname The hostname to associate with the event.
-  # @param [Time] timestamp The moment the status of the service was checkes. Defaults to now.
-  # @param [String] aggregation_key A key to aggregate similar events into groups.
-  # @param [String] priority The event's priority, either `"low"` or `"normal"` (default).
-  # @param [String] source_type_name The source type.
-  # @param [String] alert_type The type of alert. Either `"info"` (default), `"warning"`, `"error"`, or `"success"`.
-  # @param tags (see #increment)
-  # @return [void]
-  #
-  # @note Supported by the Datadog implementation only.
-  def event(
-    title, text,
-    deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,
-    sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg,
-    prefix: StatsD.prefix, no_prefix: false,
-    hostname: nil, date_happened: nil, timestamp: date_happened,
-    aggregation_key: nil, priority: nil, source_type_name: nil, alert_type: nil,
-    **_ignored
-  )
-    prefix = nil if no_prefix
-    collect_metric(:_e, title, text, sample_rate: sample_rate, tags: tags, prefix: prefix, metadata: {
-      hostname: hostname, timestamp: timestamp, aggregation_key: aggregation_key,
-      priority: priority, source_type_name: source_type_name, alert_type: alert_type
-    })
-  end
-
-  # @!method service_check(name, status, tags: nil, hostname: nil, timestamp: nil, message: nil)
-  #
-  # Emits a service check.
-  #
-  # @param [String] name Name of the service. A configured prefix may be applied to this title.
-  # @param [Symbol] status Current status of the service. Either `:ok`, `:warning`, `:critical`, or `:unknown`.
-  # @param [String] hostname The hostname to associate with the event.
-  # @param [Time] timestamp The moment the status of the service was checkes. Defaults to now.
-  # @param [String] message A message that describes the current status.
-  # @param tags (see #increment)
-  # @return [void]
-  #
-  # @note Supported by the Datadog implementation only.
-  def service_check(
-    name, status,
-    deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,
-    sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg,
-    prefix: StatsD.prefix, no_prefix: false,
-    hostname: nil, timestamp: nil, message: nil, **_ignored
-  )
-    prefix = nil if no_prefix
-    collect_metric(:_sc, name, status, sample_rate: sample_rate, prefix: prefix, tags: tags, metadata: {
-      hostname: hostname, timestamp: timestamp, message: message
-    })
-  end
-
-  private
-
-  def measure_latency(type, key, sample_rate:, tags:, prefix:)
-    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    begin
-      yield
-    ensure
-      # Ensure catches both a raised exception and a return in the invoked block
-      value = 1000.0 * (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start)
-      collect_metric(type, key, value, sample_rate: sample_rate, tags: tags, prefix: prefix)
-    end
-  end
-
-  # Instantiates a metric, and sends it to the backend for further processing.
-  # @param options (see StatsD::Instrument::Metric#initialize)
-  # @return [void]
-  def collect_metric(type, name, value, sample_rate:, tags: nil, prefix:, metadata: nil)
-    sample_rate ||= default_sample_rate
-    name = "#{prefix}.#{name}" if prefix
-
-    metric = StatsD::Instrument::Metric.new(type: type, name: name, value: value,
-      sample_rate: sample_rate, tags: tags, metadata: metadata)
-    backend.collect_metric(metric)
-    metric # TODO: return `nil` in the next major version
-  end
+  # Deprecated methods will be delegated to the legacy client
+  def_delegators :legacy_singleton_client, :default_tags, :default_tags=,
+    :default_sample_rate, :default_sample_rate=, :prefix, :prefix=, :backend, :backend=
 end
 
 require 'statsd/instrument/version'
 require 'statsd/instrument/metric'
+require 'statsd/instrument/legacy_client'
 require 'statsd/instrument/backend'
 require 'statsd/instrument/environment'
 require 'statsd/instrument/helpers'

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -6,12 +6,20 @@ require 'forwardable'
 
 # The StatsD module contains low-level metrics for collecting metrics and sending them to the backend.
 #
+# @!attribute client
+#   @return [StatsD::Instrument::Backend] The client that will handle singleton method calls in the next
+#     major version of this library.
+#   @note This new Client implementation is intended to become the new default in
+#     the next major release of this library. While this class may already be functional,
+#     we provide no guarantees about the API and the behavior may change.
+#
 # @!attribute backend
 #   The backend that is being used to emit the metrics.
 #   @return [StatsD::Instrument::Backend] the currently active backend. If there is no active backend
 #     yet, it will call {StatsD::Instrument::Environment#default_backend} to obtain a
 #     default backend for the environment.
 #   @see StatsD::Instrument::Environment#default_backend
+#   @deprecated
 #
 # @!attribute prefix
 #   The prefix to apply to metric names. This can be useful to group all the metrics
@@ -22,10 +30,12 @@ require 'forwardable'
 #
 #   @return [String, nil] The prefix, or <tt>nil</tt> when no prefix is used
 #   @see StatsD::Instrument::Metric#name
+#   @deprecated
 #
 # @!attribute default_sample_rate
 #   The sample rate to use if the sample rate is unspecified for a metric call.
 #   @return [Float] Default is 1.0.
+#   @deprecated
 #
 # @!attribute logger
 #   The logger to use in case of any errors. The logger is also used as default logger
@@ -36,9 +46,45 @@ require 'forwardable'
 # @!attribute default_tags
 #   The tags to apply to all metrics.
 #   @return [Array<String>, Hash<String, String>, nil] The default tags, or <tt>nil</tt> when no default tags is used
+#   @deprecated
+#
+# @!attribute legacy_singleton_client
+#   @nodoc
+#   @deprecated
+#
+# @!attribute singleton_client
+#   @nodoc
+#   @deprecated
+#
+# @!method measure(name, value = nil, sample_rate: nil, tags: nil, &block)
+#   (see StatsD::Instrument::LegacyClient#measure)
+#
+# @!method increment(name, value = 1, sample_rate: nil, tags: nil)
+#   (see StatsD::Instrument::LegacyClient#increment)
+#
+# @!method gauge(name, value, sample_rate: nil, tags: nil)
+#   (see StatsD::Instrument::LegacyClient#gauge)
+#
+# @!method set(name, value, sample_rate: nil, tags: nil)
+#   (see StatsD::Instrument::LegacyClient#set)
+#
+# @!method histogram(name, value, sample_rate: nil, tags: nil)
+#   (see StatsD::Instrument::LegacyClient#histogram)
+#
+# @!method distribution(name, value = nil, sample_rate: nil, tags: nil, &block)
+#   (see StatsD::Instrument::LegacyClient#distribution)
+#
+# @!method key_value(name, value)
+#   (see StatsD::Instrument::LegacyClient#key_value)
+#
+# @!method event(title, text, tags: nil, hostname: nil, timestamp: nil, aggregation_key: nil, priority: nil, source_type_name: nil, alert_type: nil) # rubocop:disable Metrics/LineLength
+#   (see StatsD::Instrument::LegacyClient#event)
+#
+# @!method service_check(name, status, tags: nil, hostname: nil, timestamp: nil, message: nil)
+#   (see StatsD::Instrument::LegacyClient#service_check)
 #
 # @see StatsD::Instrument <tt>StatsD::Instrument</tt> contains module to instrument
-#    existing methods with StatsD metrics.
+#    existing methods with StatsD metrics
 module StatsD
   extend self
 
@@ -339,12 +385,10 @@ module StatsD
 
   extend Forwardable
 
-  # @deprecated
   def legacy_singleton_client
     StatsD::Instrument::LegacyClient.singleton
   end
 
-  # @deprecated
   def singleton_client
     @singleton_client ||= legacy_singleton_client
   end

--- a/lib/statsd/instrument/client.rb
+++ b/lib/statsd/instrument/client.rb
@@ -11,8 +11,8 @@ require 'statsd/instrument/log_sink'
 
 # The Client is the main interface for using StatsD.
 #
-# @note This new new Client implementation that is intended to become the new default in
-#   the next major release of this library. While this class may already be functional,
+# @note This new Client implementation is intended to become the new default in the
+#   next major release of this library. While this class may already be functional,
 #   we provide no guarantees about the API and the behavior may change.
 class StatsD::Instrument::Client
   attr_reader :sink, :datagram_builder_class, :prefix, :default_tags, :default_sample_rate

--- a/lib/statsd/instrument/legacy_client.rb
+++ b/lib/statsd/instrument/legacy_client.rb
@@ -1,0 +1,300 @@
+# frozen_string_literal: true
+
+class StatsD::Instrument::LegacyClient
+  def self.singleton
+    @singleton ||= new
+  end
+
+  attr_accessor :default_sample_rate, :prefix
+  attr_writer :backend
+  attr_reader :default_tags
+
+  def default_tags=(tags)
+    @default_tags = StatsD::Instrument::Metric.normalize_tags(tags)
+  end
+
+  def backend
+    @backend ||= StatsD::Instrument::Environment.default_backend
+  end
+
+  # @!method measure(name, value = nil, sample_rate: nil, tags: nil, &block)
+  #
+  # Emits a timing metric
+  #
+  # @param [String] key The name of the metric.
+  # @param sample_rate (see #increment)
+  # @param tags (see #increment)
+  #
+  # @example Providing a value directly
+  #    start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
+  #    do_something
+  #    stop = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
+  #    http_response = StatsD.measure('HTTP.call.duration', stop - start)
+  #
+  # @example Providing a block to measure the duration of its execution
+  #    http_response = StatsD.measure('HTTP.call.duration') do
+  #      Net::HTTP.get(url)
+  #    end
+  #
+  # @overload measure(key, value, sample_rate: nil, tags: nil)
+  #   Emits a timing metric, by providing a duration in milliseconds.
+  #
+  #   @param [Float] value The measured duration in milliseconds
+  #   @return [void]
+  #
+  # @overload measure(key, sample_rate: nil, tags: nil, &block)
+  #   Emits a timing metric, after measuring the execution duration of the
+  #   block passed to this method.
+  #
+  #   @yield `StatsD.measure` will yield the block and measure the duration. After the block
+  #     returns, the duration in millisecond will be emitted as metric.
+  #   @return The value that was returned by the block passed through.
+  def measure(
+    key, value_arg = nil, deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,
+    value: value_arg, sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg,
+    prefix: self.prefix, no_prefix: false, as_dist: false,
+    &block
+  )
+    # TODO: in the next version, hardcode this to :ms when the as_dist argument is dropped.
+    type = as_dist ? :d : :ms
+    prefix = nil if no_prefix
+    if block_given?
+      measure_latency(type, key, sample_rate: sample_rate, tags: tags, prefix: prefix, &block)
+    else
+      collect_metric(type, key, value, sample_rate: sample_rate, tags: tags, prefix: prefix)
+    end
+  end
+
+  # @!method increment(name, value = 1, sample_rate: nil, tags: nil)
+  # Emits a counter metric.
+  #
+  # @param key [String] The name of the metric.
+  # @param value [Integer] The value to increment the counter by.
+  #
+  #   You should not compensate for the sample rate using the counter increment. E.g., if
+  #   your sample rate is 0.01, you should <b>not</b> use 100 as increment to compensate for it.
+  #   The sample rate is part of the packet that is being sent to the server, and the server
+  #   should know how to handle it.
+  #
+  # @param sample_rate [Float] (default: `StatsD.default_sample_rate`) The rate at which to sample
+  #   this metric call. This value should be between 0 and 1. This value can be used to reduce
+  #   the amount of network I/O (and CPU cycles) used for very frequent metrics.
+  #
+  #   - A value of `0.1` means that only 1 out of 10 calls will be emitted; the other 9 will
+  #     be short-circuited.
+  #   - When set to `1`, every metric will be emitted.
+  #   - If this parameter is not set, the default sample rate for this client will be used.
+  # @param tags [Array<String>, Hash<Symbol, String>] The tags to associate with this measurement.
+  #   They can be provided as an array of strings, or a hash of key/value pairs.
+  #   _Note:_ Tags are not supported by all implementations.
+  # @return [void]
+  def increment(
+    key, value_arg = 1, deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,
+    value: value_arg, sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg,
+    prefix: self.prefix, no_prefix: false
+  )
+    prefix = nil if no_prefix
+    collect_metric(:c, key, value, sample_rate: sample_rate, tags: tags, prefix: prefix)
+  end
+
+  # @!method gauge(name, value, sample_rate: nil, tags: nil)
+  #
+  # Emits a gauge metric.
+  #
+  # @param key The name of the metric.
+  # @param value [Numeric] The current value to record.
+  # @param sample_rate (see #increment)
+  # @param tags (see #increment)
+  # @return [void]
+  def gauge(
+    key, value_arg = nil, deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,
+    value: value_arg, sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg,
+    prefix: self.prefix, no_prefix: false
+  )
+    prefix = nil if no_prefix
+    collect_metric(:g, key, value, sample_rate: sample_rate, tags: tags, prefix: prefix)
+  end
+
+  # @!method set(name, value, sample_rate: nil, tags: nil)
+  #
+  # Emits a set metric, which counts the number of distinct values that have occurred.
+  #
+  # @example Couning the number of unique visitors
+  #   StatsD.set('visitors.unique', Current.user.id)
+  #
+  # @param key [String] The name of the metric.
+  # @param value [Numeric] The value to record.
+  # @param sample_rate (see #increment)
+  # @param tags (see #increment)
+  # @return [void]
+  def set(
+    key, value_arg = nil, deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,
+    value: value_arg, sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg,
+    prefix: self.prefix, no_prefix: false
+  )
+    prefix = nil if no_prefix
+    collect_metric(:s, key, value, sample_rate: sample_rate, tags: tags, prefix: prefix)
+  end
+
+  # @!method histogram(name, value, sample_rate: nil, tags: nil)
+  #
+  # Emits a histogram metric.
+  #
+  # @param key The name of the metric.
+  # @param value [Numeric] The value to record.
+  # @param sample_rate (see #increment)
+  # @param tags (see #increment)
+  # @return (see #collect_metric)
+  # @note Supported by the datadog implementation only.
+  def histogram(
+    key, value_arg = nil, deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,
+    value: value_arg, sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg,
+    prefix: self.prefix, no_prefix: false
+  )
+    prefix = nil if no_prefix
+    collect_metric(:h, key, value, sample_rate: sample_rate, tags: tags, prefix: prefix)
+  end
+
+  # @!method distribution(name, value = nil, sample_rate: nil, tags: nil, &block)
+  #
+  # Emits a distribution metric.
+  #
+  # @param [String] key The name of the metric.
+  # @param sample_rate (see #increment)
+  # @param tags (see #increment)
+  #
+  # @note Supported by the datadog implementation only.
+  # @example
+  #    http_response = StatsD.distribution('HTTP.call.duration') do
+  #      Net::HTTP.get(url)
+  #    end
+  #
+  # @overload distribution(name, value, sample_rate: nil, tags: nil)
+  #
+  #   Emits a distribution metric, given a provided value to record.
+  #
+  #   @param [Numeric] value The value to record.
+  #   @return [void]
+  #
+  # @overload distribution(key, metric_options = {}, &block)
+  #
+  #   Emits a distribution metric for the duration of the provided block, in milliseconds.
+  #
+  #   @yield `StatsD.distribution` will yield the block and measure the duration. After
+  #     the block returns, the duration in millisecond will be emitted as metric.
+  #   @return The value that was returned by the block passed through.
+  def distribution(
+    key, value_arg = nil, deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,
+    value: value_arg, sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg,
+    prefix: self.prefix, no_prefix: false,
+    &block
+  )
+    prefix = nil if no_prefix
+    if block_given?
+      measure_latency(:d, key, sample_rate: sample_rate, tags: tags, prefix: prefix, &block)
+    else
+      collect_metric(:d, key, value, sample_rate: sample_rate, tags: tags, prefix: prefix)
+    end
+  end
+
+  # @!method key_value(name, value)
+  #
+  # Emits a key/value metric.
+  #
+  # @param key [String] The name of the metric.
+  # @param value [Numeric] The value to record.
+  # @return [void]
+  #
+  # @note Supported by the statsite implementation only.
+  def key_value(
+    key, value_arg = nil, deprecated_sample_rate_arg = nil,
+    value: value_arg, sample_rate: deprecated_sample_rate_arg, no_prefix: false
+  )
+    prefix = nil if no_prefix
+    collect_metric(:kv, key, value, sample_rate: sample_rate, prefix: prefix)
+  end
+
+  # @!method event(title, text, tags: nil, hostname: nil, timestamp: nil, aggregation_key: nil, priority: nil, source_type_name: nil, alert_type: nil) # rubocop:disable Metrics/LineLength
+  #
+  # Emits an event.
+  #
+  # @param title [String] Title of the event. A configured prefix may be applied to this title.
+  # @param text [String] Body of the event. Can contain newlines.
+  # @param [String] hostname The hostname to associate with the event.
+  # @param [Time] timestamp The moment the status of the service was checkes. Defaults to now.
+  # @param [String] aggregation_key A key to aggregate similar events into groups.
+  # @param [String] priority The event's priority, either `"low"` or `"normal"` (default).
+  # @param [String] source_type_name The source type.
+  # @param [String] alert_type The type of alert. Either `"info"` (default), `"warning"`, `"error"`, or `"success"`.
+  # @param tags (see #increment)
+  # @return [void]
+  #
+  # @note Supported by the Datadog implementation only.
+  def event(
+    title, text,
+    deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,
+    sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg,
+    prefix: self.prefix, no_prefix: false,
+    hostname: nil, date_happened: nil, timestamp: date_happened,
+    aggregation_key: nil, priority: nil, source_type_name: nil, alert_type: nil,
+    **_ignored
+  )
+    prefix = nil if no_prefix
+    collect_metric(:_e, title, text, sample_rate: sample_rate, tags: tags, prefix: prefix, metadata: {
+      hostname: hostname, timestamp: timestamp, aggregation_key: aggregation_key,
+      priority: priority, source_type_name: source_type_name, alert_type: alert_type
+    })
+  end
+
+  # @!method service_check(name, status, tags: nil, hostname: nil, timestamp: nil, message: nil)
+  #
+  # Emits a service check.
+  #
+  # @param [String] name Name of the service. A configured prefix may be applied to this title.
+  # @param [Symbol] status Current status of the service. Either `:ok`, `:warning`, `:critical`, or `:unknown`.
+  # @param [String] hostname The hostname to associate with the event.
+  # @param [Time] timestamp The moment the status of the service was checkes. Defaults to now.
+  # @param [String] message A message that describes the current status.
+  # @param tags (see #increment)
+  # @return [void]
+  #
+  # @note Supported by the Datadog implementation only.
+  def service_check(
+    name, status,
+    deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,
+    sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg,
+    prefix: self.prefix, no_prefix: false,
+    hostname: nil, timestamp: nil, message: nil, **_ignored
+  )
+    prefix = nil if no_prefix
+    collect_metric(:_sc, name, status, sample_rate: sample_rate, prefix: prefix, tags: tags, metadata: {
+      hostname: hostname, timestamp: timestamp, message: message
+    })
+  end
+
+  private
+
+  def measure_latency(type, key, sample_rate:, tags:, prefix:)
+    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    begin
+      yield
+    ensure
+      # Ensure catches both a raised exception and a return in the invoked block
+      value = 1000.0 * (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start)
+      collect_metric(type, key, value, sample_rate: sample_rate, tags: tags, prefix: prefix)
+    end
+  end
+
+  # Instantiates a metric, and sends it to the backend for further processing.
+  # @param options (see StatsD::Instrument::Metric#initialize)
+  # @return [void]
+  def collect_metric(type, name, value, sample_rate:, tags: nil, prefix:, metadata: nil)
+    sample_rate ||= default_sample_rate
+    name = "#{prefix}.#{name}" if prefix
+
+    metric = StatsD::Instrument::Metric.new(type: type, name: name, value: value,
+      sample_rate: sample_rate, tags: tags, metadata: metadata)
+    backend.collect_metric(metric)
+    metric # TODO: return `nil` in the next major version
+  end
+end

--- a/lib/statsd/instrument/legacy_client.rb
+++ b/lib/statsd/instrument/legacy_client.rb
@@ -66,6 +66,7 @@ class StatsD::Instrument::LegacyClient
   end
 
   # @!method increment(name, value = 1, sample_rate: nil, tags: nil)
+  #
   # Emits a counter metric.
   #
   # @param key [String] The name of the metric.

--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -43,9 +43,9 @@ class StatsD::Instrument::Metric
     using RubyBackports
   end
 
-  def self.new(
-    type:, name:, value: default_value(type), sample_rate: StatsD.default_sample_rate, tags: nil, metadata: nil
-  )
+  def self.new(type:, name:, value: default_value(type), tags: nil, metadata: nil,
+    sample_rate: StatsD.legacy_singleton_client.default_sample_rate)
+
     # pass keyword arguments as positional arguments for performance reasons,
     # since MRI's C implementation of new turns keyword arguments into a hash
     super(type, name, value, sample_rate, tags, metadata)
@@ -92,8 +92,8 @@ class StatsD::Instrument::Metric
     @value = value
     @sample_rate = sample_rate
     @tags = StatsD::Instrument::Metric.normalize_tags(tags)
-    if StatsD.default_tags
-      @tags = Array(@tags) + StatsD.default_tags
+    if StatsD.legacy_singleton_client.default_tags
+      @tags = Array(@tags) + StatsD.legacy_singleton_client.default_tags
     end
     @metadata = metadata
   end

--- a/test/metric_test.rb
+++ b/test/metric_test.rb
@@ -36,11 +36,11 @@ class MetricTest < Minitest::Test
   end
 
   def test_default_tags
-    StatsD.stubs(:default_tags).returns(['default_tag:default_value'])
+    StatsD.legacy_singleton_client.stubs(:default_tags).returns(['default_tag:default_value'])
     m = StatsD::Instrument::Metric.new(type: :c, name: 'counter', tags: { tag: 'value' })
     assert_equal ['tag:value', 'default_tag:default_value'], m.tags
 
-    StatsD.stubs(:default_tags).returns(['tag:value'])
+    StatsD.legacy_singleton_client.stubs(:default_tags).returns(['tag:value'])
     m = StatsD::Instrument::Metric.new(type: :c, name: 'counter', tags: { tag: 'value' })
     assert_equal ['tag:value', 'tag:value'], m.tags # we don't care about duplicates
   end

--- a/test/statsd_test.rb
+++ b/test/statsd_test.rb
@@ -213,7 +213,7 @@ class StatsDTest < Minitest::Test
   end
 
   def test_name_prefix
-    StatsD.stubs(:prefix).returns('prefix')
+    StatsD.legacy_singleton_client.stubs(:prefix).returns('prefix')
     m = capture_statsd_call { StatsD.increment('counter') }
     assert_equal 'prefix.counter', m.name
 

--- a/test/udp_backend_test.rb
+++ b/test/udp_backend_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class UDPBackendTest < Minitest::Test
   def setup
-    StatsD.stubs(:backend).returns(@backend = StatsD::Instrument::Backends::UDPBackend.new)
+    StatsD.legacy_singleton_client.stubs(:backend).returns(@backend = StatsD::Instrument::Backends::UDPBackend.new)
     @backend.stubs(:rand).returns(0.0)
 
     UDPSocket.stubs(:new).returns(@socket = mock('socket'))


### PR DESCRIPTION
This adds a client object, which handles all the StatsD metric calls. The current `StatsD` singleton methods are forwarded to this client object.

This is for two reasons:

1. I've always disliked that `StatsD` is a singleton. It means that in some cases, we have had to include a second StatsD client in the same codebase, because we wanted to use a different backend or different settings for certain purposes. 
   - E.g., when running the test suite, we generally don't want to send StatsD packets to our StatsD server, _except_ the metadata statistics about the test suite itself.
   - Another example would be to set a tag for all metrics emitted for a given request or job, e.g. `shard_id:123`. This is not possible right now except for monkey patching.

2. I have a plan to simplify the client implementation, which would give us a performance boost by having less indirection, fewer if statements, and fewer object allocations. Without keeping the old implementation around, showing that the performance of the new implementation has better performance while maintaining compatibility will be hard.

#### Performance implications

We do introduce another level of indirection to do this, which affects performance.

On my local machine:

```
Warming up --------------------------------------
StatsD metrics to /dev/null log (branch: legacy_singleton_client, sha: 15d8d95)
                       790.000  i/100ms
Calculating -------------------------------------
StatsD metrics to /dev/null log (branch: legacy_singleton_client, sha: 15d8d95)
                          8.236k (± 3.1%) i/s -     41.870k in   5.088692s

Comparison:
StatsD metrics to /dev/null log (branch: master, sha: 2e2d6a5):     8678.8 i/s
StatsD metrics to /dev/null log (branch: legacy_singleton_client, sha: 15d8d95):     8235.9 i/s - same-ish: difference falls within error
```

The performance hit is small (within the range of error). On CI, the hit is a bit more pronounced (in the range of a 5-15% slowdown).