### PR TITLE
Rubocop: run our own cops on this repo.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,11 @@
 inherit_from:
   - https://shopify.github.io/ruby-style-guide/rubocop.yml
 
+require:
+  - ./lib/statsd/instrument/rubocop/metric_return_value.rb
+  - ./lib/statsd/instrument/rubocop/metric_value_keyword_argument.rb
+  - ./lib/statsd/instrument/rubocop/positional_arguments.rb
+
 AllCops:
   TargetRubyVersion: 2.3
   UseCache: true
@@ -19,3 +24,14 @@ Style/ClassAndModuleChildren:
 
 Style/MethodCallWithArgsParentheses:
   Enabled: false # TODO: enable later
+
+# Enable our own cops on our own repos
+
+StatsD/MetricReturnValue:
+  Enabled: true
+
+StatsD/MetricValueKeywordArgument:
+  Enabled: true
+
+StatsD/PositionalArguments:
+  Enabled: true

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -84,6 +84,8 @@ module StatsD
       Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
     end
 
+    # rubocop:disable StatsD/PositionalArguments
+
     # Adds execution duration instrumentation to a method as a timing.
     #
     # @param method [Symbol] The name of the method to instrument.
@@ -191,6 +193,7 @@ module StatsD
           ensure
             if truthiness
               metric_name = StatsD::Instrument.generate_metric_name(name, self, *args)
+              # TODO: is this a bug, because 1 is missing?
               StatsD.increment(metric_name, *metric_options)
             end
           end
@@ -216,6 +219,8 @@ module StatsD
         end
       end
     end
+
+    # rubocop:enable StatsD/PositionalArguments
 
     # Removes StatsD counter instrumentation from a method
     # @param method [Symbol] The method to remove instrumentation from.

--- a/lib/statsd/instrument/rubocop/positional_arguments.rb
+++ b/lib/statsd/instrument/rubocop/positional_arguments.rb
@@ -9,7 +9,7 @@ module RuboCop
         STATSD_SINGLETON_METHODS = %i{increment gauge measure set histogram distribution key_value}
 
         POSITIONAL_ARGUMENT_TYPES = Set[:int, :float, :nil]
-        UNKNOWN_ARGUMENT_TYPES = Set[:send, :const, :lvar]
+        UNKNOWN_ARGUMENT_TYPES = Set[:send, :const, :lvar, :splat]
         REFUSED_ARGUMENT_TYPES = POSITIONAL_ARGUMENT_TYPES | UNKNOWN_ARGUMENT_TYPES
 
         KEYWORD_ARGUMENT_TYPES = Set[:hash]

--- a/test/deprecations_test.rb
+++ b/test/deprecations_test.rb
@@ -5,6 +5,7 @@ require 'test_helper'
 class DeprecationsTest < Minitest::Test
   include StatsD::Instrument::Assertions
 
+  # rubocop:disable StatsD/MetricValueKeywordArgument
   def test__deprecated__statsd_measure_with_explicit_value_as_keyword_argument
     metric = capture_statsd_call { StatsD.measure('values.foobar', value: 42) }
     assert_equal 'values.foobar', metric.name
@@ -30,6 +31,27 @@ class DeprecationsTest < Minitest::Test
     assert_equal 'values.foobar', metric.name
     assert_equal 13, metric.value
   end
+  # rubocop:enable StatsD/MetricValueKeywordArgument
+
+  # rubocop:disable StatsD/MetricReturnValue
+  def test__deprecated__statsd_increment_retuns_metric_instance
+    metric = StatsD.increment('key')
+    assert_kind_of StatsD::Instrument::Metric, metric
+    assert_equal 'key', metric.name
+    assert_equal :c, metric.type
+    assert_equal 1, metric.value
+  end
+  # rubocop:enable StatsD/MetricReturnValue
+
+  # rubocop:disable StatsD/PositionalArguments
+  def test__deprecated__statsd_increment_with_positional_argument_for_tags
+    metric = capture_statsd_call { StatsD.increment('values.foobar', 12, nil, ['test']) }
+    assert_equal StatsD.default_sample_rate, metric.sample_rate
+    assert_equal ['test'], metric.tags
+    assert_equal 12, metric.value
+    assert_equal StatsD.default_sample_rate, metric.sample_rate
+  end
+  # rubocop:enable StatsD/PositionalArguments
 
   protected
 

--- a/test/rubocop/positional_arguments_test.rb
+++ b/test/rubocop/positional_arguments_test.rb
@@ -40,6 +40,10 @@ module Rubocop
       RUBY
     end
 
+    def test_offense_when_using_splat
+      assert_offense("StatsD.gauge('foo', 2, *options)")
+    end
+
     def test_no_autocorrect_when_using_method_or_constant
       assert_no_autocorrect("StatsD.gauge('foo', 2, SAMPLE_RATE_CONSTANT)")
       assert_no_autocorrect("StatsD.gauge('foo', 2, method_ruturning_a_hash)")

--- a/test/statsd_test.rb
+++ b/test/statsd_test.rb
@@ -107,13 +107,6 @@ class StatsDTest < Minitest::Test
     assert_equal 1, metric.value
   end
 
-  def test_statsd_increment_with_multiple_arguments
-    metric = capture_statsd_call { StatsD.increment('values.foobar', 12, nil, ['test']) }
-    assert_equal StatsD.default_sample_rate, metric.sample_rate
-    assert_equal ['test'], metric.tags
-    assert_equal 12, metric.value
-  end
-
   def test_statsd_gauge
     metric = capture_statsd_call { StatsD.gauge('values.foobar', 12) }
     assert_equal :g, metric.type

--- a/test/udp_backend_test.rb
+++ b/test/udp_backend_test.rb
@@ -148,11 +148,19 @@ class UDPBackendTest < Minitest::Test
     StatsD.key_value('fooy', 42)
   end
 
+  # For key_value metrics (only supported by statsite), the sample rate
+  # part of the datagram format is (ab)used to be set to a timestamp instead.
+  # Changing that to `sample_rate: timestamp` does not make sense, so we
+  # disable the rubocop rule for positional arguments for now,
+  # until we figure out how we want to handle this.
+
+  # rubocop:disable StatsD/PositionalArguments
   def test_supports_key_value_with_timestamp_on_statsite
     @backend.implementation = :statsite
     @backend.expects(:write_packet).with("fooy:42|kv|@123456\n")
     StatsD.key_value('fooy', 42, 123456)
   end
+  # rubocop:enable StatsD/PositionalArguments
 
   def test_warn_when_using_key_value_and_not_on_statsite
     @backend.implementation = :other


### PR DESCRIPTION
We have some nice Rubocop rules. We should make sure our codebase conforms. By doing so, I already found some interesting things:

- `StatsD.key_value`'s third argument is secretly actually a timestamp, not a sample rate. So changing this to `sample_rate: timestamp` does not make sense. We probably should figure out how we want to handle this. The README doesn't mention this at all (https://github.com/statsite/statsite), so maybe we should simply :fire: this?

- Our metaprogramming methods (`stats_count` and friends) still rely on positional arguments. I am pretty sure I also found a bug (a missing value argument). How do we want to deal with this? I am not a big fan of these methods, but we cannot really get rid of them. 