### PR TITLE
Add a cop to find splatting arguments in StatsD method calls.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ require:
   - ./lib/statsd/instrument/rubocop/metric_return_value.rb
   - ./lib/statsd/instrument/rubocop/metric_value_keyword_argument.rb
   - ./lib/statsd/instrument/rubocop/positional_arguments.rb
+  - ./lib/statsd/instrument/rubocop/splat_arguments.rb
 
 AllCops:
   TargetRubyVersion: 2.3
@@ -34,4 +35,7 @@ StatsD/MetricValueKeywordArgument:
   Enabled: true
 
 StatsD/PositionalArguments:
+  Enabled: true
+
+StatsD/SplatArguments:
   Enabled: true

--- a/lib/statsd/instrument/rubocop/splat_arguments.rb
+++ b/lib/statsd/instrument/rubocop/splat_arguments.rb
@@ -1,0 +1,37 @@
+# frozen-string-literal: true
+
+module RuboCop
+  module Cop
+    module StatsD
+      # This Rubocop will check for using splat arguments (*args) in StatsD metric calls. To run
+      # this rule on your codebase, invoke Rubocop this way:
+      #
+      #    rubocop --require \
+      #      `bundle show statsd-instrument`/lib/statsd/instrument/rubocop/splat_arguments.rb \
+      #      --only StatsD/SplatArguments
+      #
+      # This cop will not autocorrect offenses.
+      class SplatArguments < Cop
+        MSG = 'Do not use splat arguments in StatsD metric calls'
+
+        STATSD_METRIC_METHODS = %i{increment gauge measure set histogram distribution key_value}
+
+        def on_send(node)
+          if node.receiver&.type == :const && node.receiver&.const_name == "StatsD"
+            if STATSD_METRIC_METHODS.include?(node.method_name)
+              check_for_splat_arguments(node)
+            end
+          end
+        end
+
+        private
+
+        def check_for_splat_arguments(node)
+          if node.arguments.any? { |arg| arg.type == :splat }
+            add_offense(node)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/rubocop/splat_arguments_test.rb
+++ b/test/rubocop/splat_arguments_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'statsd/instrument/rubocop/splat_arguments'
+
+module Rubocop
+  class SplatArgumentsTest < Minitest::Test
+    include RubocopHelper
+
+    def setup
+      @cop = RuboCop::Cop::StatsD::SplatArguments.new
+    end
+
+    def test_no_offenses
+      assert_no_offenses("StatsD.increment 'foo'")
+      assert_no_offenses("StatsD.gauge('foo', 2, tags: 'foo')")
+      assert_no_offenses("StatsD.measure('foo', 2, **kwargs)")
+      assert_no_offenses("StatsD.measure('foo', 2, **kwargs) { }")
+    end
+
+    def test_offenses
+      assert_offense("StatsD.increment(*increment_arguments)")
+      assert_offense("StatsD.gauge('foo', 2, *options)")
+      assert_offense("StatsD.measure('foo', 2, *options, &block)")
+    end
+  end
+end


### PR DESCRIPTION
This is not necessarily bad or a bug, but it very unlikely to be useful. Most occurrences are probably related to the past when using position arguments was required.

I’ve used this cop to find some deprecated uses of the StatsD API in the Shopify codebase.