### PR TITLE
Use keyword args to capture hash options to avoid hash allocation

### DIFF
--- a/test/matchers_test.rb
+++ b/test/matchers_test.rb
@@ -41,7 +41,7 @@ class MatchersTest < Minitest::Test
 
   def test_statsd_increment_with_times_not_matched
     refute StatsD::Instrument::Matchers::Increment.new(:c, 'counter', times: 2)
-      .matches?(lambda { StatsD.increment('counter', times: 3) })
+      .matches? lambda { 3.times { StatsD.increment('counter') } }
   end
 
   def test_statsd_increment_with_sample_rate_matched

--- a/test/metric_test.rb
+++ b/test/metric_test.rb
@@ -16,27 +16,12 @@ class MetricTest < Minitest::Test
     assert m.tags.nil?
   end
 
-  def test_name_prefix
-    StatsD.stubs(:prefix).returns('prefix')
-    m = StatsD::Instrument::Metric.new(type: :c, name: 'counter')
-    assert_equal 'prefix.counter', m.name
-
-    m = StatsD::Instrument::Metric.new(type: :c, name: 'counter', no_prefix: true)
-    assert_equal 'counter', m.name
-
-    m = StatsD::Instrument::Metric.new(type: :c, name: 'counter', prefix: "foobar")
-    assert_equal 'foobar.counter', m.name
-
-    m = StatsD::Instrument::Metric.new(type: :c, name: 'counter', prefix: "foobar", no_prefix: true)
-    assert_equal 'counter', m.name
-  end
-
   def test_bad_metric_name
-    m = StatsD::Instrument::Metric.new(type: :c, name: 'my:metric', no_prefix: true)
+    m = StatsD::Instrument::Metric.new(type: :c, name: 'my:metric')
     assert_equal 'my_metric', m.name
-    m = StatsD::Instrument::Metric.new(type: :c, name: 'my|metric', no_prefix: true)
+    m = StatsD::Instrument::Metric.new(type: :c, name: 'my|metric')
     assert_equal 'my_metric', m.name
-    m = StatsD::Instrument::Metric.new(type: :c, name: 'my@metric', no_prefix: true)
+    m = StatsD::Instrument::Metric.new(type: :c, name: 'my@metric')
     assert_equal 'my_metric', m.name
   end
 

--- a/test/statsd_test.rb
+++ b/test/statsd_test.rb
@@ -277,6 +277,21 @@ class StatsDTest < Minitest::Test
     assert_equal ['first_tag:first_value', 'second_tag:second_value'], StatsD.default_tags
   end
 
+  def test_name_prefix
+    StatsD.stubs(:prefix).returns('prefix')
+    m = capture_statsd_call { StatsD.increment('counter') }
+    assert_equal 'prefix.counter', m.name
+
+    m = capture_statsd_call { StatsD.increment('counter', no_prefix: true) }
+    assert_equal 'counter', m.name
+
+    m = capture_statsd_call { StatsD.increment('counter', prefix: "foobar") }
+    assert_equal 'foobar.counter', m.name
+
+    m = capture_statsd_call { StatsD.increment('counter', prefix: "foobar", no_prefix: true) }
+    assert_equal 'counter', m.name
+  end
+
   protected
 
   def capture_statsd_call(&block)


### PR DESCRIPTION
There were a bunch of objects being allocated to handle keyword-like operations, which was being handled as a hash, as well as converting positional arguments to keyword arguments.  Using keyword argument directly allows ruby to handle the arguments without them being converted to a hash as well as letting us leverage default values.

The benchmark results show the improvement:

```
$ benchmark/send-metrics-to-local-udp-receiver
Warming up --------------------------------------
StatsD metrics to local UDP receiver (branch: master, sha: 779193d)
                       903.000  i/100ms
Calculating -------------------------------------
StatsD metrics to local UDP receiver (branch: master, sha: 779193d)
                          9.221k (± 1.8%) i/s -     46.956k in   5.093885s

Comparison:
StatsD metrics to local UDP receiver (branch: keyword-args, sha: 7611487):    11026.8 i/s
StatsD metrics to local UDP receiver (branch: master, sha: 779193d):     9221.2 i/s - 1.20x  (± 0.00) slower
```