### PR TITLE
Allow using a different Datagram parser class when capturing datagrams

### DIFF
--- a/lib/statsd/instrument/capture_sink.rb
+++ b/lib/statsd/instrument/capture_sink.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
 class StatsD::Instrument::CaptureSink
-  attr_reader :parent, :datagrams
+  attr_reader :parent, :datagrams, :datagram_class
 
-  def initialize(parent:)
+  def initialize(parent:, datagram_class: StatsD::Instrument::Datagram)
     @parent = parent
+    @datagram_class = datagram_class
     @datagrams = []
   end
 
   def <<(datagram)
-    @datagrams << StatsD::Instrument::Datagram.new(datagram)
+    @datagrams << datagram_class.new(datagram)
     parent << datagram
     self
   end

--- a/lib/statsd/instrument/client.rb
+++ b/lib/statsd/instrument/client.rb
@@ -189,7 +189,7 @@ class StatsD::Instrument::Client
   end
 
   def capture_sink
-    StatsD::Instrument::CaptureSink.new(parent: @sink)
+    StatsD::Instrument::CaptureSink.new(parent: @sink, datagram_class: datagram_builder.datagram_class)
   end
 
   def with_capture_sink(capture_sink)

--- a/lib/statsd/instrument/datagram.rb
+++ b/lib/statsd/instrument/datagram.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# The Datagram class parses and inspects a StatsD datagrans
 class StatsD::Instrument::Datagram
   attr_reader :source
 
@@ -7,6 +8,7 @@ class StatsD::Instrument::Datagram
     @source = source
   end
 
+  # @return [Float] The sample rate at which this datagram was emitted, between 0 and 1.
   def sample_rate
     parsed_datagram[:sample_rate] ? Float(parsed_datagram[:sample_rate]) : 1.0
   end
@@ -24,12 +26,29 @@ class StatsD::Instrument::Datagram
   end
 
   def tags
-    parsed_datagram[:tags] ? parsed_datagram[:tags].split(',') : nil
+    @tags ||= parsed_datagram[:tags] ? parsed_datagram[:tags].split(',') : nil
   end
 
   def inspect
     "#<#{self.class.name}:\"#{@source}\">"
   end
+
+  def hash
+    source.hash
+  end
+
+  def eql?(other)
+    case other
+    when StatsD::Instrument::Datagram
+      source == other.source
+    when String
+      source == other
+    else
+      false
+    end
+  end
+
+  alias_method :==, :eql?
 
   private
 

--- a/lib/statsd/instrument/datagram_builder.rb
+++ b/lib/statsd/instrument/datagram_builder.rb
@@ -54,6 +54,10 @@ class StatsD::Instrument::DatagramBuilder
     generate_generic_datagram(name, value, 'kv', sample_rate, tags)
   end
 
+  def datagram_class
+    StatsD::Instrument::Datagram
+  end
+
   protected
 
   attr_reader :prefix, :default_tags

--- a/test/capture_sink_test.rb
+++ b/test/capture_sink_test.rb
@@ -33,4 +33,12 @@ class CaptureSinktest < Minitest::Test
     assert_equal ['foo:1|c', 'bar:1|c'], outer_capture_sink.datagrams.map(&:source)
     assert_equal ['bar:1|c'], inner_capture_sink.datagrams.map(&:source)
   end
+
+  def test_using_a_different_datagram_class
+    sink = StatsD::Instrument::CaptureSink.new(parent: [], datagram_class: String)
+    sink << 'foo:1|c'
+
+    assert sink.datagrams.all? { |datagram| datagram.is_a?(String) }
+    assert_equal ['foo:1|c'], sink.datagrams
+  end
 end


### PR DESCRIPTION
This will come in useful for implementations like Datadog that allow for extensions on the protocol.