### PR TITLE
Improve documentation on the StatsD metric methods

### DIFF
--- a/lib/statsd/instrument/client.rb
+++ b/lib/statsd/instrument/client.rb
@@ -28,6 +28,8 @@ class StatsD::Instrument::Client
     @default_sample_rate = default_sample_rate
   end
 
+  # @!group Metric Methods
+
   # Emits a counter metric.
   #
   # You should use a counter metric to count the frequency of something happening. As a
@@ -59,7 +61,7 @@ class StatsD::Instrument::Client
   #   - When set to `1`, every metric will be emitted.
   #   - If this parameter is not set, the default sample rate for this client will be used.
   #
-  # @param [Hash, Array] tags (default: nil)
+  # @param [Hash<Symbol, String>, Array<String>] tags (default: nil)
   # @return [void]
   def increment(name, value = 1, sample_rate: nil, tags: nil)
     sample_rate ||= @default_sample_rate
@@ -113,7 +115,11 @@ class StatsD::Instrument::Client
   end
 
   # Emits a distribution metric, which builds a histogram of the reported
-  # values
+  # values.
+  #
+  # @note The distribution metric type is not available on all implementations.
+  #   A `NotImplemetedError` will be raised if you call this method, but
+  #   the active implementation does not support it.
   #
   # @param name (see #increment)
   # @param [Numeric] value The value to include in the distribution histogram.
@@ -126,7 +132,11 @@ class StatsD::Instrument::Client
     emit(datagram_builder.d(name, value, sample_rate, tags))
   end
 
-  # Emits a histogram metric, which counts distinct values.
+  # Emits a histogram metric, which builds a histogram of the reported values.
+  #
+  # @note The histogram metric type is not available on all implementations.
+  #   A `NotImplemetedError` will be raised if you call this method, but
+  #   the active implementation does not support it.
   #
   # @param name (see #increment)
   # @param [Numeric] value The value to include in the histogram.
@@ -138,6 +148,8 @@ class StatsD::Instrument::Client
     return unless sample?(sample_rate)
     emit(datagram_builder.h(name, value, sample_rate, tags))
   end
+
+  # @!endgroup
 
   # Instantiates a new StatsD client that uses the settings of the current client,
   # except for the provided overrides.


### PR DESCRIPTION
The method signature is pretty awful because of backwards compatibility, and we don't really want to expose the deprecated options to the end user. By using the `@!method` macro, we can override the signature from Yard's point of view.

I have decided not to document a couple of keyword arguments because I may want to drop support of these in the new version:
- `prefix`
- `no_prefix`
- `as_dist` (I think this might be an internal only thing)

It turns out that many of the arguments are for the datadog-only `event` and `service_check` metrics are not actually used. To start, I have decided to simply hide all of them. In the new implementation, we should remove them from the method signature.

I've also added some examples, and properly documented the methods that optionally accept a block (`measure` and `distribution`)