### PR TITLE
Add a Strict monkeypatch to find deprecated behavior

### DIFF
--- a/lib/statsd/instrument/strict.rb
+++ b/lib/statsd/instrument/strict.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'statsd-instrument' unless Object.const_defined?(:StatsD)
+
+module StatsD
+  module Instrument
+    UNSPECIFIED = Object.new.freeze
+    private_constant :UNSPECIFIED
+
+    # The Strict monkeypatch can be loaded to see if you're using the StatsD library in
+    # a deprecated way.
+    #
+    # - The metric methods are not retuning a Metric instance.
+    # - Only accept keyword arguments for tags and sample_rate, rather than position arguments.
+    # - Only accept a position argument for value, rather than a keyword argument.
+    # - The provided arguments have the right type.
+    #
+    # You can enable thois monkeypatch by changing your Gemfile as follows:
+    #
+    #     gem 'statsd-instrument', require: 'statsd/instrument/strict'
+    #
+    # By doing this as part of your QA/CI, you can find where you are still using deprecated patterns,
+    # and fix them before the deprecated behavior is removed in the next major version.
+    #
+    # This monkeypatch is not meant to be used in production.
+    module Strict
+      def increment(key, value = 1, sample_rate: nil, tags: nil, prefix: StatsD.prefix, no_prefix: false)
+        raise ArgumentError, "StatsD.increment does not accept a block" if block_given?
+        raise ArgumentError, "The value argument should be an integer, got #{value.inspect}" unless value.is_a?(Numeric)
+        check_tags_and_sample_rate(sample_rate, tags)
+
+        super
+      end
+
+      def gauge(key, value, sample_rate: nil, tags: nil, prefix: StatsD.prefix, no_prefix: false)
+        raise ArgumentError, "StatsD.increment does not accept a block" if block_given?
+        raise ArgumentError, "The value argument should be an integer, got #{value.inspect}" unless value.is_a?(Numeric)
+        check_tags_and_sample_rate(sample_rate, tags)
+
+        super
+      end
+
+      def histogram(key, value, sample_rate: nil, tags: nil, prefix: StatsD.prefix, no_prefix: false)
+        raise ArgumentError, "StatsD.increment does not accept a block" if block_given?
+        raise ArgumentError, "The value argument should be an integer, got #{value.inspect}" unless value.is_a?(Numeric)
+        check_tags_and_sample_rate(sample_rate, tags)
+
+        super
+      end
+
+      def set(key, value, sample_rate: nil, tags: nil, prefix: StatsD.prefix, no_prefix: false)
+        raise ArgumentError, "StatsD.set does not accept a block" if block_given?
+        check_tags_and_sample_rate(sample_rate, tags)
+
+        super
+      end
+
+      def measure(key, value = UNSPECIFIED, sample_rate: nil, tags: nil,
+        prefix: StatsD.prefix, no_prefix: false, as_dist: false, &block)
+
+        check_block_or_numeric_value(value, &block)
+        check_tags_and_sample_rate(sample_rate, tags)
+
+        super
+      end
+
+      def distribution(key, value = UNSPECIFIED, sample_rate: nil, tags: nil,
+        prefix: StatsD.prefix, no_prefix: false, &block)
+
+        check_block_or_numeric_value(value, &block)
+        check_tags_and_sample_rate(sample_rate, tags)
+
+        super
+      end
+
+      protected
+
+      def check_block_or_numeric_value(value)
+        if block_given?
+          raise ArgumentError, "The value argument should not be set when providing a block" unless value == UNSPECIFIED
+        else
+          raise ArgumentError, "The value argument should be a number, got #{value.inspect}" unless value.is_a?(Numeric)
+        end
+      end
+
+      def check_tags_and_sample_rate(sample_rate, tags)
+        unless sample_rate.nil? || sample_rate.is_a?(Numeric)
+          raise ArgumentError, "The sample_rate argument should be a number, got #{sample_rate}"
+        end
+        unless tags.nil? || tags.is_a?(Hash) || tags.is_a?(Array)
+          raise ArgumentError, "The tags argument should be a hash or an array, got #{tags.inspect}"
+        end
+      end
+
+      def collect_metric(type, name, value, sample_rate:, tags: nil, prefix:, metadata: nil)
+        super
+        nil # We explicitly discard the return value, so people cannot depend on it.
+      end
+    end
+  end
+end
+
+StatsD.singleton_class.prepend(StatsD::Instrument::Strict)

--- a/lib/statsd/instrument/strict.rb
+++ b/lib/statsd/instrument/strict.rb
@@ -73,7 +73,7 @@ module StatsD
         super
       end
 
-      protected
+      private
 
       def check_block_or_numeric_value(value)
         if block_given?

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -271,6 +271,7 @@ class AssertionsTest < Minitest::Test
   end
 
   def test_assert_statsd_call_with_wrong_sample_rate_type
+    skip("In Strict mode, the StatsD.increment call will raise") if StatsD::Instrument.strict_mode_enabled?
     assert_assertion_triggered "Unexpected sample rate type for metric counter, must be numeric" do
       @test_case.assert_statsd_increment('counter', tags: ['a', 'b']) do
         StatsD.increment('counter', sample_rate: 'abc', tags: ['a', 'b'])

--- a/test/deprecations_test.rb
+++ b/test/deprecations_test.rb
@@ -11,6 +11,10 @@ class DeprecationsTest < Minitest::Test
 
   include StatsD::Instrument::Assertions
 
+  def setup
+    skip("Deprecation are not supported in strict mode") if StatsD::Instrument.strict_mode_enabled?
+  end
+
   # rubocop:disable StatsD/MetricValueKeywordArgument
   def test__deprecated__statsd_measure_with_explicit_value_as_keyword_argument
     metric = capture_statsd_call { StatsD.measure('values.foobar', value: 42) }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,4 +11,13 @@ require 'statsd-instrument'
 
 require_relative 'helpers/rubocop_helper'
 
+require 'statsd/instrument/strict' if ENV['STATSD_STRICT_MODE']
+
+module StatsD::Instrument
+  def self.strict_mode_enabled?
+    StatsD::Instrument.const_defined?(:Strict) &&
+      StatsD.singleton_class.ancestors.include?(StatsD::Instrument::Strict)
+  end
+end
+
 StatsD.logger = Logger.new(File::NULL)


### PR DESCRIPTION
Adds a `Strict` monkeypatch that strictly validates the arguments provided to StatsD methods for correct usage. You can enable this in CI of a project by adding `require 'statsd/instrument/strict'`, to fin deprecated behavior that may no longer work in the future.