### PR TITLE
DogStatsD `service_check` metric bugfixes & improvements

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -565,10 +565,13 @@ module StatsD
     name, status,
     deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,
     sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg,
-    prefix: StatsD.prefix, no_prefix: false, **metadata
+    prefix: StatsD.prefix, no_prefix: false,
+    hostname: nil, timestamp: nil, message: nil, **_ignored
   )
     prefix = nil if no_prefix
-    collect_metric(:_sc, name, status, sample_rate: sample_rate, tags: tags, prefix: prefix, metadata: metadata)
+    collect_metric(:_sc, name, status, sample_rate: sample_rate, prefix: prefix, tags: tags, metadata: {
+      hostname: hostname, timestamp: timestamp, message: message
+    })
   end
 
   private

--- a/lib/statsd/instrument/strict.rb
+++ b/lib/statsd/instrument/strict.rb
@@ -55,6 +55,12 @@ module StatsD
         super
       end
 
+      def service_check(name, status, tags: nil, prefix: StatsD.prefix, no_prefix: false,
+        hostname: nil, timestamp: nil, message: nil)
+
+        super
+      end
+
       def measure(key, value = UNSPECIFIED, sample_rate: nil, tags: nil,
         prefix: StatsD.prefix, no_prefix: false, as_dist: false, &block)
 


### PR DESCRIPTION
- The message (`m`) field has to show up as the very final field according to the documentation (see https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/#service-checks). 
- Sample rate is not supported. 
- The value has to be provided as an integer. We now include a mapping that can find the right number for strings and symbols like `:ok`.
- The timestamp value should be a unix timestamp. We now call `to_i` on the value so a Time value will be properly converted.