### PR TITLE
Refactor assert_statsd_calls to flunk if an exception occurs inside the block

### DIFF
--- a/lib/statsd/instrument/assertions.rb
+++ b/lib/statsd/instrument/assertions.rb
@@ -43,78 +43,69 @@ module StatsD::Instrument::Assertions
 
     capture_backend = StatsD::Instrument::Backends::CaptureBackend.new
     with_capture_backend(capture_backend) do
-      exception_occurred = nil
       begin
         block.call
       rescue => exception
-        exception_occurred = exception
-        raise
-      ensure
-        metrics = capture_backend.collected_metrics
-        matched_expected_metrics = []
-        expected_metrics.each do |expected_metric|
-          expected_metric_times = expected_metric.times
-          expected_metric_times_remaining = expected_metric.times
-          filtered_metrics = metrics.select { |m| m.type == expected_metric.type && m.name == expected_metric.name }
+        flunk(<<~MESSAGE)
+          An exception occurred in the block provided to the StatsD assertion.
 
-          if filtered_metrics.empty?
-            flunk_with_exception_info(exception_occurred, "No StatsD calls for metric #{expected_metric.name} " \
-              "of type #{expected_metric.type} were made.")
-          end
+          #{exception.class.name}: #{exception.message}
+          \t#{exception.backtrace.join("\n\t")}
 
-          filtered_metrics.each do |metric|
-            next unless expected_metric.matches(metric)
-
-            assert(within_numeric_range?(metric.sample_rate),
-              "Unexpected sample rate type for metric #{metric.name}, must be numeric")
-
-            if expected_metric_times_remaining == 0
-              flunk_with_exception_info(exception_occurred, "Unexpected StatsD call; number of times this metric " \
-                "was expected exceeded: #{expected_metric.inspect}")
-            end
-
-            expected_metric_times_remaining -= 1
-            metrics.delete(metric)
-            if expected_metric_times_remaining == 0
-              matched_expected_metrics << expected_metric
-            end
-          end
-
-          next if expected_metric_times_remaining == 0
-
-          msg = +"Metric expected #{expected_metric_times} times but seen " \
-            "#{expected_metric_times - expected_metric_times_remaining} " \
-            "times: #{expected_metric.inspect}."
-          msg << "\nCaptured metrics with the same key: #{filtered_metrics}" if filtered_metrics.any?
-          flunk_with_exception_info(exception_occurred, msg)
-        end
-        expected_metrics -= matched_expected_metrics
-
-        unless expected_metrics.empty?
-          flunk_with_exception_info(exception_occurred, "Unexpected StatsD calls; the following metric expectations " \
-            "were not satisfied: #{expected_metrics.inspect}")
-        end
-
-        pass
+          If this exception is expected, make sure to handle it using `assert_raises`
+          inside the block provided to the StatsD assertion.
+        MESSAGE
       end
+
+      metrics = capture_backend.collected_metrics
+      matched_expected_metrics = []
+      expected_metrics.each do |expected_metric|
+        expected_metric_times = expected_metric.times
+        expected_metric_times_remaining = expected_metric.times
+        filtered_metrics = metrics.select { |m| m.type == expected_metric.type && m.name == expected_metric.name }
+
+        if filtered_metrics.empty?
+          flunk("No StatsD calls for metric #{expected_metric.name} of type #{expected_metric.type} were made.")
+        end
+
+        filtered_metrics.each do |metric|
+          next unless expected_metric.matches(metric)
+
+          assert(within_numeric_range?(metric.sample_rate),
+            "Unexpected sample rate type for metric #{metric.name}, must be numeric")
+
+          if expected_metric_times_remaining == 0
+            flunk("Unexpected StatsD call; number of times this metric " \
+              "was expected exceeded: #{expected_metric.inspect}")
+          end
+
+          expected_metric_times_remaining -= 1
+          metrics.delete(metric)
+          if expected_metric_times_remaining == 0
+            matched_expected_metrics << expected_metric
+          end
+        end
+
+        next if expected_metric_times_remaining == 0
+
+        msg = +"Metric expected #{expected_metric_times} times but seen " \
+          "#{expected_metric_times - expected_metric_times_remaining} " \
+          "times: #{expected_metric.inspect}."
+        msg << "\nCaptured metrics with the same key: #{filtered_metrics}" if filtered_metrics.any?
+        flunk(msg)
+      end
+      expected_metrics -= matched_expected_metrics
+
+      unless expected_metrics.empty?
+        flunk("Unexpected StatsD calls; the following metric expectations " \
+          "were not satisfied: #{expected_metrics.inspect}")
+      end
+
+      pass
     end
   end
 
   private
-
-  def flunk_with_exception_info(exception, message)
-    if exception
-      flunk(<<~EXCEPTION)
-        #{message}
-
-        This could be due to the exception that occurred inside the block:
-        #{exception.class.name}: #{exception.message}
-        \t#{exception.backtrace.join("\n\t")}
-      EXCEPTION
-    else
-      flunk(message)
-    end
-  end
 
   def assert_statsd_call(metric_type, metric_name, options = {}, &block)
     options[:name] = metric_name

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -10,141 +10,120 @@ class AssertionsTest < Minitest::Test
   end
 
   def test_assert_no_statsd_calls
-    assert_no_assertion_triggered do
-      @test_case.assert_no_statsd_calls('counter') do
-        # noop
-      end
+    @test_case.assert_no_statsd_calls('counter') do
+      # noop
     end
 
-    assert_no_assertion_triggered do
-      @test_case.assert_no_statsd_calls('counter') do
-        StatsD.increment('other')
-      end
+    @test_case.assert_no_statsd_calls('counter') do
+      StatsD.increment('other')
     end
 
-    assert_assertion_triggered("No StatsD calls for metric counter expected.") do
+    assertion = assert_raises(Minitest::Assertion) do
       @test_case.assert_no_statsd_calls('counter') do
         StatsD.increment('counter')
       end
     end
+    assert_equal assertion.message, "No StatsD calls for metric counter expected."
 
-    assert_assertion_triggered("No StatsD calls for metric other expected.") do
+    assertion = assert_raises(Minitest::Assertion) do
       @test_case.assert_no_statsd_calls do
         StatsD.increment('other')
       end
     end
+    assert_equal assertion.message, "No StatsD calls for metric other expected."
 
-    assert_assertion_triggered("No StatsD calls for metric other, another expected.") do
+    assertion = assert_raises(Minitest::Assertion) do
       @test_case.assert_no_statsd_calls do
         StatsD.increment('other')
         StatsD.increment('another')
       end
     end
+    assert_equal assertion.message, "No StatsD calls for metric other, another expected."
   end
 
   def test_assert_statsd_call
-    assert_no_assertion_triggered do
-      @test_case.assert_statsd_increment('counter') do
-        StatsD.increment('counter')
-      end
+    @test_case.assert_statsd_increment('counter') do
+      StatsD.increment('counter')
     end
 
-    assert_no_assertion_triggered do
-      @test_case.assert_statsd_increment('counter') do
-        StatsD.increment('counter')
-        StatsD.increment('other')
-      end
+    @test_case.assert_statsd_increment('counter') do
+      StatsD.increment('counter')
+      StatsD.increment('other')
     end
 
-    assert_assertion_triggered do
+    assert_raises(Minitest::Assertion) do
       @test_case.assert_statsd_increment('counter') do
         StatsD.increment('other')
       end
     end
 
-    assert_assertion_triggered do
+    assert_raises(Minitest::Assertion) do
       @test_case.assert_statsd_increment('counter') do
         StatsD.gauge('counter', 42)
       end
     end
 
-    assert_assertion_triggered do
+    assert_raises(Minitest::Assertion) do
       @test_case.assert_statsd_increment('counter') do
         StatsD.increment('counter')
         StatsD.increment('counter')
       end
     end
 
-    assert_no_assertion_triggered do
-      @test_case.assert_statsd_increment('counter', times: 2) do
-        StatsD.increment('counter')
-        StatsD.increment('counter')
-      end
+    @test_case.assert_statsd_increment('counter', times: 2) do
+      StatsD.increment('counter')
+      StatsD.increment('counter')
     end
 
-    assert_no_assertion_triggered do
-      @test_case.assert_statsd_increment('counter', times: 2, tags: ['foo:1']) do
-        StatsD.increment('counter', tags: { foo: 1 })
-        StatsD.increment('counter', tags: { foo: 1 })
-      end
+    @test_case.assert_statsd_increment('counter', times: 2, tags: ['foo:1']) do
+      StatsD.increment('counter', tags: { foo: 1 })
+      StatsD.increment('counter', tags: { foo: 1 })
     end
 
-    assert_assertion_triggered do
+    assert_raises(Minitest::Assertion) do
       @test_case.assert_statsd_increment('counter', times: 2, tags: ['foo:1']) do
         StatsD.increment('counter', tags: { foo: 1 })
         StatsD.increment('counter', tags: { foo: 2 })
       end
     end
 
-    assert_no_assertion_triggered do
-      @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: ['a', 'b']) do
-        StatsD.increment('counter', sample_rate: 0.5, tags: ['a', 'b'])
-      end
+    @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: ['a', 'b']) do
+      StatsD.increment('counter', sample_rate: 0.5, tags: ['a', 'b'])
     end
 
-    assert_assertion_triggered do
+    assert_raises(Minitest::Assertion) do
       @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: ['a', 'b'], ignore_tags: ['b']) do
         StatsD.increment('counter', sample_rate: 0.5, tags: ['a'])
       end
     end
 
-    assert_no_assertion_triggered do
-      @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: ['a'], ignore_tags: ['b']) do
-        StatsD.increment('counter', sample_rate: 0.5, tags: ['a', 'b'])
-      end
+    @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: ['a'], ignore_tags: ['b']) do
+      StatsD.increment('counter', sample_rate: 0.5, tags: ['a', 'b'])
     end
 
-    assert_no_assertion_triggered do
-      @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: ['a'], ignore_tags: ['b']) do
-        StatsD.increment('counter', sample_rate: 0.5, tags: ['a'])
-      end
+    @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: ['a'], ignore_tags: ['b']) do
+      StatsD.increment('counter', sample_rate: 0.5, tags: ['a'])
     end
 
-    assert_no_assertion_triggered do
-      @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: { a: 1 }, ignore_tags: { b: 2 }) do
-        StatsD.increment('counter', sample_rate: 0.5, tags: { a: 1, b: 2 })
-      end
+    @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: { a: 1 }, ignore_tags: { b: 2 }) do
+      StatsD.increment('counter', sample_rate: 0.5, tags: { a: 1, b: 2 })
     end
 
-    assert_no_assertion_triggered do
-      @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: { a: 1 }, ignore_tags: { b: 2 }) do
-        StatsD.increment('counter', sample_rate: 0.5, tags: { a: 1, b: 3 })
-      end
+    @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: { a: 1 }, ignore_tags: { b: 2 }) do
+      StatsD.increment('counter', sample_rate: 0.5, tags: { a: 1, b: 3 })
     end
 
-    assert_assertion_triggered do
+    assert_raises(Minitest::Assertion) do
       @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: { a: 1, b: 3 }, ignore_tags: ['b']) do
         StatsD.increment('counter', sample_rate: 0.5, tags: { a: 1, b: 2 })
       end
     end
 
-    assert_no_assertion_triggered do
-      @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: { a: 1 }, ignore_tags: ['b']) do
-        StatsD.increment('counter', sample_rate: 0.5, tags: { a: 1, b: 2 })
-      end
+    @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: { a: 1 }, ignore_tags: ['b']) do
+      StatsD.increment('counter', sample_rate: 0.5, tags: { a: 1, b: 2 })
     end
 
-    assert_assertion_triggered do
+    assert_raises(Minitest::Assertion) do
       @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: ['a', 'b']) do
         StatsD.increment('counter', sample_rate: 0.2, tags: ['c'])
       end
@@ -152,13 +131,11 @@ class AssertionsTest < Minitest::Test
   end
 
   def test_tags_will_match_subsets
-    assert_no_assertion_triggered do
-      @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: { a: 1 }) do
-        StatsD.increment('counter', sample_rate: 0.5, tags: { a: 1, b: 2 })
-      end
+    @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: { a: 1 }) do
+      StatsD.increment('counter', sample_rate: 0.5, tags: { a: 1, b: 2 })
     end
 
-    assert_assertion_triggered do
+    assert_raises(Minitest::Assertion) do
       @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: { a: 1, b: 3 }) do
         StatsD.increment('counter', sample_rate: 0.5, tags: { a: 1, b: 2, c: 4 })
       end
@@ -166,66 +143,58 @@ class AssertionsTest < Minitest::Test
   end
 
   def test_tags_friendly_error
-    @test_case.assert_statsd_increment('counter', tags: { class: "AnotherJob" }) do
-      StatsD.increment('counter', tags: { class: "MyJob" })
+    assertion = assert_raises(Minitest::Assertion) do
+      @test_case.assert_statsd_increment('counter', tags: { class: "AnotherJob" }) do
+        StatsD.increment('counter', tags: { class: "MyJob" })
+      end
     end
-  rescue MiniTest::Assertion => assertion
-    assert_match(/Captured metrics with the same key/, assertion.message)
-    assert_match(/MyJob/, assertion.message)
+
+    assert_includes assertion.message, "Captured metrics with the same key"
+    assert_includes assertion.message, "MyJob"
   end
 
   def test_multiple_metrics_are_not_order_dependent
-    assert_no_assertion_triggered do
-      foo_1_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:1'])
-      foo_2_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
-      @test_case.assert_statsd_calls([foo_1_metric, foo_2_metric]) do
-        StatsD.increment('counter', tags: { foo: 1 })
-        StatsD.increment('counter', tags: { foo: 2 })
-      end
+    foo_1_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:1'])
+    foo_2_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
+    @test_case.assert_statsd_calls([foo_1_metric, foo_2_metric]) do
+      StatsD.increment('counter', tags: { foo: 1 })
+      StatsD.increment('counter', tags: { foo: 2 })
     end
 
-    assert_no_assertion_triggered do
-      foo_1_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:1'])
-      foo_2_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
-      @test_case.assert_statsd_calls([foo_2_metric, foo_1_metric]) do
-        StatsD.increment('counter', tags: { foo: 1 })
-        StatsD.increment('counter', tags: { foo: 2 })
-      end
+    foo_1_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:1'])
+    foo_2_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
+    @test_case.assert_statsd_calls([foo_2_metric, foo_1_metric]) do
+      StatsD.increment('counter', tags: { foo: 1 })
+      StatsD.increment('counter', tags: { foo: 2 })
     end
 
-    assert_no_assertion_triggered do
-      foo_1_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
-      foo_2_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
-      @test_case.assert_statsd_calls([foo_1_metric, foo_2_metric]) do
-        StatsD.increment('counter', tags: { foo: 1 })
-        StatsD.increment('counter', tags: { foo: 1 })
-        StatsD.increment('counter', tags: { foo: 2 })
-      end
+    foo_1_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
+    foo_2_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
+    @test_case.assert_statsd_calls([foo_1_metric, foo_2_metric]) do
+      StatsD.increment('counter', tags: { foo: 1 })
+      StatsD.increment('counter', tags: { foo: 1 })
+      StatsD.increment('counter', tags: { foo: 2 })
     end
 
-    assert_no_assertion_triggered do
-      foo_1_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
-      foo_2_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
-      @test_case.assert_statsd_calls([foo_2_metric, foo_1_metric]) do
-        StatsD.increment('counter', tags: { foo: 1 })
-        StatsD.increment('counter', tags: { foo: 1 })
-        StatsD.increment('counter', tags: { foo: 2 })
-      end
+    foo_1_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
+    foo_2_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
+    @test_case.assert_statsd_calls([foo_2_metric, foo_1_metric]) do
+      StatsD.increment('counter', tags: { foo: 1 })
+      StatsD.increment('counter', tags: { foo: 1 })
+      StatsD.increment('counter', tags: { foo: 2 })
     end
 
-    assert_no_assertion_triggered do
-      foo_1_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
-      foo_2_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
-      @test_case.assert_statsd_calls([foo_2_metric, foo_1_metric]) do
-        StatsD.increment('counter', tags: { foo: 1 })
-        StatsD.increment('counter', tags: { foo: 2 })
-        StatsD.increment('counter', tags: { foo: 1 })
-      end
+    foo_1_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
+    foo_2_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
+    @test_case.assert_statsd_calls([foo_2_metric, foo_1_metric]) do
+      StatsD.increment('counter', tags: { foo: 1 })
+      StatsD.increment('counter', tags: { foo: 2 })
+      StatsD.increment('counter', tags: { foo: 1 })
     end
   end
 
   def test_assert_multiple_statsd_calls
-    assert_assertion_triggered do
+    assert_raises(Minitest::Assertion) do
       foo_1_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
       foo_2_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
       @test_case.assert_statsd_calls([foo_1_metric, foo_2_metric]) do
@@ -234,7 +203,7 @@ class AssertionsTest < Minitest::Test
       end
     end
 
-    assert_assertion_triggered do
+    assert_raises(Minitest::Assertion) do
       foo_1_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
       foo_2_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
       @test_case.assert_statsd_calls([foo_1_metric, foo_2_metric]) do
@@ -245,60 +214,52 @@ class AssertionsTest < Minitest::Test
       end
     end
 
-    assert_no_assertion_triggered do
-      foo_1_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
-      foo_2_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
-      @test_case.assert_statsd_calls([foo_1_metric, foo_2_metric]) do
-        StatsD.increment('counter', tags: { foo: 1 })
-        StatsD.increment('counter', tags: { foo: 1 })
-        StatsD.increment('counter', tags: { foo: 2 })
-      end
+    foo_1_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
+    foo_2_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
+    @test_case.assert_statsd_calls([foo_1_metric, foo_2_metric]) do
+      StatsD.increment('counter', tags: { foo: 1 })
+      StatsD.increment('counter', tags: { foo: 1 })
+      StatsD.increment('counter', tags: { foo: 2 })
     end
   end
 
   def test_assert_statsd_call_with_tags
-    assert_no_assertion_triggered do
-      @test_case.assert_statsd_increment('counter', tags: ['a:b', 'c:d']) do
-        StatsD.increment('counter', tags: { a: 'b', c: 'd' })
-      end
+    @test_case.assert_statsd_increment('counter', tags: ['a:b', 'c:d']) do
+      StatsD.increment('counter', tags: { a: 'b', c: 'd' })
     end
 
-    assert_no_assertion_triggered do
-      @test_case.assert_statsd_increment('counter', tags: { a: 'b', c: 'd' }) do
-        StatsD.increment('counter', tags: ['a:b', 'c:d'])
-      end
+    @test_case.assert_statsd_increment('counter', tags: { a: 'b', c: 'd' }) do
+      StatsD.increment('counter', tags: ['a:b', 'c:d'])
     end
   end
 
   def test_assert_statsd_call_with_wrong_sample_rate_type
     skip("In Strict mode, the StatsD.increment call will raise") if StatsD::Instrument.strict_mode_enabled?
-    assert_assertion_triggered "Unexpected sample rate type for metric counter, must be numeric" do
+
+    assertion = assert_raises(Minitest::Assertion) do
       @test_case.assert_statsd_increment('counter', tags: ['a', 'b']) do
         StatsD.increment('counter', sample_rate: 'abc', tags: ['a', 'b'])
       end
     end
+    assert_equal "Unexpected sample rate type for metric counter, must be numeric", assertion.message
   end
 
   def test_nested_assertions
-    assert_no_assertion_triggered do
-      @test_case.assert_statsd_increment('counter1') do
-        @test_case.assert_statsd_increment('counter2') do
-          StatsD.increment('counter1')
-          StatsD.increment('counter2')
-        end
-      end
-    end
-
-    assert_no_assertion_triggered do
-      @test_case.assert_statsd_increment('counter1') do
+    @test_case.assert_statsd_increment('counter1') do
+      @test_case.assert_statsd_increment('counter2') do
         StatsD.increment('counter1')
-        @test_case.assert_statsd_increment('counter2') do
-          StatsD.increment('counter2')
-        end
+        StatsD.increment('counter2')
       end
     end
 
-    assert_assertion_triggered do
+    @test_case.assert_statsd_increment('counter1') do
+      StatsD.increment('counter1')
+      @test_case.assert_statsd_increment('counter2') do
+        StatsD.increment('counter2')
+      end
+    end
+
+    assert_raises(Minitest::Assertion) do
       @test_case.assert_statsd_increment('counter1') do
         @test_case.assert_statsd_increment('counter2') do
           StatsD.increment('counter2')
@@ -306,7 +267,7 @@ class AssertionsTest < Minitest::Test
       end
     end
 
-    assert_assertion_triggered do
+    assert_raises(Minitest::Assertion) do
       @test_case.assert_statsd_increment('counter1') do
         @test_case.assert_statsd_increment('counter2') do
           StatsD.increment('counter1')
@@ -317,20 +278,18 @@ class AssertionsTest < Minitest::Test
   end
 
   def test_assertion_block_with_expected_exceptions
-    assert_no_assertion_triggered do
-      @test_case.assert_statsd_increment('expected_happened') do
-        @test_case.assert_raises(RuntimeError) do
-          begin
-            raise "expected"
-          rescue
-            StatsD.increment('expected_happened')
-            raise
-          end
+    @test_case.assert_statsd_increment('expected_happened') do
+      @test_case.assert_raises(RuntimeError) do
+        begin
+          raise "expected"
+        rescue
+          StatsD.increment('expected_happened')
+          raise
         end
       end
     end
 
-    assertion = assert_assertion_triggered do
+    assertion = assert_raises(Minitest::Assertion) do
       @test_case.assert_statsd_increment('counter') do
         @test_case.assert_raises(RuntimeError) do
           raise "expected"
@@ -341,7 +300,7 @@ class AssertionsTest < Minitest::Test
   end
 
   def test_assertion_block_with_unexpected_exceptions
-    assertion = assert_assertion_triggered do
+    assertion = assert_raises(Minitest::Assertion) do
       @test_case.assert_statsd_increment('counter') do
         StatsD.increment('counter')
         raise "unexpected"
@@ -349,7 +308,7 @@ class AssertionsTest < Minitest::Test
     end
     assert_includes assertion.message, "An exception occurred in the block provided to the StatsD assertion"
 
-    assertion = assert_assertion_triggered do
+    assertion = assert_raises(Minitest::Assertion) do
       @test_case.assert_raises(RuntimeError) do
         @test_case.assert_statsd_increment('counter') do
           StatsD.increment('counter')
@@ -362,33 +321,11 @@ class AssertionsTest < Minitest::Test
 
   def test_assertion_block_with_other_assertion_failures
     # If another assertion failure happens inside the block, that failrue should have priority
-    assert_assertion_triggered("other assertion failure") do
+    assertion = assert_raises(Minitest::Assertion) do
       @test_case.assert_statsd_increment('counter') do
         @test_case.flunk('other assertion failure')
       end
     end
-  end
-
-  private
-
-  def assert_no_assertion_triggered(&block)
-    block.call
-  rescue MiniTest::Assertion => assertion
-    flunk("No assertion trigger expected, but one was triggered with message #{assertion.message}.")
-  else
-    pass
-  end
-
-  def assert_assertion_triggered(message = nil, &block)
-    block.call
-  rescue MiniTest::Assertion => assertion
-    if message
-      assert_equal(message, assertion.message, "Assertion triggered, but message was not what was expected.")
-    else
-      pass
-    end
-    assertion
-  else
-    flunk("No assertion was triggered, but one was expected.")
+    assert_equal "other assertion failure", assertion.message
   end
 end


### PR DESCRIPTION
Ref #166 & #184.

This is a more straightforward way of dealing with exception that our previous approach. We tell people they should nest `assert_raises` inside the statsD assertion block.

This is a backwards incompatible change though - it may cause some tests to fail that previously were succeeding. However, the fix for those is easy: change the nesting order. The assertion message will tell you how to fix it.

``` ruby
# - This used to succeed in version < 2.3.3
# - This fails due to the lack of statsd increment in version >= 2.3.3
# - This will fail due to an unhandled exception after this PR is merged
assert_raises(RuntimeError) do
  assert_statsd_increment('foo') do
    raise 'error'
  end
end

# - This used to succeed in version < 2.3.3
# - This also succeeds in version >= 2.3.3
# - This will fail due to an unhandled exception after this PR is merged
assert_raises(RuntimeError) do
  assert_statsd_increment('foo') do
    StatsD.increment('foo')
    raise 'error'
  end
end

# - This behaves the same (succeeds) in all versions
assert_statsd_increment('foo') do
  assert_raises(RuntimeError) do
    StatsD.increment('foo')
    raise 'error'
  end
end

# - This behaves the same (fails) in all versions
assert_statsd_increment('foo') do
  assert_raises(RuntimeError) do
    raise 'error'
  end
end

```