### PR TITLE
Strict module for StatsD meta-programming methods

### DIFF
--- a/lib/statsd/instrument/strict.rb
+++ b/lib/statsd/instrument/strict.rb
@@ -97,7 +97,49 @@ module StatsD
         nil # We explicitly discard the return value, so people cannot depend on it.
       end
     end
+
+    module StrictMetaprogramming
+      def statsd_measure(method, name, sample_rate: nil, tags: nil,
+        prefix: StatsD.prefix, no_prefix: false, as_dist: false)
+
+        check_method_and_metric_name(method, name)
+        super
+      end
+
+      def statsd_distribution(method, name, sample_rate: nil, tags: nil, prefix: StatsD.prefix, no_prefix: false)
+        check_method_and_metric_name(method, name)
+        super
+      end
+
+      def statsd_count_success(method, name, sample_rate: nil, tags: nil, prefix: StatsD.prefix, no_prefix: false)
+        check_method_and_metric_name(method, name)
+        super
+      end
+
+      def statsd_count_if(method, name, sample_rate: nil, tags: nil, prefix: StatsD.prefix, no_prefix: false)
+        check_method_and_metric_name(method, name)
+        super
+      end
+
+      def statsd_count(method, name, sample_rate: nil, tags: nil, prefix: StatsD.prefix, no_prefix: false)
+        check_method_and_metric_name(method, name)
+        super
+      end
+
+      private
+
+      def check_method_and_metric_name(method, metric_name)
+        unless method.is_a?(Symbol)
+          raise ArgumentError, "The method name should be provided as symbol, got #{method.inspect}"
+        end
+
+        unless metric_name.is_a?(String) || metric_name.is_a?(Proc)
+          raise ArgumentError, "The metric name should be a proc or string, got #{metric_name.inspect}"
+        end
+      end
+    end
   end
 end
 
 StatsD.singleton_class.prepend(StatsD::Instrument::Strict)
+StatsD::Instrument.prepend(StatsD::Instrument::StrictMetaprogramming)

--- a/test/deprecations_test.rb
+++ b/test/deprecations_test.rb
@@ -3,10 +3,12 @@
 require 'test_helper'
 
 class DeprecationsTest < Minitest::Test
-  class InstrumentedClass
-    extend StatsD::Instrument
-    def foo; end
-    statsd_count :foo, 'metric', 0.5, ['tag']
+  unless StatsD::Instrument.strict_mode_enabled?
+    class InstrumentedClass
+      extend StatsD::Instrument
+      def foo; end
+      statsd_count :foo, 'metric', 0.5, ['tag']
+    end
   end
 
   include StatsD::Instrument::Assertions


### PR DESCRIPTION
Followup to #183.

This adds a strict definition of the metaprogramming methods as part of strict mode. This can be used to find deprecated patterns in codebases that use this library.