### PR TITLE
Add YARD documentation to the StatsD assertion methods.

### DIFF
--- a/lib/statsd/instrument/assertions.rb
+++ b/lib/statsd/instrument/assertions.rb
@@ -1,50 +1,170 @@
 # frozen_string_literal: true
 
+# This module defines several assertion methods that can be used to verify that
+# your application is emitting the right StatsD metrics.
+#
+# Every metric type has its own assertion method, like {#assert_statsd_increment}
+# to assert `StatsD.increment` calls. You can also assert other properties of the
+# metric that was emitted, lioke the sample rate or presence of tags.
+# To check for the absence of metrics, use {#assert_no_statsd_calls}.
+#
+# @example Check for metric properties:
+#   assert_statsd_measure('foo', sample_rate: 0.1, tags: ["bar"]) do
+#     StatsD.measure('foo', sample_rate: 0.5, tags: ['bar','baz']) do
+#       some_code_to_measure
+#     end
+#   end
+#
+# @example Check for multiple occurrences:
+#   assert_statsd_increment('foo', times: 2) do
+#     StatsD.increment('foo')
+#     StatsD.increment('foo')
+#   end
+#
+# @example Absence of metrics
+#   assert_no_statsd_calls do
+#     foo
+#   end
+#
+# @example Handling exceptions
+#   assert_statsd_increment('foo.error') do
+#     # If we expect exceptions to occur, we have to handle them inside
+#     # the block we pass to assert_statsd_increment.
+#     assert_raises(RuntimeError) do
+#       begin
+#         attempt_foo
+#       rescue
+#         StatsD.increment('foo.error')
+#         raise 'foo failed'
+#       end
+#     end
+#   end
 module StatsD::Instrument::Assertions
   include StatsD::Instrument::Helpers
 
+  # Asserts no metric occurred during the execution of the provided block.
+  #
+  # @param [String] metric_name (default: nil) The metric name that is not allowed
+  #   to happen inside the block. If this is set to `nil`, the assertion will fail
+  #   if any metric occurs.
+  # @yield A block in which the specified metric should not occur. This block
+  #   should not raise any exceptions.
+  # @return [void]
+  # @raise [Minitest::Assertion] If an exception occurs, or if any metric (with the
+  #   provided name, or any), occurred during the execution of the provided block.
   def assert_no_statsd_calls(metric_name = nil, &block)
     metrics = capture_statsd_calls(&block)
     metrics.select! { |m| m.name == metric_name } if metric_name
     assert(metrics.empty?, "No StatsD calls for metric #{metrics.map(&:name).join(', ')} expected.")
+  rescue => exception
+    flunk(<<~MESSAGE)
+      An exception occurred in the block provided to the StatsD assertion.
+
+      #{exception.class.name}: #{exception.message}
+      \t#{exception.backtrace.join("\n\t")}
+
+      If this exception is expected, make sure to handle it using `assert_raises`
+      inside the block provided to the StatsD assertion.
+    MESSAGE
   end
 
+  # Asserts that a given counter metric occurred inside the provided block.
+  #
+  # @param [String] metric_name The name of the metric that should occur.
+  # @param [Hash] options (see StatsD::Instrument::MetricExpectation.new)
+  # @yield A block in which the specified metric should occur. This block
+  #   should not raise any exceptions.
+  # @return [void]
+  # @raise [Minitest::Assertion] If an exception occurs, or if the metric did
+  #   not occur as specified during the execution the block.
   def assert_statsd_increment(metric_name, options = {}, &block)
     assert_statsd_call(:c, metric_name, options, &block)
   end
 
+  # Asserts that a given timing metric occurred inside the provided block.
+  #
+  # @param metric_name (see #assert_statsd_increment)
+  # @param options (see #assert_statsd_increment)
+  # @yield (see #assert_statsd_increment)
+  # @return [void]
+  # @raise (see #assert_statsd_increment)
   def assert_statsd_measure(metric_name, options = {}, &block)
     assert_statsd_call(:ms, metric_name, options, &block)
   end
 
+  # Asserts that a given gauge metric occurred inside the provided block.
+  #
+  # @param metric_name (see #assert_statsd_increment)
+  # @param options (see #assert_statsd_increment)
+  # @yield (see #assert_statsd_increment)
+  # @return [void]
+  # @raise (see #assert_statsd_increment)
   def assert_statsd_gauge(metric_name, options = {}, &block)
     assert_statsd_call(:g, metric_name, options, &block)
   end
 
+  # Asserts that a given histogram metric occurred inside the provided block.
+  #
+  # @param metric_name (see #assert_statsd_increment)
+  # @param options (see #assert_statsd_increment)
+  # @yield (see #assert_statsd_increment)
+  # @return [void]
+  # @raise (see #assert_statsd_increment)
   def assert_statsd_histogram(metric_name, options = {}, &block)
     assert_statsd_call(:h, metric_name, options, &block)
   end
 
+  # Asserts that a given distribution metric occurred inside the provided block.
+  #
+  # @param metric_name (see #assert_statsd_increment)
+  # @param options (see #assert_statsd_increment)
+  # @yield (see #assert_statsd_increment)
+  # @return [void]
+  # @raise (see #assert_statsd_increment)
   def assert_statsd_distribution(metric_name, options = {}, &block)
     assert_statsd_call(:d, metric_name, options, &block)
   end
 
+  # Asserts that a given set metric occurred inside the provided block.
+  #
+  # @param metric_name (see #assert_statsd_increment)
+  # @param options (see #assert_statsd_increment)
+  # @yield (see #assert_statsd_increment)
+  # @return [void]
+  # @raise (see #assert_statsd_increment)
   def assert_statsd_set(metric_name, options = {}, &block)
     assert_statsd_call(:s, metric_name, options, &block)
   end
 
+  # Asserts that a given key/value metric occurred inside the provided block.
+  #
+  # @param metric_name (see #assert_statsd_increment)
+  # @param options (see #assert_statsd_increment)
+  # @yield (see #assert_statsd_increment)
+  # @return [void]
+  # @raise (see #assert_statsd_increment)
   def assert_statsd_key_value(metric_name, options = {}, &block)
     assert_statsd_call(:kv, metric_name, options, &block)
   end
 
+  # Asserts that the set of provided metric expectations came true.
+  #
+  # Generally, it's recommended to  use more specific assertion methods, like
+  # {#assert_statsd_increment} and others.
+  #
   # @private
-  def assert_statsd_calls(expected_metrics, &block)
+  # @param [Array<StatsD::Instrument::MetricExpectation>] expected_metrics The set of
+  #   metric expectations to verify.
+  # @yield (see #assert_statsd_increment)
+  # @return [void]
+  # @raise (see #assert_statsd_increment)
+  def assert_statsd_calls(expected_metrics)
     raise ArgumentError, "block must be given" unless block_given?
 
     capture_backend = StatsD::Instrument::Backends::CaptureBackend.new
     with_capture_backend(capture_backend) do
       begin
-        block.call
+        yield
       rescue => exception
         flunk(<<~MESSAGE)
           An exception occurred in the block provided to the StatsD assertion.

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -317,6 +317,15 @@ class AssertionsTest < Minitest::Test
       end
     end
     assert_includes assertion.message, "An exception occurred in the block provided to the StatsD assertion"
+
+    assertion = assert_raises(Minitest::Assertion) do
+      @test_case.assert_raises(RuntimeError) do
+        @test_case.assert_no_statsd_calls do
+          raise "unexpected"
+        end
+      end
+    end
+    assert_includes assertion.message, "An exception occurred in the block provided to the StatsD assertion"
   end
 
   def test_assertion_block_with_other_assertion_failures


### PR DESCRIPTION
These methods did not have any documentation except for a mention in the README. 