### PR TITLE
StatsD.event bugfixes & improvements

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -546,10 +546,16 @@ module StatsD
     title, text,
     deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,
     sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg,
-    prefix: StatsD.prefix, no_prefix: false, **metadata
+    prefix: StatsD.prefix, no_prefix: false,
+    hostname: nil, date_happened: nil, timestamp: date_happened,
+    aggregation_key: nil, priority: nil, source_type_name: nil, alert_type: nil,
+    **_ignored
   )
     prefix = nil if no_prefix
-    collect_metric(:_e, title, text, sample_rate: sample_rate, tags: tags, prefix: prefix, metadata: metadata)
+    collect_metric(:_e, title, text, sample_rate: sample_rate, tags: tags, prefix: prefix, metadata: {
+      hostname: hostname, timestamp: timestamp, aggregation_key: aggregation_key,
+      priority: priority, source_type_name: source_type_name, alert_type: alert_type
+    })
   end
 
   # @!method service_check(name, status, **metadata)

--- a/lib/statsd/instrument/strict.rb
+++ b/lib/statsd/instrument/strict.rb
@@ -61,6 +61,12 @@ module StatsD
         super
       end
 
+      def event(title, text, tags: nil, prefix: StatsD.prefix, no_prefix: false,
+        hostname: nil, timestamp: nil, aggregation_key: nil, priority: nil, source_type_name: nil, alert_type: nil)
+
+        super
+      end
+
       def measure(key, value = UNSPECIFIED, sample_rate: nil, tags: nil,
         prefix: StatsD.prefix, no_prefix: false, as_dist: false, &block)
 


### PR DESCRIPTION
- Be explicit in what metadata we support in the method signature.
- Ignore `sample_rate` because it's not suppored.
- Accept a Time value for a timestamp.
- Accept `timestamp` rather than `date_happened` for consistency (but support `date_happened` as well for now)

Also added a strict mode definition for StatsD.event which will raise an `ArgumentError` for stuff we no longer want to support in the next major version.