### PR TITLE
Deprecate setting prefix on metric calls

### DIFF
--- a/lib/statsd/instrument/strict.rb
+++ b/lib/statsd/instrument/strict.rb
@@ -26,7 +26,7 @@ module StatsD
     module Strict
       def increment(key, value = 1, sample_rate: nil, tags: nil, no_prefix: false)
         raise ArgumentError, "StatsD.increment does not accept a block" if block_given?
-        raise ArgumentError, "The value argument should be an integer, got #{value.inspect}" unless value.is_a?(Numeric)
+        raise ArgumentError, "The value argument should be an integer, got #{value.inspect}" unless value.is_a?(Integer)
         check_tags_and_sample_rate(sample_rate, tags)
 
         super

--- a/lib/statsd/instrument/strict.rb
+++ b/lib/statsd/instrument/strict.rb
@@ -112,28 +112,28 @@ module StatsD
 
     module StrictMetaprogramming
       def statsd_measure(method, name, sample_rate: nil, tags: nil,
-        prefix: StatsD.prefix, no_prefix: false, as_dist: false)
+        prefix: nil, no_prefix: false, as_dist: false)
 
         check_method_and_metric_name(method, name)
         super
       end
 
-      def statsd_distribution(method, name, sample_rate: nil, tags: nil, prefix: StatsD.prefix, no_prefix: false)
+      def statsd_distribution(method, name, sample_rate: nil, tags: nil, prefix: nil, no_prefix: false)
         check_method_and_metric_name(method, name)
         super
       end
 
-      def statsd_count_success(method, name, sample_rate: nil, tags: nil, prefix: StatsD.prefix, no_prefix: false)
+      def statsd_count_success(method, name, sample_rate: nil, tags: nil, prefix: nil, no_prefix: false)
         check_method_and_metric_name(method, name)
         super
       end
 
-      def statsd_count_if(method, name, sample_rate: nil, tags: nil, prefix: StatsD.prefix, no_prefix: false)
+      def statsd_count_if(method, name, sample_rate: nil, tags: nil, prefix: nil, no_prefix: false)
         check_method_and_metric_name(method, name)
         super
       end
 
-      def statsd_count(method, name, sample_rate: nil, tags: nil, prefix: StatsD.prefix, no_prefix: false)
+      def statsd_count(method, name, sample_rate: nil, tags: nil, prefix: nil, no_prefix: false)
         check_method_and_metric_name(method, name)
         super
       end

--- a/test/statsd_instrumentation_test.rb
+++ b/test/statsd_instrumentation_test.rb
@@ -355,6 +355,8 @@ class StatsDInstrumentationTest < Minitest::Test
   end
 
   def test_statsd_macro_can_overwrite_prefix
+    skip("StatsD.measure(..., prefix: 'foo') is deprecated") if StatsD::Instrument.strict_mode_enabled?
+
     StatsD.prefix = 'Foo'
     ActiveMerchant::Gateway.singleton_class.extend StatsD::Instrument
     ActiveMerchant::Gateway.singleton_class.statsd_measure :sync, 'ActiveMerchant.Gateway.sync', prefix: 'Bar'
@@ -364,8 +366,10 @@ class StatsDInstrumentationTest < Minitest::Test
     assert_equal 1, statsd_calls.length
     assert_equal "Bar.ActiveMerchant.Gateway.sync", statsd_calls.first.name
   ensure
-    StatsD.prefix = nil
-    ActiveMerchant::Gateway.singleton_class.statsd_remove_measure :sync, 'ActiveMerchant.Gateway.sync'
+    unless StatsD::Instrument.strict_mode_enabled?
+      StatsD.prefix = nil
+      ActiveMerchant::Gateway.singleton_class.statsd_remove_measure :sync, 'ActiveMerchant.Gateway.sync'
+    end
   end
 
   def test_statsd_macro_can_disable_prefix

--- a/test/statsd_instrumentation_test.rb
+++ b/test/statsd_instrumentation_test.rb
@@ -249,13 +249,16 @@ class StatsDInstrumentationTest < Minitest::Test
   end
 
   def test_statsd_measure_as_distribution
+    skip("StatsD.measure(..., as_dist: true) is deprecated") if StatsD::Instrument.strict_mode_enabled?
     ActiveMerchant::UniqueGateway.statsd_measure :ssl_post, 'ActiveMerchant.Gateway.ssl_post', as_dist: true
 
     assert_statsd_distribution('ActiveMerchant.Gateway.ssl_post') do
       ActiveMerchant::UniqueGateway.new.purchase(true)
     end
   ensure
-    ActiveMerchant::UniqueGateway.statsd_remove_measure :ssl_post, 'ActiveMerchant.Gateway.ssl_post'
+    unless StatsD::Instrument.strict_mode_enabled?
+      ActiveMerchant::UniqueGateway.statsd_remove_measure :ssl_post, 'ActiveMerchant.Gateway.ssl_post'
+    end
   end
 
   def test_statsd_distribution

--- a/test/statsd_test.rb
+++ b/test/statsd_test.rb
@@ -22,6 +22,7 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_measure_with_explicit_value_and_distribution_override
+    skip("StatsD.measure(..., as_dist: true) is deprecated") if StatsD::Instrument.strict_mode_enabled?
     metric = capture_statsd_call { StatsD.measure('values.foobar', 42, as_dist: true) }
     assert_equal :d, metric.type
   end
@@ -44,6 +45,7 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_measure_use_distribution_override_for_a_block
+    skip("StatsD.measure(..., as_dist: true) is deprecated") if StatsD::Instrument.strict_mode_enabled?
     metric = capture_statsd_call do
       StatsD.measure('values.foobar', as_dist: true) { 'foo' }
     end
@@ -56,6 +58,7 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_measure_as_distribution_returns_return_value_of_block_even_if_nil
+    skip("StatsD.measure(..., as_dist: true) is deprecated") if StatsD::Instrument.strict_mode_enabled?
     return_value = StatsD.measure('values.foobar', as_dist: true) { nil }
     assert_nil return_value
   end

--- a/test/statsd_test.rb
+++ b/test/statsd_test.rb
@@ -240,11 +240,13 @@ class StatsDTest < Minitest::Test
     m = capture_statsd_call { StatsD.increment('counter', no_prefix: true) }
     assert_equal 'counter', m.name
 
-    m = capture_statsd_call { StatsD.increment('counter', prefix: "foobar") }
-    assert_equal 'foobar.counter', m.name
+    unless StatsD::Instrument.strict_mode_enabled?
+      m = capture_statsd_call { StatsD.increment('counter', prefix: "foobar") }
+      assert_equal 'foobar.counter', m.name
 
-    m = capture_statsd_call { StatsD.increment('counter', prefix: "foobar", no_prefix: true) }
-    assert_equal 'counter', m.name
+      m = capture_statsd_call { StatsD.increment('counter', prefix: "foobar", no_prefix: true) }
+      assert_equal 'counter', m.name
+    end
   end
 
   protected


### PR DESCRIPTION
- Deprecate `StatsD.measure(..., as_dict: true)`. AFAICS this keyword argument was mostly meant for internal use, but is part of a public method signature. You should use `StatsD.distribution` directly instead.
- Deprecate `StatsD.metric(..., prefix: "foo")`. You can simply incorporate the prefix in the metric name. If you want to override the global prefix, set `no_prefix` to `true` and incorporate your desired prefix in the name directly.

I've modified strict mode to blow up when these keyword arguments are used. Testing that on the Shopify codebase now.