### PR TITLE
Enable strict mode if STATSD_STRICT_MODE is set.

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -638,3 +638,4 @@ require 'statsd/instrument/assertions'
 require 'statsd/instrument/metric_expectation'
 require 'statsd/instrument/matchers' if defined?(::RSpec)
 require 'statsd/instrument/railtie' if defined?(::Rails::Railtie)
+require 'statsd/instrument/strict' if ENV['STATSD_STRICT_MODE']

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,8 +11,6 @@ require 'statsd-instrument'
 
 require_relative 'helpers/rubocop_helper'
 
-require 'statsd/instrument/strict' if ENV['STATSD_STRICT_MODE']
-
 module StatsD::Instrument
   def self.strict_mode_enabled?
     StatsD::Instrument.const_defined?(:Strict) &&


### PR DESCRIPTION
We now only use this environment variable for our own test suite. But it is very useful for applications that use this gem as well to quickly run tests in strict mode to find whether they are using the library in a deprecated way.

Updating your project's Gemfile to change the `require` for the statsd-instrument gem entry is more work. Also you have to be careful to only do it in test mode, and not to accidentally enable it in production.