### PR TITLE
Add support for Client#event and Client#service_check 

### DIFF
--- a/lib/statsd/instrument/client.rb
+++ b/lib/statsd/instrument/client.rb
@@ -183,6 +183,44 @@ class StatsD::Instrument::Client
     end
   end
 
+  # Emits a service check.
+  #
+  # @param [String] title Event title.
+  # @param [String] text Event description. Newlines are allowed.
+  # @param [Time] timestamp The of the event. If not provided,
+  #   Datadog will interpret it as the current timestamp.
+  # @param [String] hostname A hostname to associate with the event.
+  # @param [String] aggregation_key An aggregation key to group events with the same key.
+  # @param [String] priority Priority of the event. Either "normal" (default) or "low".
+  # @param [String] source_type_name The source type of the event.
+  # @param [String] alert_type Either "error", "warning", "info" (default) or "success".
+  # @param [Array, Hash] tags Tags to associate with the event.
+  # @return [void]
+  #
+  # @note Supported by the Datadog implementation only.
+  def service_check(name, status, timestamp: nil, hostname: nil, tags: nil, message: nil)
+    emit(datagram_builder._sc(name, status, timestamp: timestamp, hostname: hostname, tags: tags, message: message))
+  end
+
+  # Emits an event.
+  #
+  # @param [String] name Name of the service
+  # @param [Symbol] status Either `:ok`, `:warning`, `:critical` or `:unknown`
+  # @param [Time] timestamp The moment when the service was checked. If not provided,
+  #   Datadog will interpret it as the current timestamp.
+  # @param [String] hostname A hostname to associate with the check.
+  # @param [Array, Hash] tags Tags to associate with the check.
+  # @param [String] message A message describing the current state of the service check.
+  # @return [void]
+  #
+  # @note Supported by the Datadog implementation only.
+  def event(title, text, timestamp: nil, hostname: nil, aggregation_key: nil, priority: nil,
+    source_type_name: nil, alert_type: nil, tags: nil)
+
+    emit(datagram_builder._e(title, text, timestamp: timestamp, hostname: hostname, aggregation_key: aggregation_key,
+      priority: priority, source_type_name: source_type_name, alert_type: alert_type, tags: tags))
+  end
+
   # Instantiates a new StatsD client that uses the settings of the current client,
   # except for the provided overrides.
   #

--- a/lib/statsd/instrument/dogstatsd_datagram_builder.rb
+++ b/lib/statsd/instrument/dogstatsd_datagram_builder.rb
@@ -55,12 +55,12 @@ class StatsD::Instrument::DogStatsDDatagramBuilder < StatsD::Instrument::Datagra
   #
   # @see https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/#service-checks
   def _sc(name, status, timestamp: nil, hostname: nil, tags: nil, message: nil)
-    status_number = SERVICE_CHECK_STATUS_VALUES.fetch(status)
+    status_number = status.is_a?(Integer) ? status : SERVICE_CHECK_STATUS_VALUES.fetch(status.to_sym)
     tags = normalize_tags(tags) + default_tags
 
     datagram = +"_sc|#{@prefix}#{normalize_name(name)}|#{status_number}"
-    datagram << "|d:#{timestamp.to_i}" if timestamp
     datagram << "|h:#{hostname}" if hostname
+    datagram << "|d:#{timestamp.to_i}" if timestamp
     datagram << "|##{tags.join(',')}" unless tags.empty?
     datagram << "|m:#{normalize_name(message)}" if message
     datagram

--- a/lib/statsd/instrument/dogstatsd_datagram_builder.rb
+++ b/lib/statsd/instrument/dogstatsd_datagram_builder.rb
@@ -27,7 +27,7 @@ class StatsD::Instrument::DogStatsDDatagramBuilder < StatsD::Instrument::Datagra
   def _e(title, text, timestamp: nil, hostname: nil, aggregation_key: nil, priority: nil,
     source_type_name: nil, alert_type: nil, tags: nil)
 
-    escaped_title = title.gsub("\n", '\n')
+    escaped_title = "#{@prefix}#{title}".gsub("\n", '\n')
     escaped_text = text.gsub("\n", '\n')
     tags = normalize_tags(tags) + default_tags
 
@@ -58,7 +58,7 @@ class StatsD::Instrument::DogStatsDDatagramBuilder < StatsD::Instrument::Datagra
     status_number = SERVICE_CHECK_STATUS_VALUES.fetch(status)
     tags = normalize_tags(tags) + default_tags
 
-    datagram = +"_sc|#{normalize_name(name)}|#{status_number}"
+    datagram = +"_sc|#{@prefix}#{normalize_name(name)}|#{status_number}"
     datagram << "|d:#{timestamp.to_i}" if timestamp
     datagram << "|h:#{hostname}" if hostname
     datagram << "|##{tags.join(',')}" unless tags.empty?

--- a/lib/statsd/instrument/dogstatsd_datagram_builder.rb
+++ b/lib/statsd/instrument/dogstatsd_datagram_builder.rb
@@ -8,4 +8,64 @@ class StatsD::Instrument::DogStatsDDatagramBuilder < StatsD::Instrument::Datagra
   def latency_metric_type
     :d
   end
+
+  # Constricts an event datagram.
+  #
+  # @param [String] title Event title.
+  # @param [String] text Event description. Newlines are allowed.
+  # @param [Time] timestamp The of the event. If not provided,
+  #   Datadog will interpret it as the current timestamp.
+  # @param [String] hostname A hostname to associate with the event.
+  # @param [String] aggregation_key An aggregation key to group events with the same key.
+  # @param [String] priority Priority of the event. Either "normal" (default) or "low".
+  # @param [String] source_type_name The source type of the event.
+  # @param [String] alert_type Either "error", "warning", "info" (default) or "success".
+  # @param [Array, Hash] tags Tags to associate with the event.
+  # @return [String] The correctly formatted service check datagram
+  #
+  # @see https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/#events
+  def _e(title, text, timestamp: nil, hostname: nil, aggregation_key: nil, priority: nil,
+    source_type_name: nil, alert_type: nil, tags: nil)
+
+    escaped_title = title.gsub("\n", '\n')
+    escaped_text = text.gsub("\n", '\n')
+    tags = normalize_tags(tags) + default_tags
+
+    datagram = +"_e{#{escaped_title.length},#{escaped_text.length}}:#{escaped_title}|#{escaped_text}"
+    datagram << "|h:#{hostname}" if hostname
+    datagram << "|d:#{timestamp.to_i}" if timestamp
+    datagram << "|k:#{aggregation_key}" if aggregation_key
+    datagram << "|p:#{priority}" if priority
+    datagram << "|s:#{source_type_name}" if source_type_name
+    datagram << "|t:#{alert_type}" if alert_type
+    datagram << "|##{tags.join(',')}" unless tags.empty?
+    datagram
+  end
+
+  # Constricts a service check datagram.
+  #
+  # @param [String] name Name of the service
+  # @param [Symbol] status Either `:ok`, `:warning`, `:critical` or `:unknown`
+  # @param [Time] timestamp The moment when the service was checked. If not provided,
+  #   Datadog will interpret it as the current timestamp.
+  # @param [String] hostname A hostname to associate with the check.
+  # @param [Array, Hash] tags Tags to associate with the check.
+  # @param [String] message A message describing the current state of the service check.
+  # @return [String] The correctly formatted service check datagram
+  #
+  # @see https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/#service-checks
+  def _sc(name, status, timestamp: nil, hostname: nil, tags: nil, message: nil)
+    status_number = SERVICE_CHECK_STATUS_VALUES.fetch(status)
+    tags = normalize_tags(tags) + default_tags
+
+    datagram = +"_sc|#{normalize_name(name)}|#{status_number}"
+    datagram << "|d:#{timestamp.to_i}" if timestamp
+    datagram << "|h:#{hostname}" if hostname
+    datagram << "|##{tags.join(',')}" unless tags.empty?
+    datagram << "|m:#{normalize_name(message)}" if message
+    datagram
+  end
+
+  SERVICE_CHECK_STATUS_VALUES = { ok: 0, warning: 1, critical: 2, unknown: 3 }.freeze
+  private_constant :SERVICE_CHECK_STATUS_VALUES
 end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -116,6 +116,18 @@ class ClientTest < Minitest::Test
     assert called, "The block should have been called"
   end
 
+  def test_service_check
+    datagrams = @dogstatsd_client.capture { @dogstatsd_client.service_check('service', :ok) }
+    assert_equal 1, datagrams.size
+    assert_equal "_sc|service|0", datagrams.first.source
+  end
+
+  def test_event
+    datagrams = @dogstatsd_client.capture { @dogstatsd_client.event('service', "event\ndescription") }
+    assert_equal 1, datagrams.size
+    assert_equal "_e{7,18}:service|event\\ndescription", datagrams.first.source
+  end
+
   def test_clone_with_prefix_option
     datagrams = []
     original_client = StatsD::Instrument::Client.new(sink: datagrams)

--- a/test/compatibility/dogstatsd_datagram_compatibility_test.rb
+++ b/test/compatibility/dogstatsd_datagram_compatibility_test.rb
@@ -83,6 +83,25 @@ module Compatibility
       end
     end
 
+    def test_service_check_compatibility
+      assert_equal_datagrams { |client| client.service_check('service', 0) }
+      assert_equal_datagrams { |client| client.event('foo', "bar\nbaz") }
+      assert_equal_datagrams do |client|
+        client.service_check('service', "ok", timestamp: Time.parse('2019-09-09T04:22:17Z'),
+          hostname: 'localhost', tags: ['foo'], message: 'bar')
+      end
+    end
+
+    def test_event_compatibility
+      assert_equal_datagrams { |client| client.event('foo', "bar\nbaz") }
+      assert_equal_datagrams { |client| client.event('foo', "bar\nbaz") }
+      assert_equal_datagrams do |client|
+        client.event('Something happend', "And it's not good", timestamp: Time.parse('2019-09-09T04:22:17Z'),
+          hostname: 'localhost', tags: ['foo'], alert_type: 'warning', priority: 'low',
+          aggregation_key: 'foo', source_type_name: 'logs')
+      end
+    end
+
     private
 
     MODES = [:normal, :with_prefix, :with_default_tags]

--- a/test/dogstatsd_datagram_builder_test.rb
+++ b/test/dogstatsd_datagram_builder_test.rb
@@ -17,7 +17,7 @@ class DogStatsDDatagramBuilderTest < Minitest::Test
     assert_equal '_sc|service|0', @datagram_builder._sc('service', :ok)
     datagram = @datagram_builder._sc('service', :warning, timestamp: Time.parse('2019-09-30T04:22:12Z'),
       hostname: 'localhost', tags: { foo: 'bar|baz' }, message: 'blah')
-    assert_equal "_sc|service|1|d:1569817332|h:localhost|#foo:barbaz|m:blah", datagram
+    assert_equal "_sc|service|1|h:localhost|d:1569817332|#foo:barbaz|m:blah", datagram
   end
 
   def test_event

--- a/test/dogstatsd_datagram_builder_test.rb
+++ b/test/dogstatsd_datagram_builder_test.rb
@@ -12,4 +12,21 @@ class DogStatsDDatagramBuilderTest < Minitest::Test
   def test_raises_on_unsupported_metrics
     assert_raises(NotImplementedError) { @datagram_builder.kv('foo', 10, nil, nil) }
   end
+
+  def test_service_check
+    assert_equal '_sc|service|0', @datagram_builder._sc('service', :ok)
+    datagram = @datagram_builder._sc('service', :warning, timestamp: Time.parse('2019-09-30T04:22:12Z'),
+      hostname: 'localhost', tags: { foo: 'bar|baz' }, message: 'blah')
+    assert_equal "_sc|service|1|d:1569817332|h:localhost|#foo:barbaz|m:blah", datagram
+  end
+
+  def test_event
+    assert_equal '_e{5,5}:hello|world', @datagram_builder._e('hello', "world")
+
+    datagram = @datagram_builder._e("testing", "with\nnewline", timestamp: Time.parse('2019-09-30T04:22:12Z'),
+      hostname: 'localhost', aggregation_key: 'my-key', priority: 'low', source_type_name: 'source',
+      alert_type: 'success', tags: { foo: 'bar|baz' })
+    assert_equal '_e{7,13}:testing|with\\nnewline|h:localhost|d:1569817332|k:my-key|' \
+      'p:low|s:source|t:success|#foo:barbaz', datagram
+  end
 end


### PR DESCRIPTION
Those methods are only supported in DogStatsD, so will only be available when using the DogStatsD datagram builder. See https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/ for the datagram format.

Questions:

- Note that neither of these support sample rates in their datagram formats. We could still apply sampling if we want to, but I think that's generally not what you'd expect. What do you think?
- Related, I don't expect these metrics to be emitted very often, and we can be a bit more strict w.r.t. input validation. Anything that we should check?
- Should we still use prefixes when one is defined on the client?

TODO in followups or in this PR: 

- ~Ensure the legacy API is compatible with the new one. (The old API is kind of awful, but we should do our best)~ A compatibility test has been added.
- Ensure the datagram parser can parse these datagrams.
