### PR TITLE
Delegate the decision whether to sample a metric to the sink.

### DIFF
--- a/lib/statsd/instrument/capture_sink.rb
+++ b/lib/statsd/instrument/capture_sink.rb
@@ -11,6 +11,10 @@ class StatsD::Instrument::CaptureSink
     @datagrams = []
   end
 
+  def sample?(_sample_rate)
+    true
+  end
+
   def <<(datagram)
     @datagrams << datagram_class.new(datagram)
     parent << datagram

--- a/lib/statsd/instrument/client.rb
+++ b/lib/statsd/instrument/client.rb
@@ -287,7 +287,7 @@ class StatsD::Instrument::Client
   end
 
   def sample?(sample_rate)
-    sample_rate == 1 || rand < sample_rate
+    @sink.sample?(sample_rate)
   end
 
   def emit(datagram)

--- a/lib/statsd/instrument/log_sink.rb
+++ b/lib/statsd/instrument/log_sink.rb
@@ -10,6 +10,10 @@ class StatsD::Instrument::LogSink
     @severity = severity
   end
 
+  def sample?(_sample_rate)
+    true
+  end
+
   def <<(datagram)
     # Some implementations require a newline at the end of datagrams.
     # When logging, we make sure those newlines are removed using chomp.

--- a/lib/statsd/instrument/null_sink.rb
+++ b/lib/statsd/instrument/null_sink.rb
@@ -3,6 +3,10 @@
 # @note This class is part of the new Client implementation that is intended
 #   to become the new default in the next major release of this library.
 class StatsD::Instrument::NullSink
+  def sample?(_sample_rate)
+    false
+  end
+
   def <<(_datagram)
     self # noop
   end

--- a/lib/statsd/instrument/udp_sink.rb
+++ b/lib/statsd/instrument/udp_sink.rb
@@ -17,6 +17,10 @@ class StatsD::Instrument::UDPSink
     @socket = nil
   end
 
+  def sample?(sample_rate)
+    sample_rate == 1 || rand < sample_rate
+  end
+
   def <<(datagram)
     with_socket { |socket| socket.send(datagram, 0) > 0 }
     self

--- a/test/compatibility/dogstatsd_datagram_compatibility_test.rb
+++ b/test/compatibility/dogstatsd_datagram_compatibility_test.rb
@@ -6,7 +6,7 @@ require 'statsd/instrument/client'
 module Compatibility
   class DogStatsDDatagramCompatibilityTest < Minitest::Test
     def setup
-      StatsD::Instrument::Client.any_instance.stubs(:rand).returns(0)
+      StatsD::Instrument::UDPSink.any_instance.stubs(:sample?).returns(true)
       StatsD::Instrument::Backends::UDPBackend.any_instance.stubs(:rand).returns(0)
 
       @server = UDPSocket.new

--- a/test/udp_sink_test.rb
+++ b/test/udp_sink_test.rb
@@ -24,6 +24,18 @@ class UDPSinktest < Minitest::Test
     assert_equal 'foo:1|c', datagram
   end
 
+  def test_sample?
+    udp_sink = StatsD::Instrument::UDPSink.new(@host, @port)
+    assert udp_sink.sample?(1)
+    refute udp_sink.sample?(0)
+
+    udp_sink.stubs(:rand).returns(0.3)
+    assert udp_sink.sample?(0.5)
+
+    udp_sink.stubs(:rand).returns(0.7)
+    refute udp_sink.sample?(0.5)
+  end
+
   def test_parallelism
     udp_sink = StatsD::Instrument::UDPSink.new(@host, @port)
     50.times { |i| Thread.new { udp_sink << "foo:#{i}|c" << "bar:#{i}|c" } }


### PR DESCRIPTION
Delegate the decision whether to sample a metric to the sink. This allows us to sink to determine whether it wants to see the packet.

- `NullSink`: never
- `LogSink`: always
- `CaptureSink`: always
- `UDPSink`: implement actual sampling using `rand()`

This will allow us to use `capture` to capture packets like the old client.