### PR TITLE
Add custom Rubocop cop to rewrite positional arguments on StatsD calls.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ require 'rake/testtask'
 Rake::TestTask.new('test') do |t|
   t.ruby_opts << '-r rubygems'
   t.libs << 'lib' << 'test'
-  t.test_files = FileList['test/*.rb']
+  t.test_files = FileList['test/**/*_test.rb']
 end
 
 task default: :test

--- a/lib/statsd/instrument/rubocop/positional_arguments.rb
+++ b/lib/statsd/instrument/rubocop/positional_arguments.rb
@@ -7,14 +7,15 @@ module RuboCop
         MSG = 'Use keyword arguments for StatsD calls'
 
         STATSD_SINGLETON_METHODS = %i{increment gauge measure set histogram distribution key_value}
-        POSITIONAL_THIRD_ARGUMENT_TYPES = [:int, :float, :nil, :send]
-        NON_POSITIONAL_SECOND_ARGUMENT_TYPES = [:block_pass, :hash]
+        POSITIONAL_ARGUMENT_TYPES = Set[:int, :float, :nil]
+        UNKNOWN_ARGUMENT_TYPES = Set[:send, :const]
+        REFUSED_ARGUMENT_TYPES = POSITIONAL_ARGUMENT_TYPES | UNKNOWN_ARGUMENT_TYPES
 
         def on_send(node)
           if node.receiver&.type == :const && node.receiver&.const_name == "StatsD"
             if STATSD_SINGLETON_METHODS.include?(node.method_name)
               arguments = node.arguments
-              if arguments.length >= 3 && POSITIONAL_THIRD_ARGUMENT_TYPES.include?(arguments[2].type)
+              if arguments.length >= 3 && REFUSED_ARGUMENT_TYPES.include?(arguments[2].type)
                 add_offense(node)
               end
             end
@@ -29,9 +30,24 @@ module RuboCop
               node.arguments[2...node.arguments.length]
             end
 
-            if positial_arguments[0].type == :send
-              corrector.replace(positial_arguments[0].source_range, "**#{positial_arguments[0].source_range.source}")
-            else
+            case positial_arguments[0].type
+            when *UNKNOWN_ARGUMENT_TYPES
+              # We don't know whether the method returns a hash, in which case it would be interpreted
+              # as keyword arguments. In this case, the fix would be to add a keywordf splat:
+              #
+              # `StatsD.instrument('foo', 1, method_call)`
+              # => `StatsD.instrument('foo', 1, **method_call)`
+              #
+              # However, it's also possible this method returns a sample rate, in which case the fix
+              # above will not do the right thing.
+              #
+              # `StatsD.instrument('foo', 1, SAMPLE_RATE_CONSTANT)`
+              # => `StatsD.instrument('foo', 1, sample_rate: SAMPLE_RATE_CONSTANT)`
+              #
+              # Because of this, we will not auto-correct and let the user fix the issue manually.
+              return
+
+            when *POSITIONAL_ARGUMENT_TYPES
               value_argument = node.arguments[1]
               from = value_argument.source_range.end_pos
               to = positial_arguments.last.source_range.end_pos
@@ -41,21 +57,24 @@ module RuboCop
               keyword_arguments = []
               sample_rate = positial_arguments[0]
               if sample_rate && sample_rate.type != :nil
-                keyword_arguments << "sample_rate: #{sample_rate.source_range.source}"
+                keyword_arguments << "sample_rate: #{sample_rate.source}"
               end
 
               tags = positial_arguments[1]
               if tags && tags.type != :nil
-                keyword_arguments << if tags.type == :hash && tags.source_range.source[0] != '{'
-                  "tags: { #{tags.source_range.source} }"
+                keyword_arguments << if tags.type == :hash && tags.source[0] != '{'
+                  "tags: { #{tags.source} }"
                 else
-                  "tags: #{tags.source_range.source}"
+                  "tags: #{tags.source}"
                 end
               end
 
               unless keyword_arguments.empty?
                 corrector.insert_after(value_argument.source_range, ", #{keyword_arguments.join(', ')}")
               end
+
+            else
+              puts "Unknown arg type #{positial_arguments[0].type}"
             end
           end
         end

--- a/lib/statsd/instrument/rubocop/positional_arguments.rb
+++ b/lib/statsd/instrument/rubocop/positional_arguments.rb
@@ -1,0 +1,60 @@
+# frozen-string-literal: true
+
+module RuboCop
+  module Cop
+    module StatsD
+      class PositionalArguments < Cop
+        MSG = 'Use keyword arguments for StatsD calls'
+
+        STATSD_SINGLETON_METHODS = %i{increment gauge measure set histogram distribution key_value}
+        NON_POSITIONAL_SECOND_ARGUMENT_TYPES = [:block_pass, :hash]
+
+        def on_send(node)
+          if node.receiver&.type == :const && node.receiver&.const_name == "StatsD"
+            if STATSD_SINGLETON_METHODS.include?(node.method_name)
+              arguments = node.arguments
+              if arguments.length > 2 && !NON_POSITIONAL_SECOND_ARGUMENT_TYPES.include?(arguments[2].type)
+                add_offense(node)
+              end
+            end
+          end
+        end
+
+        def autocorrect(node)
+          -> (corrector) do
+            positial_arguments = if node.arguments.last.type == :block_pass
+              node.arguments[2...node.arguments.length - 1]
+            else
+              node.arguments[2...node.arguments.length]
+            end
+
+            value_argument = node.arguments[1]
+            from = value_argument.source_range.end_pos
+            to = positial_arguments.last.source_range.end_pos
+            range = Parser::Source::Range.new(node.source_range.source_buffer, from, to)
+            corrector.remove(range)
+
+            keyword_arguments = []
+            sample_rate = positial_arguments[0]
+            if sample_rate && sample_rate.type != :nil
+              keyword_arguments << "sample_rate: #{sample_rate.source_range.source}"
+            end
+
+            tags = positial_arguments[1]
+            if tags && tags.type != :nil
+              keyword_arguments << if tags.type == :hash && tags.source_range.source[0] != '{'
+                "tags: { #{tags.source_range.source} }"
+              else
+                "tags: #{tags.source_range.source}"
+              end
+            end
+
+            unless keyword_arguments.empty?
+              corrector.insert_after(value_argument.source_range, ", #{keyword_arguments.join(', ')}")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/statsd/instrument/rubocop/positional_arguments.rb
+++ b/lib/statsd/instrument/rubocop/positional_arguments.rb
@@ -7,13 +7,14 @@ module RuboCop
         MSG = 'Use keyword arguments for StatsD calls'
 
         STATSD_SINGLETON_METHODS = %i{increment gauge measure set histogram distribution key_value}
+        POSITIONAL_THIRD_ARGUMENT_TYPES = [:int, :float, :nil, :send]
         NON_POSITIONAL_SECOND_ARGUMENT_TYPES = [:block_pass, :hash]
 
         def on_send(node)
           if node.receiver&.type == :const && node.receiver&.const_name == "StatsD"
             if STATSD_SINGLETON_METHODS.include?(node.method_name)
               arguments = node.arguments
-              if arguments.length > 2 && !NON_POSITIONAL_SECOND_ARGUMENT_TYPES.include?(arguments[2].type)
+              if arguments.length >= 3 && POSITIONAL_THIRD_ARGUMENT_TYPES.include?(arguments[2].type)
                 add_offense(node)
               end
             end
@@ -28,29 +29,33 @@ module RuboCop
               node.arguments[2...node.arguments.length]
             end
 
-            value_argument = node.arguments[1]
-            from = value_argument.source_range.end_pos
-            to = positial_arguments.last.source_range.end_pos
-            range = Parser::Source::Range.new(node.source_range.source_buffer, from, to)
-            corrector.remove(range)
+            if positial_arguments[0].type == :send
+              corrector.replace(positial_arguments[0].source_range, "**#{positial_arguments[0].source_range.source}")
+            else
+              value_argument = node.arguments[1]
+              from = value_argument.source_range.end_pos
+              to = positial_arguments.last.source_range.end_pos
+              range = Parser::Source::Range.new(node.source_range.source_buffer, from, to)
+              corrector.remove(range)
 
-            keyword_arguments = []
-            sample_rate = positial_arguments[0]
-            if sample_rate && sample_rate.type != :nil
-              keyword_arguments << "sample_rate: #{sample_rate.source_range.source}"
-            end
-
-            tags = positial_arguments[1]
-            if tags && tags.type != :nil
-              keyword_arguments << if tags.type == :hash && tags.source_range.source[0] != '{'
-                "tags: { #{tags.source_range.source} }"
-              else
-                "tags: #{tags.source_range.source}"
+              keyword_arguments = []
+              sample_rate = positial_arguments[0]
+              if sample_rate && sample_rate.type != :nil
+                keyword_arguments << "sample_rate: #{sample_rate.source_range.source}"
               end
-            end
 
-            unless keyword_arguments.empty?
-              corrector.insert_after(value_argument.source_range, ", #{keyword_arguments.join(', ')}")
+              tags = positial_arguments[1]
+              if tags && tags.type != :nil
+                keyword_arguments << if tags.type == :hash && tags.source_range.source[0] != '{'
+                  "tags: { #{tags.source_range.source} }"
+                else
+                  "tags: #{tags.source_range.source}"
+                end
+              end
+
+              unless keyword_arguments.empty?
+                corrector.insert_after(value_argument.source_range, ", #{keyword_arguments.join(', ')}")
+              end
             end
           end
         end

--- a/test/helpers/rubocop_helper.rb
+++ b/test/helpers/rubocop_helper.rb
@@ -17,6 +17,11 @@ module RubocopHelper
     refute_predicate cop.offenses, :empty?, "Expected Rubocop to find offenses"
   end
 
+  def assert_no_autocorrect(source)
+    corrected = autocorrect_source(source)
+    assert_equal source, corrected
+  end
+
   def autocorrect_source(source)
     RuboCop::Formatter::DisabledConfigFormatter.config_to_allow_offenses = {}
     RuboCop::Formatter::DisabledConfigFormatter.detected_styles = {}

--- a/test/rubocop/positional_arguments_test.rb
+++ b/test/rubocop/positional_arguments_test.rb
@@ -32,6 +32,14 @@ module Rubocop
       assert_offense("StatsD.gauge('foo', 2, method_ruturning_a_hash)")
     end
 
+    def test_offense_when_using_local_variable
+      assert_offense("lambda { |x| StatsD.gauge('foo', 2, x) }")
+      assert_offense(<<~RUBY)
+        x = foo
+        StatsD.gauge('foo', 2, x)
+      RUBY
+    end
+
     def test_no_autocorrect_when_using_method_or_constant
       assert_no_autocorrect("StatsD.gauge('foo', 2, SAMPLE_RATE_CONSTANT)")
       assert_no_autocorrect("StatsD.gauge('foo', 2, method_ruturning_a_hash)")

--- a/test/rubocop/positional_arguments_test.rb
+++ b/test/rubocop/positional_arguments_test.rb
@@ -21,6 +21,12 @@ module Rubocop
       assert_no_offenses("StatsD.increment('foo', 2, &block)")
     end
 
+    def test_no_offense_for_now
+      assert_no_offenses("StatsD.increment 'foo', value: 3")
+      assert_no_offenses("StatsD.increment 'foo', value: 3, sample_rate: 0.5")
+      assert_no_offenses("StatsD.increment('foo', value: 3, tags: ['foo']) { foo }")
+    end
+
     def test_autocorrect_only_sample_rate
       corrected = autocorrect_source("StatsD.increment('foo', 2, 0.5)")
       assert_equal "StatsD.increment('foo', 2, sample_rate: 0.5)", corrected

--- a/test/rubocop/positional_arguments_test.rb
+++ b/test/rubocop/positional_arguments_test.rb
@@ -19,9 +19,15 @@ module Rubocop
       assert_no_offenses("StatsD.increment('foo', 2, sample_rate: 0.1, tags: { foo: 'bar' })")
       assert_no_offenses("StatsD.increment('foo', 2) { foo }")
       assert_no_offenses("StatsD.increment('foo', 2, &block)")
+      assert_no_offenses("StatsD.gauge('foo', 2, **kwargs)")
     end
 
-    def test_no_offense_for_now
+    def test_test_autocorrect_third_argument_to_keyword_splat
+      corrected = autocorrect_source("StatsD.gauge('foo', 2, method_ruturning_a_hash)")
+      assert_equal "StatsD.gauge('foo', 2, **method_ruturning_a_hash)", corrected
+    end
+
+    def test_no_offense_for_now_when_using_value_keyword_argumenr
       assert_no_offenses("StatsD.increment 'foo', value: 3")
       assert_no_offenses("StatsD.increment 'foo', value: 3, sample_rate: 0.5")
       assert_no_offenses("StatsD.increment('foo', value: 3, tags: ['foo']) { foo }")
@@ -30,6 +36,11 @@ module Rubocop
     def test_autocorrect_only_sample_rate
       corrected = autocorrect_source("StatsD.increment('foo', 2, 0.5)")
       assert_equal "StatsD.increment('foo', 2, sample_rate: 0.5)", corrected
+    end
+
+    def test_autocorrect_only_sample_rate_as_int
+      corrected = autocorrect_source("StatsD.increment('foo', 2, 1)")
+      assert_equal "StatsD.increment('foo', 2, sample_rate: 1)", corrected
     end
 
     def test_autocorrect_only_tags

--- a/test/rubocop/positional_arguments_test.rb
+++ b/test/rubocop/positional_arguments_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'rubocop'
+require 'statsd/instrument/rubocop/positional_arguments'
+
+module Rubocop
+  class PositionalArgumentsTest < Minitest::Test
+    attr_reader :cop
+
+    def setup
+      @cop = RuboCop::Cop::StatsD::PositionalArguments.new
+    end
+
+    def test_no_offenses
+      assert_no_offenses("StatsD.increment 'foo'")
+      assert_no_offenses("StatsD.gauge('foo', 2)")
+      assert_no_offenses("StatsD.increment('foo', 2, tags: ['foo:bar'])")
+      assert_no_offenses("StatsD.increment('foo', 2, sample_rate: 0.1, tags: { foo: 'bar' })")
+      assert_no_offenses("StatsD.increment('foo', 2) { foo }")
+      assert_no_offenses("StatsD.increment('foo', 2, &block)")
+    end
+
+    def test_autocorrect_only_sample_rate
+      corrected = autocorrect_source("StatsD.increment('foo', 2, 0.5)")
+      assert_equal "StatsD.increment('foo', 2, sample_rate: 0.5)", corrected
+    end
+
+    def test_autocorrect_only_tags
+      corrected = autocorrect_source("StatsD.increment('foo', 2, nil, ['foo', 'bar'])")
+      assert_equal "StatsD.increment('foo', 2, tags: ['foo', 'bar'])", corrected
+    end
+
+    def test_autocorrect_sample_rate_and_tags_as_array
+      corrected = autocorrect_source("StatsD.increment('foo', 2, 0.5, ['foo', 'bar'])")
+      assert_equal "StatsD.increment('foo', 2, sample_rate: 0.5, tags: ['foo', 'bar'])", corrected
+    end
+
+    def test_autocorrect_sample_rate_and_tags_as_hash_with_curly_braces
+      corrected = autocorrect_source("StatsD.increment('foo', 2, 0.5, { foo: 'bar' })")
+      assert_equal "StatsD.increment('foo', 2, sample_rate: 0.5, tags: { foo: 'bar' })", corrected
+    end
+
+    def test_autocorrect_sample_rate_and_tags_as_hash_without_curly_braces
+      corrected = autocorrect_source("StatsD.increment('foo', 2, 0.5, foo: 'bar')")
+      assert_equal "StatsD.increment('foo', 2, sample_rate: 0.5, tags: { foo: 'bar' })", corrected
+    end
+
+    def test_autocorrect_sample_rate_and_block_pass
+      corrected = autocorrect_source("StatsD.distribution('foo', 2, 0.5, &block)")
+      assert_equal "StatsD.distribution('foo', 2, sample_rate: 0.5, &block)", corrected
+    end
+
+    def test_autocorrect_sample_rate_tags_and_block_pass
+      corrected = autocorrect_source("StatsD.measure('foo', 2, nil, foo: 'bar', &block)")
+      assert_equal "StatsD.measure('foo', 2, tags: { foo: 'bar' }, &block)", corrected
+    end
+
+    def test_autocorrect_sample_rate_and_curly_braces_block
+      corrected = autocorrect_source("StatsD.measure('foo', 2, 0.5) { foo }")
+      assert_equal "StatsD.measure('foo', 2, sample_rate: 0.5) { foo }", corrected
+    end
+
+    def test_autocorrect_sample_rate_and_do_end_block
+      corrected = autocorrect_source(<<~RUBY)
+        StatsD.distribution 'foo', 124, 0.6, ['bar'] do
+          foo
+        end
+      RUBY
+      assert_equal <<~RUBY, corrected
+        StatsD.distribution 'foo', 124, sample_rate: 0.6, tags: ['bar'] do
+          foo
+        end
+      RUBY
+    end
+
+    private
+
+    def assert_no_offenses(source)
+      corrected = autocorrect_source(source)
+      assert_equal(source, corrected, "An unexpected offense was detected and corrected")
+    end
+
+    def autocorrect_source(source)
+      RuboCop::Formatter::DisabledConfigFormatter.config_to_allow_offenses = {}
+      RuboCop::Formatter::DisabledConfigFormatter.detected_styles = {}
+      cop.instance_variable_get(:@options)[:auto_correct] = true
+      processed_source = RuboCop::ProcessedSource.new(source, 2.3, nil)
+      investigate(cop, processed_source)
+
+      corrector = RuboCop::Cop::Corrector.new(processed_source.buffer, cop.corrections)
+      corrector.rewrite
+    end
+
+    def investigate(cop, processed_source)
+      forces = RuboCop::Cop::Force.all.each_with_object([]) do |klass, instances|
+        next unless cop.join_force?(klass)
+        instances << klass.new([cop])
+      end
+
+      commissioner = RuboCop::Cop::Commissioner.new([cop], forces, raise_error: true)
+      commissioner.investigate(processed_source)
+      commissioner
+    end
+  end
+end


### PR DESCRIPTION
This rewrites deprecated positional arguments for `StatsD.metric` calls to use keyword arguments instead.

Currently, `value` can also be provides as keyword argument rather than positional argument, which is not the preferred way of using this. The cop does not correct that (yet).
