### PR TITLE
Add a custom Rubocop cop that checks for using `value` as keyword argument

### DIFF
--- a/lib/statsd/instrument/rubocop/metric_return_value.rb
+++ b/lib/statsd/instrument/rubocop/metric_return_value.rb
@@ -4,9 +4,10 @@ module RuboCop
   module Cop
     module StatsD
       # This Rubocop will check for using the return value of StatsD metric calls, which is deprecated.
-      # To run, use the following command:
+      # To check your codebase, use the following Rubocop invocation:
       #
-      #     rubocop --require /absolute/path/to/metric_return_value.rb --only StatsD/MetricReturnValue filename
+      #     rubocop --require `bundle show statsd-instrument`/lib/statsd/instrument/rubocop//metric_return_value.rb \
+      #       --only StatsD/MetricReturnValue
       #
       # This cop cannot autocorrect offenses. In production code, StatsD should be used in a fire-and-forget
       # fashion. This means that you shouldn't rely on the return value. If you really need to access the

--- a/lib/statsd/instrument/rubocop/metric_value_keyword_argument.rb
+++ b/lib/statsd/instrument/rubocop/metric_value_keyword_argument.rb
@@ -23,9 +23,13 @@ module RuboCop
         def on_send(node)
           if node.receiver&.type == :const && node.receiver&.const_name == "StatsD"
             if STATSD_METRIC_METHODS.include?(node.method_name)
-              arguments = node.arguments
-              arguments.pop if node.arguments.last.type == :block_pass
-              check_keyword_arguments_for_value_entry(node, arguments.pop) if arguments.last&.type == :hash
+              last_argument = if node.arguments.last&.type == :block_pass
+                node.arguments[node.arguments.length - 2]
+              else
+                node.arguments[node.arguments.length - 1]
+              end
+
+              check_keyword_arguments_for_value_entry(node, last_argument) if last_argument&.type == :hash
             end
           end
         end

--- a/lib/statsd/instrument/rubocop/metric_value_keyword_argument.rb
+++ b/lib/statsd/instrument/rubocop/metric_value_keyword_argument.rb
@@ -1,0 +1,42 @@
+# frozen-string-literal: true
+
+module RuboCop
+  module Cop
+    module StatsD
+      # This Rubocop will check for providing the value for a metric using a keyword argument, which is
+      # deprecated. Use the following Rubocop invocation to check your project's codebase:
+      #
+      #    rubocop --require \
+      #      `bundle show statsd-instrument`/lib/statsd/instrument/rubocop/metric_value_keyword_argument.rb \
+      #      --only StatsD/MetricValueKeywordArgument
+      #
+      # This cop will not autocorrect offenses. Most of the time, these are easy to fix by providing the
+      # value as the second argument, rather than a keyword argument.
+      #
+      # `StatsD.increment('foo', value: 3)` => `StatsD.increment('foo', 3)`
+      #
+      class MetricValueKeywordArgument < Cop
+        MSG = 'Do not use the value keyword argument, but use a positional argument'
+
+        STATSD_METRIC_METHODS = %i{increment gauge measure set histogram distribution key_value}
+
+        def on_send(node)
+          if node.receiver&.type == :const && node.receiver&.const_name == "StatsD"
+            if STATSD_METRIC_METHODS.include?(node.method_name)
+              arguments = node.arguments
+              arguments.pop if node.arguments.last.type == :block_pass
+              check_keyword_arguments_for_value_entry(node, arguments.pop) if arguments.last&.type == :hash
+            end
+          end
+        end
+
+        def check_keyword_arguments_for_value_entry(node, keyword_arguments)
+          value_pair_found = keyword_arguments.child_nodes.any? do |pair|
+            pair.child_nodes[0].type == :sym && pair.child_nodes[0].value == :value
+          end
+          add_offense(node) if value_pair_found
+        end
+      end
+    end
+  end
+end

--- a/test/deprecations_test.rb
+++ b/test/deprecations_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class DeprecationsTest < Minitest::Test
+  include StatsD::Instrument::Assertions
+
+  def test__deprecated__statsd_measure_with_explicit_value_as_keyword_argument
+    metric = capture_statsd_call { StatsD.measure('values.foobar', value: 42) }
+    assert_equal 'values.foobar', metric.name
+    assert_equal 42, metric.value
+    assert_equal :ms, metric.type
+  end
+
+  def test__deprecated__statsd_measure_with_explicit_value_keyword_and_distribution_override
+    metric = capture_statsd_call { StatsD.measure('values.foobar', value: 42, as_dist: true) }
+    assert_equal 42, metric.value
+    assert_equal :d, metric.type
+  end
+
+  def test__deprecated__statsd_increment_with_value_as_keyword_argument
+    metric = capture_statsd_call { StatsD.increment('values.foobar', value: 2) }
+    assert_equal StatsD.default_sample_rate, metric.sample_rate
+    assert_equal 2, metric.value
+  end
+
+  def test__deprecated__statsd_gauge_with_keyword_argument
+    metric = capture_statsd_call { StatsD.gauge('values.foobar', value: 13) }
+    assert_equal :g, metric.type
+    assert_equal 'values.foobar', metric.name
+    assert_equal 13, metric.value
+  end
+
+  protected
+
+  def capture_statsd_call(&block)
+    metrics = capture_statsd_calls(&block)
+    assert_equal 1, metrics.length
+    metrics.first
+  end
+end

--- a/test/matchers_test.rb
+++ b/test/matchers_test.rb
@@ -61,15 +61,15 @@ class MatchersTest < Minitest::Test
 
   def test_statsd_increment_with_value_matched_when_multiple_metrics
     assert StatsD::Instrument::Matchers::Increment.new(:c, 'counter', value: 1).matches?(lambda {
-      StatsD.increment('counter', value: 2)
-      StatsD.increment('counter', value: 1)
+      StatsD.increment('counter', 2)
+      StatsD.increment('counter', 1)
     })
   end
 
   def test_statsd_increment_with_value_not_matched_when_multiple_metrics
     refute StatsD::Instrument::Matchers::Increment.new(:c, 'counter', value: 1).matches?(lambda {
-      StatsD.increment('counter', value: 2)
-      StatsD.increment('counter', value: 3)
+      StatsD.increment('counter', 2)
+      StatsD.increment('counter', 3)
     })
   end
 
@@ -90,15 +90,15 @@ class MatchersTest < Minitest::Test
 
   def test_statsd_increment_with_times_and_value_matched
     assert StatsD::Instrument::Matchers::Increment.new(:c, 'counter', times: 2, value: 1).matches?(lambda {
-      StatsD.increment('counter', value: 1)
-      StatsD.increment('counter', value: 1)
+      StatsD.increment('counter', 1)
+      StatsD.increment('counter', 1)
     })
   end
 
   def test_statsd_increment_with_times_and_value_not_matched
     refute StatsD::Instrument::Matchers::Increment.new(:c, 'counter', times: 2, value: 1).matches?(lambda {
-      StatsD.increment('counter', value: 1)
-      StatsD.increment('counter', value: 2)
+      StatsD.increment('counter', 1)
+      StatsD.increment('counter', 2)
     })
   end
 

--- a/test/rubocop/metric_value_keyword_argument_test.rb
+++ b/test/rubocop/metric_value_keyword_argument_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'statsd/instrument/rubocop/metric_value_keyword_argument'
+
+module Rubocop
+  class MetricValueKeywordArgumentTest < Minitest::Test
+    include RubocopHelper
+
+    def setup
+      @cop = RuboCop::Cop::StatsD::MetricValueKeywordArgument.new
+    end
+
+    def test_ok_for_non_metric_method
+      assert_no_offenses("StatsD.backend('foo', value: 1)")
+    end
+
+    def test_ok_with_no_keywords
+      assert_no_offenses("StatsD.increment('foo', 1)")
+    end
+
+    def test_ok_with_no_matching_keyword
+      assert_no_offenses("StatsD.increment('foo', 1, tags: ['foo'])")
+      assert_no_offenses("StatsD.increment('foo', 1, tags: { value: 'bar' })")
+    end
+
+    def test_offense_with_value_keyword
+      assert_offense("StatsD.increment('foo', value: 1)")
+      assert_offense("StatsD.increment('foo', :value => 1)")
+      assert_offense("StatsD.increment('foo', 'value' => 1)")
+      assert_offense("StatsD.increment('foo', sample_rate: 0.1, value: 1, tags: ['foo'])")
+      assert_offense("StatsD.increment('foo', value: 1, &block)")
+    end
+  end
+end

--- a/test/rubocop/metric_value_keyword_argument_test.rb
+++ b/test/rubocop/metric_value_keyword_argument_test.rb
@@ -11,6 +11,10 @@ module Rubocop
       @cop = RuboCop::Cop::StatsD::MetricValueKeywordArgument.new
     end
 
+    def test_ok_for_method_without_arguments
+      assert_no_offenses("StatsD.increment")
+    end
+
     def test_ok_for_non_metric_method
       assert_no_offenses("StatsD.backend('foo', value: 1)")
     end

--- a/test/statsd_test.rb
+++ b/test/statsd_test.rb
@@ -26,18 +26,6 @@ class StatsDTest < Minitest::Test
     assert_equal :d, metric.type
   end
 
-  def test_statsd_measure_with_explicit_value_as_keyword_argument
-    metric = capture_statsd_call { StatsD.measure('values.foobar', value: 42) }
-    assert_equal 'values.foobar', metric.name
-    assert_equal 42, metric.value
-    assert_equal :ms, metric.type
-  end
-
-  def test_statsd_measure_with_explicit_value_keyword_and_distribution_override
-    metric = capture_statsd_call { StatsD.measure('values.foobar', value: 42, as_dist: true) }
-    assert_equal :d, metric.type
-  end
-
   def test_statsd_measure_without_value_or_block
     assert_raises(ArgumentError) { StatsD.measure('values.foobar', tags: 123) }
   end
@@ -119,12 +107,6 @@ class StatsDTest < Minitest::Test
     assert_equal 1, metric.value
   end
 
-  def test_statsd_increment_with_value_as_keyword_argument
-    metric = capture_statsd_call { StatsD.increment('values.foobar', value: 2) }
-    assert_equal StatsD.default_sample_rate, metric.sample_rate
-    assert_equal 2, metric.value
-  end
-
   def test_statsd_increment_with_multiple_arguments
     metric = capture_statsd_call { StatsD.increment('values.foobar', 12, nil, ['test']) }
     assert_equal StatsD.default_sample_rate, metric.sample_rate
@@ -137,13 +119,6 @@ class StatsDTest < Minitest::Test
     assert_equal :g, metric.type
     assert_equal 'values.foobar', metric.name
     assert_equal 12, metric.value
-  end
-
-  def test_statsd_gauge_with_keyword_argument
-    metric = capture_statsd_call { StatsD.gauge('values.foobar', value: 13) }
-    assert_equal :g, metric.type
-    assert_equal 'values.foobar', metric.name
-    assert_equal 13, metric.value
   end
 
   def test_statsd_gauge_without_value


### PR DESCRIPTION
Using `StatsD.increment 'foo, value: 3` is deprecated - you should use `StatsD.increment('foo', 3)` instead. This rule will check for violations as best as it can.

I ran this cop on Shopify/shopify, and found no violations.