### PR TITLE
Deprecate using StatsD metric method return values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ please at an entry to the "unreleased changes" section below.
 
 ### Unreleased changes
 
+- **DEPRECATION**: Relying on the return value of the StatsD metric methods (e.g. `StatsD.increment`)
+  is deprecated. StatsD is a fire-and-forget protocol, so your code should not depend on the return'
+  value of this method.
+
+  The documentation of the methods has been updated to reflect this change. The behavior of the
+  library is not changed for the time being, so you can safely upgrade to this version. However,
+  in a future major release, we will start to explicitly return `nil`.
+
+  This gem comes with a Rubocop rule that can help verify that your application is not relying
+  on the return value of the metric methods. To use this cop on your codebase, invoke Rubocop
+  with the following arguments:
+
+  ``` sh
+  rubocop --require /absolute/path/to/statsd-instrument/lib/statsd/instrument/rubocop/metric_return_value.rb \
+    --only StatsD/MetricReturnValue <file-name-or-pattern>
+
+  ```
+
 ## Version 2.4.0
 
 - Add `StatsD.default_tags` to specify tags that should be included in all metrics. (#159)

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -520,7 +520,7 @@ module StatsD
     metric = StatsD::Instrument::Metric.new(type: type, name: name, value: value,
       sample_rate: sample_rate, tags: tags, metadata: metadata)
     backend.collect_metric(metric)
-    metric
+    metric # TODO: return `nil` in the next major version
   end
 end
 

--- a/lib/statsd/instrument/rubocop/metric_return_value.rb
+++ b/lib/statsd/instrument/rubocop/metric_return_value.rb
@@ -1,0 +1,30 @@
+# frozen-string-literal: true
+
+module RuboCop
+  module Cop
+    module StatsD
+      # This Rubocop will check for using the return value of StatsD metric calls, which is deprecated.
+      # To run, use the following command:
+      #
+      #     rubocop --require /absolute/path/to/metric_return_value.rb --only StatsD/MetricReturnValue filename
+      #
+      # This cop cannot autocorrect offenses. In production code, StatsD should be used in a fire-and-forget
+      # fashion. This means that you shouldn't rely on the return value. If you really need to access the
+      # emitted metrics, you can look into `capture_statsd_calls`
+      class MetricReturnValue < Cop
+        MSG = 'Do not use the return value of StatsD metric methods'
+
+        STATSD_METRIC_METHODS = %i{increment gauge measure set histogram distribution key_value}
+        INVALID_PARENTS = %i{lvasgn array pair send return yield}
+
+        def on_send(node)
+          if node.receiver&.type == :const && node.receiver&.const_name == "StatsD"
+            if STATSD_METRIC_METHODS.include?(node.method_name) && node.arguments.last&.type != :block_pass
+              add_offense(node.parent) if INVALID_PARENTS.include?(node.parent&.type)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/helpers/rubocop_helper.rb
+++ b/test/helpers/rubocop_helper.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+
+module RubocopHelper
+  attr_accessor :cop
+
+  private
+
+  def assert_no_offenses(source)
+    investigate(RuboCop::ProcessedSource.new(source, 2.3, nil))
+    assert_predicate cop.offenses, :empty?, "Did not expect Rubocop to find offenses"
+  end
+
+  def assert_offense(source)
+    investigate(RuboCop::ProcessedSource.new(source, 2.3, nil))
+    refute_predicate cop.offenses, :empty?, "Expected Rubocop to find offenses"
+  end
+
+  def autocorrect_source(source)
+    RuboCop::Formatter::DisabledConfigFormatter.config_to_allow_offenses = {}
+    RuboCop::Formatter::DisabledConfigFormatter.detected_styles = {}
+    cop.instance_variable_get(:@options)[:auto_correct] = true
+
+    processed_source = RuboCop::ProcessedSource.new(source, 2.3, nil)
+    investigate(processed_source)
+
+    corrector = RuboCop::Cop::Corrector.new(processed_source.buffer, cop.corrections)
+    corrector.rewrite
+  end
+
+  def investigate(processed_source)
+    forces = RuboCop::Cop::Force.all.each_with_object([]) do |klass, instances|
+      next unless cop.join_force?(klass)
+      instances << klass.new([cop])
+    end
+
+    commissioner = RuboCop::Cop::Commissioner.new([cop], forces, raise_error: true)
+    commissioner.investigate(processed_source)
+    commissioner
+  end
+end

--- a/test/rubocop/metric_return_value_test.rb
+++ b/test/rubocop/metric_return_value_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'statsd/instrument/rubocop/metric_return_value'
+
+module Rubocop
+  class MetricReturnValueTest < Minitest::Test
+    include RubocopHelper
+
+    def setup
+      @cop = RuboCop::Cop::StatsD::MetricReturnValue.new
+    end
+
+    def test_ok_for_non_metric_method
+      assert_no_offenses('backend = StatsD.backend')
+    end
+
+    def test_ok_as_naked_statement
+      assert_no_offenses("StatsD.increment('foo')")
+      assert_no_offenses("StatsD.measure('foo') { foo }")
+    end
+
+    def test_ok_as_multiple_statement
+      assert_no_offenses <<~RUBY
+        StatsD.increment 'foo'
+        StatsD.increment 'bar'
+      RUBY
+    end
+
+    def test_ok_inside_block
+      assert_no_offenses <<~RUBY
+        block do
+          StatsD.measure
+        end
+      RUBY
+    end
+
+    def test_ok_when_passing_a_block_as_param
+      assert_no_offenses("block_result = StatsD.measure('foo', &block)")
+    end
+
+    def test_ok_when_passing_a_curly_braces_block
+      assert_no_offenses("block_result = StatsD.measure('foo') { measure_me }")
+    end
+
+    def test_ok_when_passing_do_end_block
+      assert_no_offenses <<~RUBY
+        block_result = StatsD.measure('foo') do
+          return_something_useful
+        end
+      RUBY
+    end
+
+    def test_offense_in_assignment
+      assert_offense("metric = StatsD.increment('foo')")
+    end
+
+    def test_offense_in_multi_assignment
+      assert_offense("foo, metric = bar, StatsD.increment('foo')")
+    end
+
+    def test_offense_in_hash
+      assert_offense("{ metric: StatsD.increment('foo') }")
+    end
+
+    def test_offense_in_method_call
+      assert_offense("process(StatsD.increment('foo'))")
+    end
+
+    def test_offense_when_returning
+      assert_offense("return StatsD.increment('foo')")
+    end
+
+    def test_offense_when_yielding
+      assert_offense("yield StatsD.increment('foo')")
+    end
+  end
+end

--- a/test/statsd_test.rb
+++ b/test/statsd_test.rb
@@ -15,9 +15,7 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_measure_with_explicit_value
-    result = nil
-    metric = capture_statsd_call { result = StatsD.measure('values.foobar', 42) }
-    assert_equal metric, result
+    metric = capture_statsd_call { StatsD.measure('values.foobar', 42) }
     assert_equal 'values.foobar', metric.name
     assert_equal 42, metric.value
     assert_equal :ms, metric.type
@@ -29,9 +27,7 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_measure_with_explicit_value_as_keyword_argument
-    result = nil
-    metric = capture_statsd_call { result = StatsD.measure('values.foobar', value: 42) }
-    assert_equal metric, result
+    metric = capture_statsd_call { StatsD.measure('values.foobar', value: 42) }
     assert_equal 'values.foobar', metric.name
     assert_equal 42, metric.value
     assert_equal :ms, metric.type
@@ -110,9 +106,7 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_increment
-    result = nil
-    metric = capture_statsd_call { result = StatsD.increment('values.foobar', 3) }
-    assert_equal metric, result
+    metric = capture_statsd_call { StatsD.increment('values.foobar', 3) }
     assert_equal :c, metric.type
     assert_equal 'values.foobar', metric.name
     assert_equal 3, metric.value
@@ -139,18 +133,14 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_gauge
-    result = nil
-    metric = capture_statsd_call { result = StatsD.gauge('values.foobar', 12) }
-    assert_equal metric, result
+    metric = capture_statsd_call { StatsD.gauge('values.foobar', 12) }
     assert_equal :g, metric.type
     assert_equal 'values.foobar', metric.name
     assert_equal 12, metric.value
   end
 
   def test_statsd_gauge_with_keyword_argument
-    result = nil
-    metric = capture_statsd_call { result = StatsD.gauge('values.foobar', value: 13) }
-    assert_equal metric, result
+    metric = capture_statsd_call { StatsD.gauge('values.foobar', value: 13) }
     assert_equal :g, metric.type
     assert_equal 'values.foobar', metric.name
     assert_equal 13, metric.value
@@ -161,27 +151,21 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_set
-    result = nil
-    metric = capture_statsd_call { result = StatsD.set('values.foobar', 'unique_identifier') }
-    assert_equal metric, result
+    metric = capture_statsd_call { StatsD.set('values.foobar', 'unique_identifier') }
     assert_equal :s, metric.type
     assert_equal 'values.foobar', metric.name
     assert_equal 'unique_identifier', metric.value
   end
 
   def test_statsd_histogram
-    result = nil
-    metric = capture_statsd_call { result = StatsD.histogram('values.foobar', 42) }
-    assert_equal metric, result
+    metric = capture_statsd_call { StatsD.histogram('values.foobar', 42) }
     assert_equal :h, metric.type
     assert_equal 'values.foobar', metric.name
     assert_equal 42, metric.value
   end
 
   def test_statsd_distribution
-    result = nil
-    metric = capture_statsd_call { result = StatsD.distribution('values.foobar', 42) }
-    assert_equal metric, result
+    metric = capture_statsd_call { StatsD.distribution('values.foobar', 42) }
     assert_equal :d, metric.type
     assert_equal 'values.foobar', metric.name
     assert_equal 42, metric.value
@@ -190,7 +174,8 @@ class StatsDTest < Minitest::Test
   def test_statsd_distribution_with_benchmarked_block_duration
     Process.stubs(:clock_gettime).returns(5.0, 5.0 + 1.12)
     metric = capture_statsd_call do
-      StatsD.distribution('values.foobar') { 'foo' }
+      result = StatsD.distribution('values.foobar') { 'foo' }
+      assert_equal 'foo', result
     end
     assert_equal :d, metric.type
     assert_equal 1120.0, metric.value
@@ -202,6 +187,7 @@ class StatsDTest < Minitest::Test
     metric = capture_statsd_call do
       lambda = -> do
         StatsD.distribution('values.foobar') { return 'from lambda' }
+        flunk("This code should not be reached")
       end
 
       result = lambda.call
@@ -253,9 +239,7 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_key_value
-    result = nil
-    metric = capture_statsd_call { result = StatsD.key_value('values.foobar', 42) }
-    assert_equal metric, result
+    metric = capture_statsd_call { StatsD.key_value('values.foobar', 42) }
     assert_equal :kv, metric.type
     assert_equal 'values.foobar', metric.name
     assert_equal 42, metric.value

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,4 +9,6 @@ require 'set'
 require 'logger'
 require 'statsd-instrument'
 
+require_relative 'helpers/rubocop_helper'
+
 StatsD.logger = Logger.new(File::NULL)


### PR DESCRIPTION
Dylan already updated the Yardoc to tell the user these method return `void`. This PR goes one step further.

- Document the deprecation in the CHANGELOG.
- Update our test suite to no longer rely on it.
- Add a Rubocop rule that can detect violations.