### PR TITLE
Add a new StatsD::Instrument::Client

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,7 +27,10 @@ Style/ClassAndModuleChildren:
 Style/MethodCallWithArgsParentheses:
   Enabled: false # TODO: enable later
 
-# Enable our own cops on our own repos
+Lint/UnusedMethodArgument:
+  AllowUnusedKeywordArguments: true
+
+# Enable our own cops on our own repo
 
 StatsD/MetricReturnValue:
   Enabled: true

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,1 @@
+--markup=markdown

--- a/benchmark/datagram-client
+++ b/benchmark/datagram-client
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'benchmark/ips'
+require 'socket'
+
+# Set up an UDP listener to which we can send StatsD packets
+legacy_receiver = UDPSocket.new
+legacy_receiver.bind('localhost', 0)
+
+ENV['ENV'] = "production"
+ENV['STATSD_ADDR'] = "#{legacy_receiver.addr[2]}:#{legacy_receiver.addr[1]}"
+ENV['STATSD_IMPLEMENTATION'] ||= 'datadog'
+
+require 'statsd-instrument'
+require 'statsd/instrument/client'
+
+legacy_client = StatsD
+
+# Set up an UDP listener to which we can send StatsD packets
+new_client_receiver = UDPSocket.new
+new_client_receiver.bind('localhost', 0)
+
+udp_sink = StatsD::Instrument::UDPSink.new(new_client_receiver.addr[2], new_client_receiver.addr[1])
+new_client = StatsD::Instrument::Client.new(sink: udp_sink)
+
+Benchmark.ips do |bench|
+  bench.report("Legacy client") do
+    legacy_client.increment('StatsD.increment', 10)
+  end
+
+  bench.report("New client") do
+    new_client.increment('StatsD.increment', 10)
+  end
+
+  bench.compare!
+end
+
+legacy_receiver.close
+new_client_receiver.close

--- a/lib/statsd/instrument/capture_sink.rb
+++ b/lib/statsd/instrument/capture_sink.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class StatsD::Instrument::CaptureSink
+  attr_reader :parent, :datagrams
+
+  def initialize(parent:)
+    @parent = parent
+    @datagrams = []
+  end
+
+  def <<(datagram)
+    @datagrams << StatsD::Instrument::Datagram.new(datagram)
+    parent << datagram
+  end
+
+  def clear
+    @datagrams.clear
+  end
+end

--- a/lib/statsd/instrument/capture_sink.rb
+++ b/lib/statsd/instrument/capture_sink.rb
@@ -11,6 +11,7 @@ class StatsD::Instrument::CaptureSink
   def <<(datagram)
     @datagrams << StatsD::Instrument::Datagram.new(datagram)
     parent << datagram
+    self
   end
 
   def clear

--- a/lib/statsd/instrument/client.rb
+++ b/lib/statsd/instrument/client.rb
@@ -7,6 +7,7 @@ require 'statsd/instrument/dogstatsd_datagram_builder'
 require 'statsd/instrument/null_sink'
 require 'statsd/instrument/udp_sink'
 require 'statsd/instrument/capture_sink'
+require 'statsd/instrument/log_sink'
 
 class StatsD::Instrument::Client
   attr_reader :sink, :datagram_builder_class, :prefix, :default_tags, :sampling_disabled, :default_sample_rate

--- a/lib/statsd/instrument/client.rb
+++ b/lib/statsd/instrument/client.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require 'statsd/instrument/datagram'
+require 'statsd/instrument/statsd_datagram_builder'
+require 'statsd/instrument/dogstatsd_datagram_builder'
+require 'statsd/instrument/null_sink'
+require 'statsd/instrument/udp_sink'
+require 'statsd/instrument/capture_sink'
+
+class StatsD::Instrument::Client
+  attr_reader :sink, :datagram_builder_class, :prefix, :default_tags, :sampling_disabled, :default_sample_rate
+
+  def initialize(
+    sink: StatsD::Instrument::NullSink.new,
+    prefix: nil,
+    sampling_disabled: false,
+    default_sample_rate: 1,
+    default_tags: nil,
+    datagram_builder_class: StatsD::Instrument::Environment.datagram_builder_class
+  )
+    @sink = sink
+    @datagram_builder_class = datagram_builder_class
+
+    @prefix = prefix
+    @default_tags = default_tags
+    @default_sample_rate = default_sample_rate
+    @sampling_disabled = sampling_disabled
+  end
+
+  # Emits a counter metric.
+  # @param name [String] The name of the metric.
+  # @param value [Integer] (default: 1) The value to increment the counter by.
+  #
+  #   You should not compensate for the sample rate using the counter increment. E.g., if
+  #   your sample rate is 0.01, you should <b>not</b> use 100 as increment to compensate for it.
+  #   The sample rate is part of the packet that is being sent to the server, and the server
+  #   should know how to handle it.
+  #
+  # @param sample_rate [Float] (default: nil)
+  # @param tags [Hash, Array] (default: nil)
+  # @return StatsD::Instrument::Datagram
+  def increment(name, value = 1, sample_rate: nil, tags: nil)
+    sample(sample_rate, datagram_builder.c(name, value, sample_rate, tags))
+  end
+
+  # Emits a timing metric.
+  # @param name [String] The name of the metric.
+  # @param value [Numeric] The timing to record in milliseconds
+  # @param sample_rate [Float] (default: nil)
+  # @param tags [Hash, Array] (default: nil)
+  # @return StatsD::Instrument::Datagram
+  def measure(name, value = nil, sample_rate: nil, tags: nil)
+    sample(sample_rate, datagram_builder.ms(name, value, sample_rate, tags))
+  end
+
+  # Emits a gauge metric.
+  # @param name [String] The name of the metric.
+  # @param value [Numeric] The gauged value
+  # @param sample_rate [Float] (default: nil)
+  # @param tags [Hash, Array] (default: nil)
+  # @return StatsD::Instrument::Datagram
+  def gauge(name, value, sample_rate: nil, tags: nil)
+    sample(sample_rate, datagram_builder.g(name, value, sample_rate, tags))
+  end
+
+  # Emits a set metric, which counts unique values.
+  # @param name [String] The name of the metric.
+  # @param value [Numeric, String] (default: 1) The value to record
+  # @param sample_rate [Float] (default: nil)
+  # @param tags [Hash, Array] (default: nil)
+  # @return StatsD::Instrument::Datagram
+  def set(name, value, sample_rate: nil, tags: nil)
+    sample(sample_rate, datagram_builder.s(name, value, sample_rate, tags))
+  end
+
+  # Instantiates a new StatsD client that uses the settings of the current client,
+  # except for the provided settings.
+  def with_options(
+    sink: nil,
+    prefix: nil,
+    sampling_disabled: nil,
+    default_sample_rate: nil,
+    default_tags: nil,
+    datagram_builder_class: nil
+  )
+    client = clone_with_options(sink: sink, prefix: prefix, sampling_disabled: sampling_disabled,
+      default_sample_rate: default_sample_rate, default_tags: default_tags,
+      datagram_builder_class: datagram_builder_class)
+
+    yield(client)
+  end
+
+  def clone_with_options(
+    sink: nil,
+    prefix: nil,
+    sampling_disabled: nil,
+    default_sample_rate: nil,
+    default_tags: nil,
+    datagram_builder_class: nil
+  )
+    self.class.new(
+      sink: sink || @sink,
+      prefix: prefix || @prefix,
+      sampling_disabled: sampling_disabled || @sampling_disabled,
+      default_sample_rate: default_sample_rate || @default_sample_rate,
+      default_tags: default_tags || @default_tags,
+      datagram_builder_class: datagram_builder_class || @datagram_builder_class,
+    )
+  end
+
+  def capture_sink
+    StatsD::Instrument::CaptureSink.new(parent: @sink)
+  end
+
+  def with_capture_sink(capture_sink)
+    @sink = capture_sink
+    yield
+    @sink.datagrams
+  ensure
+    @sink = @sink.parent
+  end
+
+  def capture(&block)
+    with_capture_sink(capture_sink, &block)
+  end
+
+  protected
+
+  def datagram_builder
+    @datagram_builder ||= @datagram_builder_class.new(prefix: prefix, default_tags: default_tags)
+  end
+
+  def sample(sample_rate, datagram)
+    sample_rate ||= @default_sample_rate
+    if sample_rate == 1 || sampling_disabled || rand < sample_rate
+      @sink << datagram
+    end
+    datagram
+  end
+end

--- a/lib/statsd/instrument/client.rb
+++ b/lib/statsd/instrument/client.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'statsd/instrument/datagram'
+require 'statsd/instrument/datagram_builder'
 require 'statsd/instrument/statsd_datagram_builder'
 require 'statsd/instrument/dogstatsd_datagram_builder'
 require 'statsd/instrument/null_sink'

--- a/lib/statsd/instrument/client.rb
+++ b/lib/statsd/instrument/client.rb
@@ -108,6 +108,31 @@ class StatsD::Instrument::Client
     emit(datagram_builder.s(name, value, sample_rate, tags))
   end
 
+  # Emits a distribution metric, which builds a histogram of the reported
+  # values
+  #
+  # @param name (see #increment)
+  # @param [Numeric] value The value to include in the distribution histogram.
+  # @param sample_rate (see #increment)
+  # @param tags (see #increment)
+  # @return [void]
+  def distribution(name, value, sample_rate: nil, tags: nil)
+    return unless sample?(sample_rate || @default_sample_rate)
+    emit(datagram_builder.d(name, value, sample_rate, tags))
+  end
+
+  # Emits a histogram metric, which counts distinct values.
+  #
+  # @param name (see #increment)
+  # @param [Numeric] value The value to include in the histogram.
+  # @param sample_rate (see #increment)
+  # @param tags (see #increment)
+  # @return [void]
+  def histogram(name, value, sample_rate: nil, tags: nil)
+    return unless sample?(sample_rate || @default_sample_rate)
+    emit(datagram_builder.h(name, value, sample_rate, tags))
+  end
+
   # Instantiates a new StatsD client that uses the settings of the current client,
   # except for the provided overrides.
   #

--- a/lib/statsd/instrument/client.rb
+++ b/lib/statsd/instrument/client.rb
@@ -62,7 +62,8 @@ class StatsD::Instrument::Client
   # @param [Hash, Array] tags (default: nil)
   # @return [void]
   def increment(name, value = 1, sample_rate: nil, tags: nil)
-    return unless sample?(sample_rate || @default_sample_rate)
+    sample_rate ||= @default_sample_rate
+    return unless sample?(sample_rate)
     emit(datagram_builder.c(name, value, sample_rate, tags))
   end
 
@@ -74,7 +75,8 @@ class StatsD::Instrument::Client
   # @param tags (see #increment)
   # @return [void]
   def measure(name, value = nil, sample_rate: nil, tags: nil)
-    return unless sample?(sample_rate || @default_sample_rate)
+    sample_rate ||= @default_sample_rate
+    return unless sample?(sample_rate)
     emit(datagram_builder.ms(name, value, sample_rate, tags))
   end
 
@@ -92,7 +94,8 @@ class StatsD::Instrument::Client
   # @param tags (see #increment)
   # @return [void]
   def gauge(name, value, sample_rate: nil, tags: nil)
-    return unless sample?(sample_rate || @default_sample_rate)
+    sample_rate ||= @default_sample_rate
+    return unless sample?(sample_rate)
     emit(datagram_builder.g(name, value, sample_rate, tags))
   end
 
@@ -104,7 +107,8 @@ class StatsD::Instrument::Client
   # @param tags (see #increment)
   # @return [void]
   def set(name, value, sample_rate: nil, tags: nil)
-    return unless sample?(sample_rate || @default_sample_rate)
+    sample_rate ||= @default_sample_rate
+    return unless sample?(sample_rate)
     emit(datagram_builder.s(name, value, sample_rate, tags))
   end
 
@@ -117,7 +121,8 @@ class StatsD::Instrument::Client
   # @param tags (see #increment)
   # @return [void]
   def distribution(name, value, sample_rate: nil, tags: nil)
-    return unless sample?(sample_rate || @default_sample_rate)
+    sample_rate ||= @default_sample_rate
+    return unless sample?(sample_rate)
     emit(datagram_builder.d(name, value, sample_rate, tags))
   end
 
@@ -129,7 +134,8 @@ class StatsD::Instrument::Client
   # @param tags (see #increment)
   # @return [void]
   def histogram(name, value, sample_rate: nil, tags: nil)
-    return unless sample?(sample_rate || @default_sample_rate)
+    sample_rate ||= @default_sample_rate
+    return unless sample?(sample_rate)
     emit(datagram_builder.h(name, value, sample_rate, tags))
   end
 

--- a/lib/statsd/instrument/client.rb
+++ b/lib/statsd/instrument/client.rb
@@ -137,6 +137,6 @@ class StatsD::Instrument::Client
     if sample_rate == 1 || sampling_disabled || rand < sample_rate
       @sink << datagram
     end
-    datagram
+    nil
   end
 end

--- a/lib/statsd/instrument/datagram.rb
+++ b/lib/statsd/instrument/datagram.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class StatsD::Instrument::Datagram
+  attr_reader :source
+
+  def initialize(source)
+    @source = source
+  end
+
+  def sample_rate
+    parsed_datagram[:sample_rate] ? Float(parsed_datagram[:sample_rate]) : 1.0
+  end
+
+  def type
+    parsed_datagram[:type]
+  end
+
+  def name
+    parsed_datagram[:name]
+  end
+
+  def value
+    parsed_datagram[:value]
+  end
+
+  def tags
+    parsed_datagram[:tags] ? parsed_datagram[:tags].split(',') : nil
+  end
+
+  def inspect
+    "#<#{self.class.name}:\"#{@source}\">"
+  end
+
+  private
+
+  PARSER = %r{
+    \A
+    (?<name>[^\:\|\@]+)\:(?<value>[^\:\|\@]+)\|(?<type>c|ms|g|s|h|d)
+    (?:\|\@(?<sample_rate>\d*(?:\.\d*)?))?
+    (?:\|\#(?<tags>(?:[^\|\#,]+(?:,[^\|\#,]+)*)))?
+    \n? # In some implementations, the datagram may include a trailing newline.
+    \z
+  }x
+  private_constant :PARSER
+
+  def parsed_datagram
+    @parsed ||= if (match_info = PARSER.match(@source))
+      match_info
+    else
+      raise ArgumentError, "Invalid StatsD datagram: #{@source}"
+    end
+  end
+end

--- a/lib/statsd/instrument/datagram_builder.rb
+++ b/lib/statsd/instrument/datagram_builder.rb
@@ -5,7 +5,7 @@ class StatsD::Instrument::DatagramBuilder
     module RubyBackports
       refine Regexp do
         def match?(str)
-          (self =~ str) != nil
+          match(str) != nil
         end
       end
     end

--- a/lib/statsd/instrument/datagram_builder.rb
+++ b/lib/statsd/instrument/datagram_builder.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+class StatsD::Instrument::DatagramBuilder
+  unless Regexp.method_defined?(:match?) # for ruby 2.3
+    module RubyBackports
+      refine Regexp do
+        def match?(str)
+          (self =~ str) != nil
+        end
+      end
+    end
+
+    using RubyBackports
+  end
+
+  def self.unsupported_datagram_types(*types)
+    types.each do |type|
+      define_method(type) do |_, _, _, _|
+        raise NotImplementedError, "Type #{type} metrics are not suppered by #{self.class.name}."
+      end
+    end
+  end
+
+  def initialize(prefix: nil, default_tags: nil)
+    @prefix = prefix.nil? ? "" : "#{normalize_name(prefix)}."
+    @default_tags = normalize_tags(default_tags)
+  end
+
+  def c(name, value, sample_rate, tags)
+    generate_generic_datagram(name, value, -'c', sample_rate, tags)
+  end
+
+  def g(name, value, sample_rate, tags)
+    generate_generic_datagram(name, value, -'g', sample_rate, tags)
+  end
+
+  def ms(name, value, sample_rate, tags)
+    generate_generic_datagram(name, value, -'ms', sample_rate, tags)
+  end
+
+  def s(name, value, sample_rate, tags)
+    generate_generic_datagram(name, value, -'s', sample_rate, tags)
+  end
+
+  def h(name, value, sample_rate, tags)
+    generate_generic_datagram(name, value, -'h', sample_rate, tags)
+  end
+
+  def d(name, value, sample_rate, tags)
+    generate_generic_datagram(name, value, -'d', sample_rate, tags)
+  end
+
+  def kv(name, value, sample_rate, tags)
+    generate_generic_datagram(name, value, -'kv', sample_rate, tags)
+  end
+
+  protected
+
+  attr_reader :prefix, :default_tags
+
+  # Utility function to convert tags to the canonical form.
+  #
+  # - Tags specified as key value pairs will be converted into an array
+  # - Tags are normalized to remove unsupported characters
+  #
+  # @param tags [Array<String>, Hash<String, String>, nil] Tags specified in any form.
+  # @return [Array<String>, nil] the list of tags in canonical form.
+  def normalize_tags(tags)
+    return [] unless tags
+    tags = tags.map { |k, v| "#{k}:#{v}" } if tags.is_a?(Hash)
+
+    # Fast path when no string replacement is needed
+    return tags unless tags.any? { |tag| /[|,]/.match?(tag) }
+    tags.map { |tag| tag.tr('|,', '') }
+  end
+
+  # Utility function to remove invalid characters from a StatsD metric name
+  def normalize_name(name)
+    # Fast path when no normalization is needed to avoid copying the string
+    return name unless /[:|@]/.match?(name)
+    name.tr(':|@', '_')
+  end
+
+  def generate_generic_datagram(name, value, type, sample_rate, tags)
+    tags = normalize_tags(tags) + default_tags
+    datagram = +"#{@prefix}#{normalize_name(name)}:#{value}|#{type}"
+    datagram << "|@#{sample_rate}" if sample_rate && sample_rate < 1
+    datagram << "|##{tags.join(',')}" unless tags.empty?
+    datagram
+  end
+end

--- a/lib/statsd/instrument/datagram_builder.rb
+++ b/lib/statsd/instrument/datagram_builder.rb
@@ -27,31 +27,31 @@ class StatsD::Instrument::DatagramBuilder
   end
 
   def c(name, value, sample_rate, tags)
-    generate_generic_datagram(name, value, -'c', sample_rate, tags)
+    generate_generic_datagram(name, value, 'c', sample_rate, tags)
   end
 
   def g(name, value, sample_rate, tags)
-    generate_generic_datagram(name, value, -'g', sample_rate, tags)
+    generate_generic_datagram(name, value, 'g', sample_rate, tags)
   end
 
   def ms(name, value, sample_rate, tags)
-    generate_generic_datagram(name, value, -'ms', sample_rate, tags)
+    generate_generic_datagram(name, value, 'ms', sample_rate, tags)
   end
 
   def s(name, value, sample_rate, tags)
-    generate_generic_datagram(name, value, -'s', sample_rate, tags)
+    generate_generic_datagram(name, value, 's', sample_rate, tags)
   end
 
   def h(name, value, sample_rate, tags)
-    generate_generic_datagram(name, value, -'h', sample_rate, tags)
+    generate_generic_datagram(name, value, 'h', sample_rate, tags)
   end
 
   def d(name, value, sample_rate, tags)
-    generate_generic_datagram(name, value, -'d', sample_rate, tags)
+    generate_generic_datagram(name, value, 'd', sample_rate, tags)
   end
 
   def kv(name, value, sample_rate, tags)
-    generate_generic_datagram(name, value, -'kv', sample_rate, tags)
+    generate_generic_datagram(name, value, 'kv', sample_rate, tags)
   end
 
   protected

--- a/lib/statsd/instrument/dogstatsd_datagram_builder.rb
+++ b/lib/statsd/instrument/dogstatsd_datagram_builder.rb
@@ -1,27 +1,5 @@
 # frozen_string_literal: true
 
 class StatsD::Instrument::DogStatsDDatagramBuilder < StatsD::Instrument::StatsDDatagramBuilder
-  def initialize(prefix: nil, default_tags: nil)
-    super
-    @default_tags = normalize_tags(default_tags)
-  end
-
-  def h(name, value, sample_rate, tags)
-    generate_generic_datagram(name, value, -'h', sample_rate, tags)
-  end
-
-  def d(name, value, sample_rate, tags)
-    generate_generic_datagram(name, value, -'d', sample_rate, tags)
-  end
-
-  protected
-
-  def generate_generic_datagram(name, value, type, sample_rate, tags)
-    tags = normalize_tags(tags) + default_tags
-    if tags.empty?
-      super
-    else
-      super << "|#" << tags.join(',')
-    end
-  end
+  unsupported_datagram_types :kv
 end

--- a/lib/statsd/instrument/dogstatsd_datagram_builder.rb
+++ b/lib/statsd/instrument/dogstatsd_datagram_builder.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class StatsD::Instrument::DogStatsDDatagramBuilder < StatsD::Instrument::StatsDDatagramBuilder
+  def initialize(prefix: nil, default_tags: nil)
+    super
+    @default_tags = normalize_tags(default_tags)
+  end
+
+  def h(name, value, sample_rate, tags)
+    generate_generic_datagram(name, value, -'h', sample_rate, tags)
+  end
+
+  def d(name, value, sample_rate, tags)
+    generate_generic_datagram(name, value, -'d', sample_rate, tags)
+  end
+
+  protected
+
+  def generate_generic_datagram(name, value, type, sample_rate, tags)
+    tags = normalize_tags(tags) + default_tags
+    if tags.empty?
+      super
+    else
+      super << "|#" << tags.join(',')
+    end
+  end
+end

--- a/lib/statsd/instrument/dogstatsd_datagram_builder.rb
+++ b/lib/statsd/instrument/dogstatsd_datagram_builder.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class StatsD::Instrument::DogStatsDDatagramBuilder < StatsD::Instrument::StatsDDatagramBuilder
+class StatsD::Instrument::DogStatsDDatagramBuilder < StatsD::Instrument::DatagramBuilder
   unsupported_datagram_types :kv
 end

--- a/lib/statsd/instrument/environment.rb
+++ b/lib/statsd/instrument/environment.rb
@@ -22,6 +22,15 @@ module StatsD::Instrument::Environment
     end
   end
 
+  def datagram_builder_class
+    case ENV['STATSD_IMPLEMENTATION']
+    when 'datadog', 'dogstatsd'
+      StatsD::Instrument::DogStatsDDatagramBuilder
+    else
+      StatsD::Instrument::StatsDDatagramBuilder
+    end
+  end
+
   # Detects the current environment, either by asking Rails, or by inspecting environment variables.
   #
   # - Within a Rails application, <tt>Rails.env</tt> is used.

--- a/lib/statsd/instrument/log_sink.rb
+++ b/lib/statsd/instrument/log_sink.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class StatsD::Instrument::LogSink
+  attr_reader :logger, :severity
+
+  def initialize(logger, severity: Logger::DEBUG)
+    @logger = logger
+    @severity = severity
+  end
+
+  def <<(datagram)
+    # Some implementations require a newline at the end of datagrams.
+    # When logging, we make sure those newlines are removed using chomp.
+
+    logger.add(severity, "[StatsD] #{datagram.chomp}")
+    self
+  end
+end

--- a/lib/statsd/instrument/null_sink.rb
+++ b/lib/statsd/instrument/null_sink.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class StatsD::Instrument::NullSink
-  def <<(datagram)
-    # noop
+  def <<(_datagram)
+    self # noop
   end
 end

--- a/lib/statsd/instrument/null_sink.rb
+++ b/lib/statsd/instrument/null_sink.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class StatsD::Instrument::NullSink
+  def <<(datagram)
+    # noop
+  end
+end

--- a/lib/statsd/instrument/statsd_datagram_builder.rb
+++ b/lib/statsd/instrument/statsd_datagram_builder.rb
@@ -1,75 +1,12 @@
 # frozen_string_literal: true
 
-class StatsD::Instrument::StatsDDatagramBuilder
-  unless Regexp.method_defined?(:match?) # for ruby 2.3
-    module RubyBackports
-      refine Regexp do
-        def match?(str)
-          (self =~ str) != nil
-        end
-      end
-    end
-
-    using RubyBackports
-  end
-
-  def initialize(prefix: nil, default_tags: nil)
-    @prefix = prefix.nil? ? "" : "#{normalize_name(prefix)}."
-  end
-
-  def c(name, value, sample_rate, tags)
-    generate_generic_datagram(name, value, -'c', sample_rate, tags)
-  end
-
-  def g(name, value, sample_rate, tags)
-    generate_generic_datagram(name, value, -'g', sample_rate, tags)
-  end
-
-  def ms(name, value, sample_rate, tags)
-    generate_generic_datagram(name, value, -'ms', sample_rate, tags)
-  end
-
-  def s(name, value, sample_rate, tags)
-    generate_generic_datagram(name, value, -'s', sample_rate, tags)
-  end
-
-  def h(name, value, sample_rate, tags)
-    # TODO: raise or log?
-  end
-
-  def d(name, value, sample_rate, tags)
-    # TODO: raise or log?
-  end
+class StatsD::Instrument::StatsDDatagramBuilder < StatsD::Instrument::DatagramBuilder
+  unsupported_datagram_types :h, :d, :kv
 
   protected
 
-  attr_reader :prefix, :default_tags
-
-  # Utility function to convert tags to the canonical form.
-  #
-  # - Tags specified as key value pairs will be converted into an array
-  # - Tags are normalized to only use word characters and underscores.
-  #
-  # @param tags [Array<String>, Hash<String, String>, nil] Tags specified in any form.
-  # @return [Array<String>, nil] the list of tags in canonical form.
   def normalize_tags(tags)
-    return [] unless tags
-    tags = tags.map { |k, v| "#{k}:#{v}" } if tags.is_a?(Hash)
-
-    # Fast path when no string replacement is needed
-    return tags unless tags.any? { /[|,]/.match?(tags) }
-    tags.map { |tag| tag.tr('|,', '') }
-  end
-
-  def normalize_name(name)
-    # Fast path when no normalization is needed to avoid copying the string
-    return name unless /[:|@]/.match?(name)
-    name.tr(':|@', '_')
-  end
-
-  def generate_generic_datagram(name, value, type, sample_rate, _tags)
-    datagram = +"#{@prefix}#{normalize_name(name)}:#{value}|#{type}"
-    datagram << "|@#{sample_rate}" if sample_rate && sample_rate < 1
-    datagram
+    raise NotImplementedError, "#{self.class.name} does not support tags" if tags
+    super
   end
 end

--- a/lib/statsd/instrument/statsd_datagram_builder.rb
+++ b/lib/statsd/instrument/statsd_datagram_builder.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+class StatsD::Instrument::StatsDDatagramBuilder
+  unless Regexp.method_defined?(:match?) # for ruby 2.3
+    module RubyBackports
+      refine Regexp do
+        def match?(str)
+          (self =~ str) != nil
+        end
+      end
+    end
+
+    using RubyBackports
+  end
+
+  def initialize(prefix: nil, default_tags: nil)
+    @prefix = prefix.nil? ? "" : "#{normalize_name(prefix)}."
+  end
+
+  def c(name, value, sample_rate, tags)
+    generate_generic_datagram(name, value, -'c', sample_rate, tags)
+  end
+
+  def g(name, value, sample_rate, tags)
+    generate_generic_datagram(name, value, -'g', sample_rate, tags)
+  end
+
+  def ms(name, value, sample_rate, tags)
+    generate_generic_datagram(name, value, -'ms', sample_rate, tags)
+  end
+
+  def s(name, value, sample_rate, tags)
+    generate_generic_datagram(name, value, -'s', sample_rate, tags)
+  end
+
+  def h(name, value, sample_rate, tags)
+    # TODO: raise or log?
+  end
+
+  def d(name, value, sample_rate, tags)
+    # TODO: raise or log?
+  end
+
+  protected
+
+  attr_reader :prefix, :default_tags
+
+  # Utility function to convert tags to the canonical form.
+  #
+  # - Tags specified as key value pairs will be converted into an array
+  # - Tags are normalized to only use word characters and underscores.
+  #
+  # @param tags [Array<String>, Hash<String, String>, nil] Tags specified in any form.
+  # @return [Array<String>, nil] the list of tags in canonical form.
+  def normalize_tags(tags)
+    return [] unless tags
+    tags = tags.map { |k, v| "#{k}:#{v}" } if tags.is_a?(Hash)
+
+    # Fast path when no string replacement is needed
+    return tags unless tags.any? { /[|,]/.match?(tags) }
+    tags.map { |tag| tag.tr('|,', '') }
+  end
+
+  def normalize_name(name)
+    # Fast path when no normalization is needed to avoid copying the string
+    return name unless /[:|@]/.match?(name)
+    name.tr(':|@', '_')
+  end
+
+  def generate_generic_datagram(name, value, type, sample_rate, _tags)
+    datagram = +"#{@prefix}#{normalize_name(name)}:#{value}|#{type}"
+    datagram << "|@#{sample_rate}" if sample_rate && sample_rate < 1
+    datagram
+  end
+end

--- a/lib/statsd/instrument/udp_sink.rb
+++ b/lib/statsd/instrument/udp_sink.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class StatsD::Instrument::UDPSink
+  def initialize(host, port)
+    @host = host
+    @port = port
+    @mutex = Mutex.new
+  end
+
+  def <<(datagram)
+    with_socket { |socket| socket.send(datagram, 0) > 0 }
+
+  rescue ThreadError
+    # In cases where a TERM or KILL signal has been sent, and we send stats as
+    # part of a signal handler, locks cannot be acquired, so we do our best
+    # to try and send the command without a lock.
+    socket.send(command, 0) > 0
+
+  rescue SocketError, IOError, SystemCallError
+    # TODO: log?
+    invalidate_socket
+  end
+
+  private
+
+  def with_socket
+    @mutex.synchronize do
+      if @socket.nil?
+        @socket = UDPSocket.new
+        @socket.connect(@host, @port)
+      end
+      yield(@socket)
+    end
+  end
+
+  def invalidate_socket
+    @mutex.synchronize do
+      @socket = nil
+    end
+  end
+end

--- a/test/capture_sink_test.rb
+++ b/test/capture_sink_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+require 'statsd/instrument/client'
+
+class CaptureSinktest < Minitest::Test
+  def test_capture_sink_captures_datagram_instances
+    capture_sink = StatsD::Instrument::CaptureSink.new(parent: [])
+    capture_sink << 'foo:1|c'
+
+    assert_equal 1, capture_sink.datagrams.length
+    assert_kind_of StatsD::Instrument::Datagram, capture_sink.datagrams.first
+    assert_equal 'foo:1|c', capture_sink.datagrams.first.source
+  end
+
+  def test_capture_sink_sends_datagrams_to_parent
+    parent = []
+    capture_sink = StatsD::Instrument::CaptureSink.new(parent: parent)
+    capture_sink << 'foo:1|c' << 'bar:1|c'
+
+    assert_equal ['foo:1|c', 'bar:1|c'], parent
+  end
+
+  def test_nesting_capture_sink_instances
+    null_sink = StatsD::Instrument::NullSink.new
+    outer_capture_sink = StatsD::Instrument::CaptureSink.new(parent: null_sink)
+    inner_capture_sink = StatsD::Instrument::CaptureSink.new(parent: outer_capture_sink)
+
+    outer_capture_sink << 'foo:1|c'
+    inner_capture_sink << 'bar:1|c'
+
+    assert_equal ['foo:1|c', 'bar:1|c'], outer_capture_sink.datagrams.map(&:source)
+    assert_equal ['bar:1|c'], inner_capture_sink.datagrams.map(&:source)
+  end
+end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -25,6 +25,13 @@ class ClientTest < Minitest::Test
     assert_equal ['baz'], inner_datagrams.map(&:name)
   end
 
+  def test_metric_methods_return_nil
+    assert_nil @client.increment('foo')
+    assert_nil @client.measure('bar', 122.54)
+    assert_nil @client.set('baz', 123)
+    assert_nil @client.gauge('baz', 12.3)
+  end
+
   def test_increment_with_default_value
     datagrams = @client.capture { @client.increment('foo') }
     assert_equal 1, datagrams.size

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+require 'statsd/instrument/client'
+
+class ClientTest < Minitest::Test
+  def setup
+    @client = StatsD::Instrument::Client.new
+  end
+
+  def test_capture
+    inner_datagrams = nil
+
+    @client.increment('foo')
+    outer_datagrams = @client.capture do
+      @client.increment('bar')
+      inner_datagrams = @client.capture do
+        @client.increment('baz')
+      end
+    end
+    @client.increment('quc')
+
+    assert_equal ['bar', 'baz'], outer_datagrams.map(&:name)
+    assert_equal ['baz'], inner_datagrams.map(&:name)
+  end
+
+  def test_increment_with_default_value
+    datagrams = @client.capture { @client.increment('foo') }
+    assert_equal 1, datagrams.size
+    assert_equal 'foo:1|c', datagrams.first.source
+  end
+
+  def test_measure_with_value
+    datagrams = @client.capture { @client.measure('foo', 122.54) }
+    assert_equal 1, datagrams.size
+    assert_equal 'foo:122.54|ms', datagrams.first.source
+  end
+
+  def test_gauge
+    datagrams = @client.capture { @client.gauge('foo', 123) }
+    assert_equal 1, datagrams.size
+    assert_equal 'foo:123|g', datagrams.first.source
+  end
+
+  def test_set
+    datagrams = @client.capture { @client.set('foo', 12345) }
+    assert_equal 1, datagrams.size
+    assert_equal 'foo:12345|s', datagrams.first.source
+  end
+
+  def test_clone_with_prefix_option
+    datagrams = []
+    original_client = StatsD::Instrument::Client.new(sink: datagrams)
+    client_with_other_options = original_client.clone_with_options(prefix: 'foo')
+
+    original_client.increment('metric')
+    client_with_other_options.increment('metric')
+
+    assert_equal 2, datagrams.size, "Message both client should use the same sink"
+    assert_equal 'metric', StatsD::Instrument::Datagram.new(datagrams[0]).name
+    assert_equal 'foo.metric', StatsD::Instrument::Datagram.new(datagrams[1]).name
+  end
+end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -56,6 +56,18 @@ class ClientTest < Minitest::Test
     assert_equal 'foo:12345|s', datagrams.first.source
   end
 
+  def test_histogram
+    datagrams = dogstatsd_client.capture { dogstatsd_client.histogram('foo', 12.44) }
+    assert_equal 1, datagrams.size
+    assert_equal 'foo:12.44|h', datagrams.first.source
+  end
+
+  def test_distribution
+    datagrams = dogstatsd_client.capture { dogstatsd_client.distribution('foo', 12.44) }
+    assert_equal 1, datagrams.size
+    assert_equal 'foo:12.44|d', datagrams.first.source
+  end
+
   def test_clone_with_prefix_option
     datagrams = []
     original_client = StatsD::Instrument::Client.new(sink: datagrams)
@@ -67,5 +79,12 @@ class ClientTest < Minitest::Test
     assert_equal 2, datagrams.size, "Message both client should use the same sink"
     assert_equal 'metric', StatsD::Instrument::Datagram.new(datagrams[0]).name
     assert_equal 'foo.metric', StatsD::Instrument::Datagram.new(datagrams[1]).name
+  end
+
+  private
+
+  def dogstatsd_client
+    @dogstatsd_client ||= StatsD::Instrument::Client.new(datagram_builder_class:
+      StatsD::Instrument::DogStatsDDatagramBuilder)
   end
 end

--- a/test/datagram_builder_test.rb
+++ b/test/datagram_builder_test.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+require 'statsd/instrument/client'
+
+class DatagramBuilderTest < Minitest::Test
+  def setup
+    @datagram_builder = StatsD::Instrument::DatagramBuilder.new
+  end
+
+  def test_normalize_name
+    assert_equal 'foo', @datagram_builder.send(:normalize_name, 'foo')
+    assert_equal 'fo_o', @datagram_builder.send(:normalize_name, 'fo|o')
+    assert_equal 'fo_o', @datagram_builder.send(:normalize_name, 'fo@o')
+    assert_equal 'fo_o', @datagram_builder.send(:normalize_name, 'fo:o')
+  end
+
+  def test_normalize_unsupported_tag_names
+    assert_equal ['ignored'], @datagram_builder.send(:normalize_tags, ['igno|re,d'])
+    # Note: how this is interpreted by the backend is undefined.
+    # We rely on the user to not do stuff like this if they don't want to be surprised.
+    # We do not want to take the performance hit of normaling this.
+    assert_equal ['lol::class:omg::lol'], @datagram_builder.send(:normalize_tags, "lol::class" => "omg::lol")
+  end
+
+  def test_normalize_tags_converts_hash_to_array
+    assert_equal ['tag:value'], @datagram_builder.send(:normalize_tags, tag: 'value')
+    assert_equal ['tag1:v1', 'tag2:v2'], @datagram_builder.send(:normalize_tags, tag1: 'v1', tag2: 'v2')
+  end
+
+  def test_c
+    datagram = @datagram_builder.c('foo', 1, nil, nil)
+    assert_equal "foo:1|c", datagram
+
+    datagram = @datagram_builder.c('fo:o', 10, 0.1, nil)
+    assert_equal "fo_o:10|c|@0.1", datagram
+  end
+
+  def test_ms
+    datagram = @datagram_builder.ms('foo', 1, nil, nil)
+    assert_equal "foo:1|ms", datagram
+
+    datagram = @datagram_builder.ms('fo:o', 10, 0.1, nil)
+    assert_equal "fo_o:10|ms|@0.1", datagram
+  end
+
+  def test_g
+    datagram = @datagram_builder.g('foo', 1, nil, nil)
+    assert_equal "foo:1|g", datagram
+
+    datagram = @datagram_builder.g('fo|o', 10, 0.01, nil)
+    assert_equal "fo_o:10|g|@0.01", datagram
+  end
+
+  def test_s
+    datagram = @datagram_builder.s('foo', 1, nil, nil)
+    assert_equal "foo:1|s", datagram
+
+    datagram = @datagram_builder.s('fo@o', 10, 0.01, nil)
+    assert_equal "fo_o:10|s|@0.01", datagram
+  end
+
+  def test_h
+    datagram = @datagram_builder.h('foo', 1, nil, nil)
+    assert_equal "foo:1|h", datagram
+
+    datagram = @datagram_builder.h('fo@o', 10, 0.01, nil)
+    assert_equal "fo_o:10|h|@0.01", datagram
+  end
+
+  def test_d
+    datagram = @datagram_builder.d('foo', 1, nil, nil)
+    assert_equal "foo:1|d", datagram
+
+    datagram = @datagram_builder.d('fo@o', 10, 0.01, nil)
+    assert_equal "fo_o:10|d|@0.01", datagram
+  end
+
+  def test_tags
+    datagram = @datagram_builder.d('foo', 10, nil, ['foo', 'bar'])
+    assert_equal "foo:10|d|#foo,bar", datagram
+
+    datagram = @datagram_builder.d('foo', 10, 0.1, ['foo:bar'])
+    assert_equal "foo:10|d|@0.1|#foo:bar", datagram
+
+    datagram = @datagram_builder.d('foo', 10, 1, foo: 'bar', baz: 'quc')
+    assert_equal "foo:10|d|#foo:bar,baz:quc", datagram
+  end
+end

--- a/test/dogstatsd_datagram_builder_test.rb
+++ b/test/dogstatsd_datagram_builder_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+require 'statsd/instrument/client'
+
+class DogStatsDDatagramBuilderTest < Minitest::Test
+  def setup
+    @datagram_builder = StatsD::Instrument::DogStatsDDatagramBuilder.new
+  end
+
+  def test_raises_on_unsupported_metrics
+    assert_raises(NotImplementedError) { @datagram_builder.kv('foo', 10, nil, nil) }
+  end
+end

--- a/test/log_sink_test.rb
+++ b/test/log_sink_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+require 'statsd/instrument/client'
+
+class LogSinktest < Minitest::Test
+  def test_log_sink
+    logger = Logger.new(log = StringIO.new)
+    logger.formatter = proc do |severity, _datetime, _progname, msg|
+      "#{severity}: #{msg}\n"
+    end
+
+    log_sink = StatsD::Instrument::LogSink.new(logger)
+    log_sink << 'foo:1|c' << 'bar:1|c'
+
+    assert_equal <<~LOG, log.string
+      DEBUG: [StatsD] foo:1|c
+      DEBUG: [StatsD] bar:1|c
+    LOG
+  end
+
+  def test_log_sink_chomps_trailing_newlines
+    logger = Logger.new(log = StringIO.new)
+    logger.formatter = proc do |severity, _datetime, _progname, msg|
+      "#{severity}: #{msg}\n"
+    end
+
+    log_sink = StatsD::Instrument::LogSink.new(logger)
+    log_sink << "foo:1|c\n" << "bar:1|c\n"
+
+    assert_equal <<~LOG, log.string
+      DEBUG: [StatsD] foo:1|c
+      DEBUG: [StatsD] bar:1|c
+    LOG
+  end
+end

--- a/test/null_sink_test.rb
+++ b/test/null_sink_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+require 'statsd/instrument/client'
+
+class NullSinktest < Minitest::Test
+  def test_null_sink
+    null_sink = StatsD::Instrument::NullSink.new
+    null_sink << 'foo:1|c' << 'bar:1|c'
+    pass # We don't have anything to assert, except that no exception was raised
+  end
+end

--- a/test/statsd_datagram_builder_test.rb
+++ b/test/statsd_datagram_builder_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+require 'statsd/instrument/client'
+
+class StatsDDatagramBuilderTest < Minitest::Test
+  def setup
+    @datagram_builder = StatsD::Instrument::StatsDDatagramBuilder.new
+  end
+
+  def test_raises_on_unsupported_metrics
+    assert_raises(NotImplementedError) { @datagram_builder.h('fo:o', 10, nil, nil) }
+    assert_raises(NotImplementedError) { @datagram_builder.d('fo:o', 10, nil, nil) }
+    assert_raises(NotImplementedError) { @datagram_builder.kv('fo:o', 10, nil, nil) }
+  end
+
+  def test_raises_when_using_tags
+    assert_raises(NotImplementedError) { @datagram_builder.c('fo:o', 10, nil, foo: 'bar') }
+    assert_raises(NotImplementedError) { StatsD::Instrument::StatsDDatagramBuilder.new(default_tags: ['foo']) }
+  end
+end

--- a/test/udp_sink_test.rb
+++ b/test/udp_sink_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+require 'statsd/instrument/client'
+
+class UDPSinktest < Minitest::Test
+  def setup
+    @receiver = UDPSocket.new
+    @receiver.bind('localhost', 0)
+    @host = @receiver.addr[2]
+    @port = @receiver.addr[1]
+  end
+
+  def teardown
+    @receiver.close
+  end
+
+  def test_udp_sink_sends_data_over_udp
+    udp_sink = StatsD::Instrument::UDPSink.new(@host, @port)
+    udp_sink << 'foo:1|c'
+
+    datagram, _source = @receiver.recvfrom(100)
+    assert_equal 'foo:1|c', datagram
+  end
+
+  def test_parallelism
+    udp_sink = StatsD::Instrument::UDPSink.new(@host, @port)
+    50.times { |i| Thread.new { udp_sink << "foo:#{i}|c" << "bar:#{i}|c" } }
+    datagrams = []
+    100.times do
+      datagram, _source = @receiver.recvfrom(100)
+      datagrams << datagram
+    end
+
+    assert_equal 100, datagrams.size
+  end
+
+  def test_socket_error_should_invalidate_socket
+    UDPSocket.stubs(:new).returns(socket = mock('socket'))
+
+    seq = sequence('connect_fail_connect_succeed')
+    socket.expects(:connect).with('localhost', 8125).in_sequence(seq)
+    socket.expects(:send).raises(Errno::EDESTADDRREQ).in_sequence(seq)
+    socket.expects(:connect).with('localhost', 8125).in_sequence(seq)
+    socket.expects(:send).returns(1).in_sequence(seq)
+
+    udp_sink = StatsD::Instrument::UDPSink.new('localhost', 8125)
+    udp_sink << 'foo:1|c'
+    udp_sink << 'bar:1|c'
+  end
+
+  def test_sends_datagram_in_signal_handler
+    udp_sink = StatsD::Instrument::UDPSink.new(@host, @port)
+    pid = fork do
+      Signal.trap('TERM') do
+        udp_sink << "exiting:1|c"
+        Process.exit!(0)
+      end
+
+      sleep(10)
+    end
+
+    Process.kill('TERM', pid)
+    _, exit_status = Process.waitpid2(pid)
+
+    assert_equal 0, exit_status, "The forked process did not exit cleanly"
+    assert_equal "exiting:1|c", @receiver.recvfrom_nonblock(100).first
+
+  rescue NotImplementedError
+    pass("Fork is not implemented on #{RUBY_PLATFORM}")
+  end
+end


### PR DESCRIPTION
This sketches how I was thinking of implementing the new StatsD client.

- It is not a singleton, so you can instantiate multiple of them.
- Rather than allocating `Metric` objects that get turned into a string before being sent over the UDP socket, it immediately generates strings. 
- You can inject a DatagramBuilder class into the client, which can cover the differences between implementations, and/or being more lenient or strict when it comes to supported types, metric names, tags, etc.
- These datagram strings are sent directly to the sink (e.g. UDP socket) as is.
- The UDP sink implementation is much simpler than before. The `NullSink` and `CaptureSink` are pretty similar to the old backends of the same time.

### Migration path

For now, this new client is implemented in a completely independent way. The Ruby files are not even `require`d yet. So we can safely land this client implementation on master and iterate on it until we are ready.

Compatibility questions?
- Right now, `StatsD.instrument` returns a `StatsD::Instrument::Metric` instance. The new implementation does not use this class anymore. What should we do?
  1. Return a `StatsD::Instrument::Datagram` instance that is duck-type compatible with `StatsD::Instrument::Metric.
  2. Break backwards compatibility and the datagram as string.
  3. Assume that basically nobody really uses the return value. Break backwards compatibility and return `void`.

- Different backends/implementations support a different subset/superset of the StatsD protocol. How should we handle when the user asks for something that the implementation does not support? (E.g. tags, distribution metrics, etc).
  1. Raise an exception (current behavior)
  2. Send the packet anyway, and let the receiver deal with the problem.
  3. Silently drop, maybe log. 

  Theoretically it is possible to support all these things by having different DatagramBuilder implementations.

### Performance

The result is that the new client is much faster than the legacy singleton.

```
Warming up --------------------------------------
       Legacy client     6.414k i/100ms
          New client     9.920k i/100ms
Calculating -------------------------------------
       Legacy client     67.000k (± 1.9%) i/s -    339.942k in   5.075621s
          New client    105.344k (± 2.1%) i/s -    535.680k in   5.087400s

Comparison:
          New client:   105343.8 i/s
       Legacy client:    67000.1 i/s - 1.57x  (± 0.00) slower
```

### TODO

- [x] Do the same name and tag normalization as the legacy implementation.
- [ ] Support for providing blocks to measure durations for `measure` and `distribution`. (And maybe `histogram`.
- [ ] Support `event` and `service_check` on DogStatsD.
- [x] Add a `LogSink`
- [x] Tests for all metric types
- [x] Tests for tag and name normalization
- [x] Tests for prefix and default tags.
- [x] Tests for datagram builder classes
- [x] Tests for sink classes
- [ ] Yardoc