### PR TITLE
Add Client#latency.

### DIFF
--- a/.rubocop-https---shopify-github-io-ruby-style-guide-rubocop-yml
+++ b/.rubocop-https---shopify-github-io-ruby-style-guide-rubocop-yml
@@ -892,7 +892,7 @@ Lint/FormatParameterMismatch:
   Enabled: true
 
 Lint/HandleExceptions:
-  Enabled: true
+  AllowComments: true
 
 Lint/ImplicitStringConcatenation:
   Description: Checks for adjacent string literals on the same line, which could

--- a/lib/statsd/instrument/client.rb
+++ b/lib/statsd/instrument/client.rb
@@ -76,7 +76,8 @@ class StatsD::Instrument::Client
   # @param sample_rate (see #increment)
   # @param tags (see #increment)
   # @return [void]
-  def measure(name, value = nil, sample_rate: nil, tags: nil)
+  def measure(name, value = nil, sample_rate: nil, tags: nil, &block)
+    return latency(name, sample_rate: sample_rate, tags: tags, metric_type: :ms, &block) if block_given?
     sample_rate ||= @default_sample_rate
     return unless sample?(sample_rate)
     emit(datagram_builder.ms(name, value, sample_rate, tags))
@@ -126,7 +127,8 @@ class StatsD::Instrument::Client
   # @param sample_rate (see #increment)
   # @param tags (see #increment)
   # @return [void]
-  def distribution(name, value, sample_rate: nil, tags: nil)
+  def distribution(name, value = nil, sample_rate: nil, tags: nil, &block)
+    return latency(name, sample_rate: sample_rate, tags: tags, metric_type: :d, &block) if block_given?
     sample_rate ||= @default_sample_rate
     return unless sample?(sample_rate)
     emit(datagram_builder.d(name, value, sample_rate, tags))

--- a/lib/statsd/instrument/client.rb
+++ b/lib/statsd/instrument/client.rb
@@ -163,9 +163,9 @@ class StatsD::Instrument::Client
   #   Generally, you should not have to set this.
   # @yield The latency (execution time) of the block
   # @return The return value of the proivded block will be passed through.
-  def latency(name, sample_rate: nil, tags: nil, metric_type: nil, &block)
+  def latency(name, sample_rate: nil, tags: nil, metric_type: nil)
     start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    block.call
+    yield
   ensure
     stop = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 

--- a/lib/statsd/instrument/datagram_builder.rb
+++ b/lib/statsd/instrument/datagram_builder.rb
@@ -58,6 +58,10 @@ class StatsD::Instrument::DatagramBuilder
     StatsD::Instrument::Datagram
   end
 
+  def latency_metric_type
+    :ms
+  end
+
   protected
 
   attr_reader :prefix, :default_tags

--- a/lib/statsd/instrument/dogstatsd_datagram_builder.rb
+++ b/lib/statsd/instrument/dogstatsd_datagram_builder.rb
@@ -2,4 +2,8 @@
 
 class StatsD::Instrument::DogStatsDDatagramBuilder < StatsD::Instrument::DatagramBuilder
   unsupported_datagram_types :kv
+
+  def latency_metric_type
+    :d
+  end
 end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -48,11 +48,12 @@ class ClientTest < Minitest::Test
   end
 
   def test_measure_with_block
+    Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(0.1, 0.2)
     datagrams = @client.capture do
       @client.measure('foo') {}
     end
     assert_equal 1, datagrams.size
-    assert_match /\Afoo:\d+\.\d+\|ms\z/, datagrams.first.source
+    assert_equal 'foo:100.0|ms', datagrams.first.source
   end
 
   def test_gauge
@@ -80,27 +81,30 @@ class ClientTest < Minitest::Test
   end
 
   def test_distribution_with_block
+    Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(0.1, 0.2)
     datagrams = @dogstatsd_client.capture do
       @dogstatsd_client.distribution('foo') {}
     end
     assert_equal 1, datagrams.size
-    assert_match /\Afoo:\d+\.\d+|d\z/, datagrams.first.source
+    assert_equal "foo:100.0|d", datagrams.first.source
   end
 
   def test_latency_emits_ms_metric
+    Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(0.1, 0.2)
     datagrams = @client.capture do
       @client.latency('foo') {}
     end
     assert_equal 1, datagrams.size
-    assert_match /\Afoo:\d+\.\d+\|ms\z/, datagrams.first.source
+    assert_equal "foo:100.0|ms", datagrams.first.source
   end
 
-  def test_latency_on_dogstatsd_prefers_distribution
+  def test_latency_on_dogstatsd_prefers_distribution_metric_type
+    Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(0.1, 0.2)
     datagrams = @dogstatsd_client.capture do
       @dogstatsd_client.latency('foo') {}
     end
     assert_equal 1, datagrams.size
-    assert_match /\Afoo:\d+\.\d+\|d\z/, datagrams.first.source
+    assert_equal "foo:100.0|d", datagrams.first.source
   end
 
   def test_latency_calls_block_even_when_not_sending_a_sample

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -47,6 +47,14 @@ class ClientTest < Minitest::Test
     assert_equal 'foo:122.54|ms', datagrams.first.source
   end
 
+  def test_measure_with_block
+    datagrams = @client.capture do
+      @client.measure('foo') {}
+    end
+    assert_equal 1, datagrams.size
+    assert_match /\Afoo:\d+\.\d+\|ms\z/, datagrams.first.source
+  end
+
   def test_gauge
     datagrams = @client.capture { @client.gauge('foo', 123) }
     assert_equal 1, datagrams.size
@@ -69,6 +77,14 @@ class ClientTest < Minitest::Test
     datagrams = @dogstatsd_client.capture { @dogstatsd_client.distribution('foo', 12.44) }
     assert_equal 1, datagrams.size
     assert_equal 'foo:12.44|d', datagrams.first.source
+  end
+
+  def test_distribution_with_block
+    datagrams = @dogstatsd_client.capture do
+      @dogstatsd_client.distribution('foo') {}
+    end
+    assert_equal 1, datagrams.size
+    assert_match /\Afoo:\d+\.\d+|d\z/, datagrams.first.source
   end
 
   def test_latency_emits_ms_metric


### PR DESCRIPTION
It measures the latency (execution time) of the provided block in milliseconds, and emits this value as a metric. The metric type by default is an `ms`, but can be overridden. For DogStatsD we default to a distribution metric.

We also use the latency method under the hood when `measure` or `distribution is called with a block, for backwards compatibility.