### PR TITLE
Respect global StatsD.prefix changes when using metaprogramming methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ section below.
 
 ### Unreleased changes
 
+- **Bugfix:** when using metaprogramming methods, changes to `StatsD.prefix` after
+  the metaprogramming method was evaluated would not be respected. This
+  unfortunately is quite common when you set the StatsD prefix inside an
+  initializer. This issue is now addressed: the prefix is evaluated at the
+  mopment the metric is emitted, not when the metaprogramming method is being
+  evaluated. (#202)
+
 - Several improvements to `StatsD.event` and `StatsD.service_check` (both are
   Datadog-only). The previous implementation would sometimes construct invalid
   datagrams based on the input. The method signatures have been made more

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -91,11 +91,12 @@ module StatsD
     # @param metric_options (see StatsD#measure)
     # @return [void]
     def statsd_measure(method, name, deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil, as_dist: false,
-      sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg, prefix: StatsD.prefix, no_prefix: false)
+      sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg, prefix: nil, no_prefix: false)
 
       add_to_method(method, name, :measure) do
         define_method(method) do |*args, &block|
           key = StatsD::Instrument.generate_metric_name(name, self, *args)
+          prefix ||= StatsD.prefix
           StatsD.measure(
             key, sample_rate: sample_rate, tags: tags, prefix: prefix, no_prefix: no_prefix, as_dist: as_dist
           ) do
@@ -114,11 +115,12 @@ module StatsD
     # @return [void]
     # @note Supported by the datadog implementation only (in beta)
     def statsd_distribution(method, name, deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,
-      sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg, prefix: StatsD.prefix, no_prefix: false)
+      sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg, prefix: nil, no_prefix: false)
 
       add_to_method(method, name, :distribution) do
         define_method(method) do |*args, &block|
           key = StatsD::Instrument.generate_metric_name(name, self, *args)
+          prefix ||= StatsD.prefix
           StatsD.distribution(key, sample_rate: sample_rate, tags: tags, prefix: prefix, no_prefix: no_prefix) do
             super(*args, &block)
           end
@@ -142,7 +144,7 @@ module StatsD
     # @return [void]
     # @see #statsd_count_if
     def statsd_count_success(method, name, deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,
-      sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg, prefix: StatsD.prefix, no_prefix: false)
+      sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg, prefix: nil, no_prefix: false)
 
       add_to_method(method, name, :count_success) do
         define_method(method) do |*args, &block|
@@ -163,6 +165,7 @@ module StatsD
           ensure
             suffix = truthiness == false ? 'failure' : 'success'
             key = "#{StatsD::Instrument.generate_metric_name(name, self, *args)}.#{suffix}"
+            prefix ||= StatsD.prefix
             StatsD.increment(key, sample_rate: sample_rate, tags: tags, prefix: prefix, no_prefix: no_prefix)
           end
         end
@@ -182,7 +185,7 @@ module StatsD
     # @return [void]
     # @see #statsd_count_success
     def statsd_count_if(method, name, deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,
-      sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg, prefix: StatsD.prefix, no_prefix: false)
+      sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg, prefix: nil, no_prefix: false)
 
       add_to_method(method, name, :count_if) do
         define_method(method) do |*args, &block|
@@ -203,6 +206,7 @@ module StatsD
           ensure
             if truthiness
               key = StatsD::Instrument.generate_metric_name(name, self, *args)
+              prefix ||= StatsD.prefix
               StatsD.increment(key, sample_rate: sample_rate, tags: tags, prefix: prefix, no_prefix: no_prefix)
             end
           end
@@ -220,11 +224,12 @@ module StatsD
     # @param metric_options (see #statsd_measure)
     # @return [void]
     def statsd_count(method, name, deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,
-      sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg, prefix: StatsD.prefix, no_prefix: false)
+      sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg, prefix: nil, no_prefix: false)
 
       add_to_method(method, name, :count) do
         define_method(method) do |*args, &block|
           key = StatsD::Instrument.generate_metric_name(name, self, *args)
+          prefix ||= StatsD.prefix
           StatsD.increment(key, sample_rate: sample_rate, tags: tags, prefix: prefix, no_prefix: no_prefix)
           super(*args, &block)
         end


### PR DESCRIPTION
For the metaprogramming methods, we currently evaluate `StatsD.prefix` when the code is loading. If the prefix changes afterwards (for instance, in a Railtie or initializer), that new prefix will not be respected. This PR ensures that the new prefix will be respected.

I've also added some tests that demonstrate that you can override or clear the prefix when using the metaprogramming methods. When you do that, any changes to the global prefix will not have any affect on those metrics.