### PR TITLE
Add StatsD.client singleton

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -329,7 +329,7 @@ module StatsD
   end
 
   attr_accessor :logger, :default_sample_rate, :prefix
-  attr_writer :backend
+  attr_writer :backend, :client
   attr_reader :default_tags
 
   def default_tags=(tags)
@@ -338,6 +338,13 @@ module StatsD
 
   def backend
     @backend ||= StatsD::Instrument::Environment.default_backend
+  end
+
+  def client
+    @client ||= begin
+      require 'statsd/instrument/client'
+      StatsD::Instrument::Environment.from_env.default_client
+    end
   end
 
   # @!method measure(name, value = nil, sample_rate: nil, tags: nil, &block)


### PR DESCRIPTION
Expose a singleton client (by default, instantiated using environment variables), so in the future we can delegate the singleton methods like `StatsD.increment` to it.

This will allow us to more easily test compatibility with the new client. We may also need #171 for that.