### PR TITLE
Improve datagram compatibility test

### DIFF
--- a/lib/statsd/instrument/client.rb
+++ b/lib/statsd/instrument/client.rb
@@ -169,15 +169,17 @@ class StatsD::Instrument::Client
   # @return The return value of the proivded block will be passed through.
   def latency(name, sample_rate: nil, tags: nil, metric_type: nil)
     start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    yield
-  ensure
-    stop = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    begin
+      yield
+    ensure
+      stop = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
-    sample_rate ||= @default_sample_rate
-    if sample?(sample_rate)
-      metric_type ||= datagram_builder.latency_metric_type
-      latency_in_ms = 1000.0 * (stop - start)
-      emit(datagram_builder.send(metric_type, name, latency_in_ms, sample_rate, tags))
+      sample_rate ||= @default_sample_rate
+      if sample?(sample_rate)
+        metric_type ||= datagram_builder.latency_metric_type
+        latency_in_ms = 1000.0 * (stop - start)
+        emit(datagram_builder.send(metric_type, name, latency_in_ms, sample_rate, tags))
+      end
     end
   end
 

--- a/test/compatibility/dogstatsd_datagram_compatibility_test.rb
+++ b/test/compatibility/dogstatsd_datagram_compatibility_test.rb
@@ -6,6 +6,9 @@ require 'statsd/instrument/client'
 module Compatibility
   class DogStatsDDatagramCompatibilityTest < Minitest::Test
     def setup
+      StatsD::Instrument::Client.any_instance.stubs(:rand).returns(0)
+      StatsD::Instrument::Backends::UDPBackend.any_instance.stubs(:rand).returns(0)
+
       @server = UDPSocket.new
       @server.bind('localhost', 0)
       @host = @server.addr[2]
@@ -17,56 +20,89 @@ module Compatibility
     end
 
     def test_increment_compatibility
-      assert_equal_datagrams_emitted { |client| client.increment('counter') }
-      assert_equal_datagrams_emitted { |client| client.increment('counter', 12) }
-      assert_equal_datagrams_emitted { |client| client.increment('counter', sample_rate: 0.1) }
-      assert_equal_datagrams_emitted { |client| client.increment('counter', tags: ['foo', 'bar']) }
-      assert_equal_datagrams_emitted { |client| client.increment('counter', tags: { foo: 'bar' }) }
-      assert_equal_datagrams_emitted { |client| client.increment('counter', sample_rate: 0.1, tags: ['quc']) }
+      assert_equal_datagrams { |client| client.increment('counter') }
+      assert_equal_datagrams { |client| client.increment('counter', 12) }
+      assert_equal_datagrams { |client| client.increment('counter', sample_rate: 0.1) }
+      assert_equal_datagrams { |client| client.increment('counter', tags: ['foo', 'bar']) }
+      assert_equal_datagrams { |client| client.increment('counter', tags: { foo: 'bar' }) }
+      assert_equal_datagrams { |client| client.increment('counter', sample_rate: 0.1, tags: ['quc']) }
     end
 
     def test_measure_compatibility
-      assert_equal_datagrams_emitted { |client| client.measure('timing', 12.34) }
-      assert_equal_datagrams_emitted { |client| client.measure('timing', 0.01) }
-      assert_equal_datagrams_emitted { |client| client.measure('timing', 0.12, sample_rate: 0.1) }
-      assert_equal_datagrams_emitted { |client| client.measure('timing', 0.12, tags: ['foo', 'bar']) }
+      assert_equal_datagrams { |client| client.measure('timing', 12.34) }
+      assert_equal_datagrams { |client| client.measure('timing', 0.01) }
+      assert_equal_datagrams { |client| client.measure('timing', 0.12, sample_rate: 0.1) }
+      assert_equal_datagrams { |client| client.measure('timing', 0.12, tags: ['foo', 'bar']) }
+    end
+
+    def test_measure_with_block_compatibility
+      Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(12.1)
+      assert_equal_datagrams do |client|
+        return_value = client.measure('timing', tags: ['foo'], sample_rate: 0.1) { 'foo' }
+        assert_equal 'foo', return_value
+      end
     end
 
     def test_gauge_compatibility
-      assert_equal_datagrams_emitted { |client| client.gauge('current', 1234) }
-      assert_equal_datagrams_emitted { |client| client.gauge('current', 1234, sample_rate: 0.1) }
-      assert_equal_datagrams_emitted { |client| client.gauge('current', 1234, tags: ['foo', 'bar']) }
-      assert_equal_datagrams_emitted { |client| client.gauge('current', 1234, tags: { foo: 'bar' }) }
-      assert_equal_datagrams_emitted { |client| client.gauge('current', 1234, sample_rate: 0.1, tags: ['quc']) }
+      assert_equal_datagrams { |client| client.gauge('current', 1234) }
+      assert_equal_datagrams { |client| client.gauge('current', 1234, sample_rate: 0.1) }
+      assert_equal_datagrams { |client| client.gauge('current', 1234, tags: ['foo', 'bar']) }
+      assert_equal_datagrams { |client| client.gauge('current', 1234, tags: { foo: 'bar' }) }
+      assert_equal_datagrams { |client| client.gauge('current', 1234, sample_rate: 0.1, tags: ['quc']) }
     end
 
     def test_set_compatibility
-      assert_equal_datagrams_emitted { |client| client.set('unique', 'foo') }
-      assert_equal_datagrams_emitted { |client| client.set('unique', 'foo', sample_rate: 0.1) }
-      assert_equal_datagrams_emitted { |client| client.set('unique', '1234', tags: ['foo', 'bar']) }
-      assert_equal_datagrams_emitted { |client| client.set('unique', '1234', tags: { foo: 'bar' }) }
-      assert_equal_datagrams_emitted { |client| client.set('unique', '1234', sample_rate: 0.1, tags: ['quc']) }
+      assert_equal_datagrams { |client| client.set('unique', 'foo') }
+      assert_equal_datagrams { |client| client.set('unique', 'foo', sample_rate: 0.1) }
+      assert_equal_datagrams { |client| client.set('unique', '1234', tags: ['foo', 'bar']) }
+      assert_equal_datagrams { |client| client.set('unique', '1234', tags: { foo: 'bar' }) }
+      assert_equal_datagrams { |client| client.set('unique', '1234', sample_rate: 0.1, tags: ['quc']) }
     end
 
     def test_histogram_compatibility
-      assert_equal_datagrams_emitted { |client| client.histogram('sample', 12.44) }
-      assert_equal_datagrams_emitted { |client| client.histogram('sample', 12.44, sample_rate: 0.1) }
-      assert_equal_datagrams_emitted { |client| client.histogram('sample', 12.44, tags: ['foo', 'bar']) }
-      assert_equal_datagrams_emitted { |client| client.histogram('sample', 12.44, tags: { foo: 'bar' }) }
-      assert_equal_datagrams_emitted { |client| client.histogram('sample', 12.44, sample_rate: 0.1, tags: ['quc']) }
+      assert_equal_datagrams { |client| client.histogram('sample', 12.44) }
+      assert_equal_datagrams { |client| client.histogram('sample', 12.44, sample_rate: 0.1) }
+      assert_equal_datagrams { |client| client.histogram('sample', 12.44, tags: ['foo', 'bar']) }
+      assert_equal_datagrams { |client| client.histogram('sample', 12.44, tags: { foo: 'bar' }) }
+      assert_equal_datagrams { |client| client.histogram('sample', 12.44, sample_rate: 0.1, tags: ['quc']) }
     end
 
     def test_distribution_compatibility
-      assert_equal_datagrams_emitted { |client| client.distribution('sample', 12.44) }
-      assert_equal_datagrams_emitted { |client| client.distribution('sample', 12.44, sample_rate: 0.1) }
-      assert_equal_datagrams_emitted { |client| client.distribution('sample', 12.44, tags: ['foo', 'bar']) }
-      assert_equal_datagrams_emitted { |client| client.distribution('sample', 12.44, tags: { foo: 'bar' }) }
-      assert_equal_datagrams_emitted { |client| client.distribution('sample', 12.44, sample_rate: 0.1, tags: ['quc']) }
+      assert_equal_datagrams { |client| client.distribution('sample', 12.44) }
+      assert_equal_datagrams { |client| client.distribution('sample', 12.44, sample_rate: 0.1) }
+      assert_equal_datagrams { |client| client.distribution('sample', 12.44, tags: ['foo', 'bar']) }
+      assert_equal_datagrams { |client| client.distribution('sample', 12.44, tags: { foo: 'bar' }) }
+      assert_equal_datagrams { |client| client.distribution('sample', 12.44, sample_rate: 0.1, tags: ['quc']) }
+    end
+
+    def test_distribution_with_block_compatibility
+      Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(12.1)
+      assert_equal_datagrams do |client|
+        return_value = client.distribution('timing', tags: ['foo'], sample_rate: 0.1) { 'foo' }
+        assert_equal 'foo', return_value
+      end
     end
 
     private
 
-    def with_legacy_client
+    MODES = [:normal, :with_prefix, :with_default_tags]
+
+    def assert_equal_datagrams(&block)
+      MODES.each do |mode|
+        legacy_datagram = with_legacy_client(mode) { |client| read_datagram(client, &block) }
+        new_datagram = with_new_client(mode) { |client| read_datagram(client, &block) }
+
+        assert_equal legacy_datagram, new_datagram, "The datagrams emitted were not the same in #{mode} mode"
+      end
+    end
+
+    def with_legacy_client(mode)
+      old_prefix = StatsD.prefix
+      StatsD.prefix = 'prefix' if mode == :with_prefix
+
+      old_default_tags = StatsD.default_tags
+      StatsD.default_tags = { key: 'value' } if mode == :with_default_tags
+
       old_backend = StatsD.backend
       new_backend = StatsD::Instrument::Backends::UDPBackend.new("#{@host}:#{@port}", :datadog)
       StatsD.backend = new_backend
@@ -75,46 +111,27 @@ module Compatibility
     ensure
       new_backend.socket.close if new_backend&.socket
       StatsD.backend = old_backend
+      StatsD.prefix = old_prefix
+      StatsD.default_tags = old_default_tags
     end
 
-    def with_new_client
+    def with_new_client(mode)
+      prefix = mode == :with_prefix ? 'prefix' : nil
+      default_tags = mode == :with_default_tags ? { key: 'value' } : nil
       client = StatsD::Instrument::Client.new(
         sink: StatsD::Instrument::UDPSink.new(@host, @port),
         datagram_builder_class: StatsD::Instrument::DogStatsDDatagramBuilder,
+        prefix: prefix,
+        default_tags: default_tags
       )
 
       yield(client)
     end
 
-    def assert_equal_datagrams_emitted(&block)
-      legacy_datagram = with_legacy_client { |client| read_datagram(client, &block) }
-      new_datagram = with_new_client { |client| read_datagram(client, &block) }
-
-      assert_equal legacy_datagram, new_datagram, "The datagrams emitted from both clients were not the same"
-    end
-
-    def drain_server
-      loop { @server.recvfrom_nonblock(100) }
-    rescue
-      IO::EAGAINWaitReadable
-    end
-
     def read_datagram(client)
-      # We first make sure that the server buffer is empty to make sure
-      # we're not reading a packet from a different run
-      drain_server
-
-      # Because of sample rates, we will start calling blocks that does the StatsD call in a loop,
-      # until we receive a packet on the server end.
-      Thread.abort_on_exception = true
-      emitter_thread = Thread.new { loop { yield(client) } }
-
-      # Block until we read a packet, then kill the emitter thread.
+      yield(client)
       data, _origin = @server.recvfrom(100)
-      emitter_thread.kill
-
-      # Now return the datagram
-      StatsD::Instrument::Datagram.new(data)
+      data
     end
   end
 end


### PR DESCRIPTION
We now run all the compatibility tests in the following modes:

- Normal (no prefix or default tags)
- With prefix
- With default tags

We now also have tests for `measure` and `distribution` in block execution time measuring mode.

There is also a reliability improvement by making sure that we always emit a packet by stubbing rand. That way, we can simply call the StatsD method once, rather than in a loop, and get rid of all the thread and draining logic.