### PR TITLE
Use match? on the fast path for normalization

### DIFF
--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -123,6 +123,9 @@ class StatsD::Instrument::Metric
   # @param name [String]
   # @return [String]
   def normalize_name(name)
+    # fast path when no normalization is needed to avoid copying the string
+    return name unless name.match?(/[:|@]/)
+
     name.tr(':|@', '_')
   end
 
@@ -136,6 +139,10 @@ class StatsD::Instrument::Metric
   def self.normalize_tags(tags)
     return unless tags
     tags = tags.map { |k, v| k.to_s + ":" + v.to_s } if tags.is_a?(Hash)
+
+    # fast path when no string replacement is needed
+    return tags unless tags.any? { |tag| tag.match?(/[|,]/) }
+
     tags.map { |tag| tag.tr('|,', '') }
   end
 end

--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -31,6 +31,18 @@
 # @see StatsD::Instrument::Backend A StatsD::Instrument::Backend is used to collect metrics.
 #
 class StatsD::Instrument::Metric
+  unless Regexp.method_defined?(:match?) # for ruby 2.3
+    module RubyBackports
+      refine Regexp do
+        def match?(str)
+          (self =~ str) != nil
+        end
+      end
+    end
+
+    using RubyBackports
+  end
+
   attr_accessor :type, :name, :value, :sample_rate, :tags, :metadata
 
   # Initializes a new metric instance.
@@ -124,7 +136,7 @@ class StatsD::Instrument::Metric
   # @return [String]
   def normalize_name(name)
     # fast path when no normalization is needed to avoid copying the string
-    return name unless name.match?(/[:|@]/)
+    return name unless /[:|@]/.match?(name)
 
     name.tr(':|@', '_')
   end
@@ -141,7 +153,7 @@ class StatsD::Instrument::Metric
     tags = tags.map { |k, v| k.to_s + ":" + v.to_s } if tags.is_a?(Hash)
 
     # fast path when no string replacement is needed
-    return tags unless tags.any? { |tag| tag.match?(/[|,]/) }
+    return tags unless tags.any? { |tag| /[|,]/.match?(tag) }
 
     tags.map { |tag| tag.tr('|,', '') }
   end


### PR DESCRIPTION
Regexp `match?` avoids having to do any object allocations by just having to return a boolean result.  `Array#any?` avoids object allocations for the same reason.

This improvement shows up in the benchmark:

```
$ ./benchmark/send-metrics-to-local-udp-receiver
Warming up --------------------------------------
StatsD metrics to local UDP receiver (branch: normalization-fast-path, sha: db42a9d)
                       926.000  i/100ms
Calculating -------------------------------------
StatsD metrics to local UDP receiver (branch: normalization-fast-path, sha: db42a9d)
                          9.376k (± 2.3%) i/s -     47.226k in   5.039640s

Comparison:
StatsD metrics to local UDP receiver (branch: normalization-fast-path, sha: db42a9d):     9376.2 i/s
StatsD metrics to local UDP receiver (branch: master, sha: 779193d):     8857.1 i/s - same-ish: difference falls within error
```

Although is based on the assumption that metric names don't have `:`, `|` or `@` in them and tag names don't have `|` or`,`.  When these assumptions aren't true, then these checks could make things a bit slower.