### PR TITLE
Check for Rails::Railtie rather than Rails

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -621,4 +621,4 @@ require 'statsd/instrument/helpers'
 require 'statsd/instrument/assertions'
 require 'statsd/instrument/metric_expectation'
 require 'statsd/instrument/matchers' if defined?(::RSpec)
-require 'statsd/instrument/railtie' if defined?(Rails)
+require 'statsd/instrument/railtie' if defined?(::Rails::Railtie)


### PR DESCRIPTION
In some corner cases the `Rails` class can be defined by some `rails-something` gems, even though you are not in a full Rails context.

Because of this we updated the documentation to recommend checking for `Rails::Railtie` definition: https://github.com/rails/rails/commit/d50049bef8c1dd23634076c1e345ed7a1c50b75d