### PR TITLE
Don’t deadlock the integration test on errors

### DIFF
--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -33,9 +33,10 @@ class IntegrationTest < Minitest::Test
     end
 
     Process.kill('TERM', pid)
-    Process.waitpid(pid)
+    _, exit_status = Process.waitpid2(pid)
 
-    assert_equal "exiting:1|c", @server.recvfrom(100).first
+    assert_equal 0, exit_status, "The foked process did not exit cleanly"
+    assert_equal "exiting:1|c", @server.recvfrom_nonblock(100).first
 
   rescue NotImplementedError
     pass("Fork is not implemented on #{RUBY_PLATFORM}")


### PR DESCRIPTION
When the forked process failed of the integration test fails to send a UDP datagram (e.g. due to a bug or exception inside the library), the read from the UDP listener would deadlock. This is not great for fast feedback.

This updates the test to fail fast in that case.