### PR TITLE
StatsD/MetaprogrammingPositionalArguments cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ require:
   - ./lib/statsd/instrument/rubocop/metric_value_keyword_argument.rb
   - ./lib/statsd/instrument/rubocop/positional_arguments.rb
   - ./lib/statsd/instrument/rubocop/splat_arguments.rb
+  - ./lib/statsd/instrument/rubocop/metaprogramming_positional_arguments.rb
 
 AllCops:
   TargetRubyVersion: 2.3
@@ -38,4 +39,7 @@ StatsD/PositionalArguments:
   Enabled: true
 
 StatsD/SplatArguments:
+  Enabled: true
+
+StatsD/MetaprogrammingPositionalArguments:
   Enabled: true

--- a/lib/statsd/instrument/rubocop/metaprogramming_positional_arguments.rb
+++ b/lib/statsd/instrument/rubocop/metaprogramming_positional_arguments.rb
@@ -1,0 +1,46 @@
+# frozen-string-literal: true
+
+module RuboCop
+  module Cop
+    module StatsD
+      # This Rubocop will check for using the metaprogramming macros for positional
+      # argument usage, which is deprecated. These macros include `statd_count_if`,
+      # `statsd_measure`, etc.
+      #
+      # Use the following Rubocop invocation to check your project's codebase:
+      #
+      #     rubocop --only StatsD/MetaprogrammingPositionalArguments
+      #       -r `bundle show statsd-instrument`/lib/statsd/instrument/rubocop/metaprogramming_positional_arguments.rb
+      #
+      #
+      # This cop will not autocorrect the offenses it finds, but generally the fixes are easy to fix
+      class MetaprogrammingPositionalArguments < Cop
+        MSG = 'Use keyword arguments for StatsD metaprogramming macros'
+
+        METAPROGRAMMING_METHODS = %i{
+          statsd_measure
+          statsd_distribution
+          statsd_count_success
+          statsd_count_if
+          statsd_count
+        }
+
+        def on_send(node)
+          if METAPROGRAMMING_METHODS.include?(node.method_name)
+            arguments = node.arguments.dup
+            arguments.shift # method
+            arguments.shift # metric
+            arguments.pop if arguments.last&.type == :block_pass
+            case arguments.length
+            when 0
+            when 1
+              add_offense(node) if arguments.first.type != :hash
+            else
+              add_offense(node)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/statsd/instrument/rubocop/metric_return_value.rb
+++ b/lib/statsd/instrument/rubocop/metric_return_value.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This Rubocop will check for using the return value of StatsD metric calls, which is deprecated.
       # To check your codebase, use the following Rubocop invocation:
       #
-      #     rubocop --require `bundle show statsd-instrument`/lib/statsd/instrument/rubocop//metric_return_value.rb \
+      #     rubocop --require `bundle show statsd-instrument`/lib/statsd/instrument/rubocop/metric_return_value.rb \
       #       --only StatsD/MetricReturnValue
       #
       # This cop cannot autocorrect offenses. In production code, StatsD should be used in a fire-and-forget

--- a/lib/statsd/instrument/rubocop/metric_value_keyword_argument.rb
+++ b/lib/statsd/instrument/rubocop/metric_value_keyword_argument.rb
@@ -14,7 +14,6 @@ module RuboCop
       # value as the second argument, rather than a keyword argument.
       #
       # `StatsD.increment('foo', value: 3)` => `StatsD.increment('foo', 3)`
-      #
       class MetricValueKeywordArgument < Cop
         MSG = 'Do not use the value keyword argument, but use a positional argument'
 

--- a/lib/statsd/instrument/rubocop/positional_arguments.rb
+++ b/lib/statsd/instrument/rubocop/positional_arguments.rb
@@ -3,6 +3,15 @@
 module RuboCop
   module Cop
     module StatsD
+      # This Rubocop will check for using the StatsD metric methods (e.g. `StatsD.instrument`)
+      # for positional argument usage, which is deprecated.
+      #
+      # Use the following Rubocop invocation to check your project's codebase:
+      #
+      #     rubocop --require `bundle show statsd-instrument`/lib/statsd/instrument/rubocop/positional_arguments.rb \
+      #       --only StatsD/PositionalArguments
+      #
+      # This cop can autocorrect some offenses it finds, but not all of them.
       class PositionalArguments < Cop
         MSG = 'Use keyword arguments for StatsD calls'
 

--- a/test/deprecations_test.rb
+++ b/test/deprecations_test.rb
@@ -4,11 +4,13 @@ require 'test_helper'
 
 class DeprecationsTest < Minitest::Test
   unless StatsD::Instrument.strict_mode_enabled?
+    # rubocop:disable StatsD/MetaprogrammingPositionalArguments
     class InstrumentedClass
       extend StatsD::Instrument
       def foo; end
       statsd_count :foo, 'metric', 0.5, ['tag']
     end
+    # rubocop:enable StatsD/MetaprogrammingPositionalArguments
   end
 
   include StatsD::Instrument::Assertions

--- a/test/rubocop/metaprogramming_positional_arguments_test.rb
+++ b/test/rubocop/metaprogramming_positional_arguments_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'statsd/instrument/rubocop/metaprogramming_positional_arguments'
+
+module Rubocop
+  class MetaprogrammingPositionalArgumentsTest < Minitest::Test
+    include RubocopHelper
+
+    def setup
+      @cop = RuboCop::Cop::StatsD::MetaprogrammingPositionalArguments.new
+    end
+
+    def test_ok_with_two_arguments
+      assert_no_offenses("ClassName.statsd_count_if(:method, 'metric') { foo }")
+      assert_no_offenses("ClassName.statsd_measure :method, 'metric'")
+      assert_no_offenses(<<~RUBY)
+        class Foo
+          statsd_count :method, 'metric'
+        end
+      RUBY
+    end
+
+    def test_ok_with_keyword_arguments_and_blocks
+      assert_no_offenses("ClassName.statsd_measure :method, 'metric', foo: 'bar'")
+      assert_no_offenses("ClassName.statsd_count_success(:method, 'metric', **kwargs)")
+      assert_no_offenses("ClassName.statsd_measure(:method, 'metric', foo: 'bar', &block)")
+      assert_no_offenses(<<~RUBY)
+        class Foo
+          statsd_count_if(:method, 'metric', foo: 'bar', baz: 'quc') do |result|
+            result == 'ok'
+          end
+        end
+      RUBY
+    end
+
+    def test_offense_with_positional_arguments
+      assert_offense("ClassName.statsd_measure(:method, 'metric', 1)")
+      assert_offense("ClassName.statsd_measure(:method, 'metric', 1, ['tag'])")
+      assert_offense("ClassName.statsd_measure(:method, 'metric', 1, tag: 'value')")
+    end
+
+    def test_offense_with_splat
+      assert_offense("ClassName.statsd_measure(:method, 'metric', *options)")
+    end
+
+    def test_offense_with_constant_or_method_as_third_argument
+      assert_offense("ClassName.statsd_measure(:method, 'metric', SAMPLE_RATE_CONSTANT)")
+      assert_offense("ClassName.statsd_measure(:method, 'metric', method_returning_a_hash)")
+    end
+  end
+end

--- a/test/rubocop/metaprogramming_positional_arguments_test.rb
+++ b/test/rubocop/metaprogramming_positional_arguments_test.rb
@@ -38,6 +38,12 @@ module Rubocop
       assert_offense("ClassName.statsd_measure(:method, 'metric', 1)")
       assert_offense("ClassName.statsd_measure(:method, 'metric', 1, ['tag'])")
       assert_offense("ClassName.statsd_measure(:method, 'metric', 1, tag: 'value')")
+      assert_offense(<<~RUBY)
+        class Foo
+          extend StatsD::Instrument
+          statsd_measure(:method, 'metric', 1)
+        end
+      RUBY
     end
 
     def test_offense_with_splat


### PR DESCRIPTION
This cop will check for basic cases of deprecated use of positional arguments, like `statsd_measure` and `statsd_count_if`.