### PR TITLE
Support the new client when capturing datagrams from the singleton client

### DIFF
--- a/lib/statsd/instrument/assertions.rb
+++ b/lib/statsd/instrument/assertions.rb
@@ -53,19 +53,11 @@ module StatsD::Instrument::Assertions
   # @raise [Minitest::Assertion] If an exception occurs, or if any metric (with the
   #   provided name, or any), occurred during the execution of the provided block.
   def assert_no_statsd_calls(metric_name = nil, &block)
-    metrics = capture_statsd_calls(&block)
+    raise ArgumentError, "block must be given" unless block_given?
+    metrics = capture_statsd_datagrams_with_exception_handling(&block)
+
     metrics.select! { |m| m.name == metric_name } if metric_name
     assert(metrics.empty?, "No StatsD calls for metric #{metrics.map(&:name).join(', ')} expected.")
-  rescue => exception
-    flunk(<<~MESSAGE)
-      An exception occurred in the block provided to the StatsD assertion.
-
-      #{exception.class.name}: #{exception.message}
-      \t#{exception.backtrace.join("\n\t")}
-
-      If this exception is expected, make sure to handle it using `assert_raises`
-      inside the block provided to the StatsD assertion.
-    MESSAGE
   end
 
   # Asserts that a given counter metric occurred inside the provided block.
@@ -158,74 +150,71 @@ module StatsD::Instrument::Assertions
   # @yield (see #assert_statsd_increment)
   # @return [void]
   # @raise (see #assert_statsd_increment)
-  def assert_statsd_calls(expected_metrics)
+  def assert_statsd_calls(expected_metrics, &block)
     raise ArgumentError, "block must be given" unless block_given?
+    metrics = capture_statsd_datagrams_with_exception_handling(&block)
 
-    capture_backend = StatsD::Instrument::Backends::CaptureBackend.new
-    with_capture_backend(capture_backend) do
-      begin
-        yield
-      rescue => exception
-        flunk(<<~MESSAGE)
-          An exception occurred in the block provided to the StatsD assertion.
+    matched_expected_metrics = []
+    expected_metrics.each do |expected_metric|
+      expected_metric_times = expected_metric.times
+      expected_metric_times_remaining = expected_metric.times
+      filtered_metrics = metrics.select { |m| m.type == expected_metric.type && m.name == expected_metric.name }
 
-          #{exception.class.name}: #{exception.message}
-          \t#{exception.backtrace.join("\n\t")}
-
-          If this exception is expected, make sure to handle it using `assert_raises`
-          inside the block provided to the StatsD assertion.
-        MESSAGE
+      if filtered_metrics.empty?
+        flunk("No StatsD calls for metric #{expected_metric.name} of type #{expected_metric.type} were made.")
       end
 
-      metrics = capture_backend.collected_metrics
-      matched_expected_metrics = []
-      expected_metrics.each do |expected_metric|
-        expected_metric_times = expected_metric.times
-        expected_metric_times_remaining = expected_metric.times
-        filtered_metrics = metrics.select { |m| m.type == expected_metric.type && m.name == expected_metric.name }
+      filtered_metrics.each do |metric|
+        next unless expected_metric.matches(metric)
 
-        if filtered_metrics.empty?
-          flunk("No StatsD calls for metric #{expected_metric.name} of type #{expected_metric.type} were made.")
+        assert(within_numeric_range?(metric.sample_rate),
+          "Unexpected sample rate type for metric #{metric.name}, must be numeric")
+
+        if expected_metric_times_remaining == 0
+          flunk("Unexpected StatsD call; number of times this metric " \
+            "was expected exceeded: #{expected_metric.inspect}")
         end
 
-        filtered_metrics.each do |metric|
-          next unless expected_metric.matches(metric)
-
-          assert(within_numeric_range?(metric.sample_rate),
-            "Unexpected sample rate type for metric #{metric.name}, must be numeric")
-
-          if expected_metric_times_remaining == 0
-            flunk("Unexpected StatsD call; number of times this metric " \
-              "was expected exceeded: #{expected_metric.inspect}")
-          end
-
-          expected_metric_times_remaining -= 1
-          metrics.delete(metric)
-          if expected_metric_times_remaining == 0
-            matched_expected_metrics << expected_metric
-          end
+        expected_metric_times_remaining -= 1
+        metrics.delete(metric)
+        if expected_metric_times_remaining == 0
+          matched_expected_metrics << expected_metric
         end
-
-        next if expected_metric_times_remaining == 0
-
-        msg = +"Metric expected #{expected_metric_times} times but seen " \
-          "#{expected_metric_times - expected_metric_times_remaining} " \
-          "times: #{expected_metric.inspect}."
-        msg << "\nCaptured metrics with the same key: #{filtered_metrics}" if filtered_metrics.any?
-        flunk(msg)
-      end
-      expected_metrics -= matched_expected_metrics
-
-      unless expected_metrics.empty?
-        flunk("Unexpected StatsD calls; the following metric expectations " \
-          "were not satisfied: #{expected_metrics.inspect}")
       end
 
-      pass
+      next if expected_metric_times_remaining == 0
+
+      msg = +"Metric expected #{expected_metric_times} times but seen " \
+        "#{expected_metric_times - expected_metric_times_remaining} " \
+        "times: #{expected_metric.inspect}."
+      msg << "\nCaptured metrics with the same key: #{filtered_metrics}" if filtered_metrics.any?
+      flunk(msg)
     end
+    expected_metrics -= matched_expected_metrics
+
+    unless expected_metrics.empty?
+      flunk("Unexpected StatsD calls; the following metric expectations " \
+        "were not satisfied: #{expected_metrics.inspect}")
+    end
+
+    pass
   end
 
   private
+
+  def capture_statsd_datagrams_with_exception_handling(&block)
+    capture_statsd_datagrams(&block)
+  rescue => exception
+    flunk(<<~MESSAGE)
+      An exception occurred in the block provided to the StatsD assertion.
+
+      #{exception.class.name}: #{exception.message}
+      \t#{exception.backtrace.join("\n\t")}
+
+      If this exception is expected, make sure to handle it using `assert_raises`
+      inside the block provided to the StatsD assertion.
+    MESSAGE
+  end
 
   def assert_statsd_call(metric_type, metric_name, options = {}, &block)
     options[:name] = metric_name

--- a/lib/statsd/instrument/assertions.rb
+++ b/lib/statsd/instrument/assertions.rb
@@ -53,7 +53,7 @@ module StatsD::Instrument::Assertions
   # @raise [Minitest::Assertion] If an exception occurs, or if any metric (with the
   #   provided name, or any), occurred during the execution of the provided block.
   def assert_no_statsd_calls(metric_name = nil, &block)
-    raise ArgumentError, "block must be given" unless block_given?
+    raise ArgumentError, "assert_no_statsd_calls requires a block" unless block_given?
     metrics = capture_statsd_datagrams_with_exception_handling(&block)
 
     metrics.select! { |m| m.name == metric_name } if metric_name
@@ -151,7 +151,7 @@ module StatsD::Instrument::Assertions
   # @return [void]
   # @raise (see #assert_statsd_increment)
   def assert_statsd_calls(expected_metrics, &block)
-    raise ArgumentError, "block must be given" unless block_given?
+    raise ArgumentError, "assert_statsd_* requires a block" unless block_given?
     metrics = capture_statsd_datagrams_with_exception_handling(&block)
 
     matched_expected_metrics = []

--- a/lib/statsd/instrument/assertions.rb
+++ b/lib/statsd/instrument/assertions.rb
@@ -167,9 +167,6 @@ module StatsD::Instrument::Assertions
       filtered_metrics.each do |metric|
         next unless expected_metric.matches(metric)
 
-        assert(within_numeric_range?(metric.sample_rate),
-          "Unexpected sample rate type for metric #{metric.name}, must be numeric")
-
         if expected_metric_times_remaining == 0
           flunk("Unexpected StatsD call; number of times this metric " \
             "was expected exceeded: #{expected_metric.inspect}")
@@ -222,9 +219,5 @@ module StatsD::Instrument::Assertions
     options[:times] ||= 1
     expected_metric = StatsD::Instrument::MetricExpectation.new(options)
     assert_statsd_calls([expected_metric], &block)
-  end
-
-  def within_numeric_range?(object)
-    object.is_a?(Numeric) && (0.0..1.0).cover?(object)
   end
 end

--- a/lib/statsd/instrument/datagram.rb
+++ b/lib/statsd/instrument/datagram.rb
@@ -17,7 +17,7 @@ class StatsD::Instrument::Datagram
   end
 
   def type
-    parsed_datagram[:type]
+    parsed_datagram[:type].to_sym
   end
 
   def name
@@ -25,7 +25,7 @@ class StatsD::Instrument::Datagram
   end
 
   def value
-    parsed_datagram[:value]
+    parsed_datagram[:value] # TODO: do we need to parse this to a number or integer?
   end
 
   def tags

--- a/lib/statsd/instrument/datagram.rb
+++ b/lib/statsd/instrument/datagram.rb
@@ -17,7 +17,7 @@ class StatsD::Instrument::Datagram
   end
 
   def type
-    parsed_datagram[:type].to_sym
+    @type ||= parsed_datagram[:type].to_sym
   end
 
   def name
@@ -25,7 +25,16 @@ class StatsD::Instrument::Datagram
   end
 
   def value
-    parsed_datagram[:value] # TODO: do we need to parse this to a number or integer?
+    @value ||= case type
+    when :c
+      Integer(parsed_datagram[:value])
+    when :g, :h, :d, :kv, :ms
+      Float(parsed_datagram[:value])
+    when :s
+      String(parsed_datagram[:value])
+    else
+      parsed_datagram[:value]
+    end
   end
 
   def tags

--- a/lib/statsd/instrument/helpers.rb
+++ b/lib/statsd/instrument/helpers.rb
@@ -1,22 +1,36 @@
 # frozen_string_literal: true
 
 module StatsD::Instrument::Helpers
-  def with_capture_backend(backend, &block)
-    if StatsD.backend.is_a?(StatsD::Instrument::Backends::CaptureBackend)
-      backend.parent = StatsD.backend
+  def capture_statsd_datagrams(&block)
+    if StatsD.singleton_client == StatsD.legacy_singleton_client
+      capture_statsd_metrics_on_legacy_client(&block)
+    else
+      StatsD.singleton_client.capture(&block)
     end
-
-    old_backend = StatsD.backend
-    StatsD.backend = backend
-
-    block.call
-  ensure
-    StatsD.backend = old_backend
   end
 
-  def capture_statsd_calls(&block)
+  # For backwards compatibility
+  alias_method :capture_statsd_calls, :capture_statsd_datagrams
+
+  def capture_statsd_metrics_on_legacy_client(&block)
     capture_backend = StatsD::Instrument::Backends::CaptureBackend.new
     with_capture_backend(capture_backend, &block)
     capture_backend.collected_metrics
+  end
+
+  private
+
+  def with_capture_backend(backend)
+    if StatsD.legacy_singleton_client.backend.is_a?(StatsD::Instrument::Backends::CaptureBackend)
+      backend.parent = StatsD.legacy_singleton_client.backend
+    end
+
+    old_backend = StatsD.legacy_singleton_client.backend
+    begin
+      StatsD.legacy_singleton_client.backend = backend
+      yield
+    ensure
+      StatsD.legacy_singleton_client.backend = old_backend
+    end
   end
 end

--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -101,9 +101,9 @@ class StatsD::Instrument::Metric
   # @private
   # @return [String]
   def to_s
-    str = +"#{TYPES[type]} #{name}:#{value}"
-    str << " @#{sample_rate}" if sample_rate != 1.0
-    tags&.each { |tag| str << " ##{tag}" }
+    str = +"#{name}:#{value}|#{type}"
+    str << "|@#{sample_rate}" if sample_rate && sample_rate != 1.0
+    str << "|#" << tags.join(',') if tags && !tags.empty?
     str
   end
 

--- a/test/assertions_on_legacy_client_test.rb
+++ b/test/assertions_on_legacy_client_test.rb
@@ -2,11 +2,10 @@
 
 require 'test_helper'
 
-class AssertionsTest < Minitest::Test
+class AssertionsOnLegacyClientTest < Minitest::Test
   def setup
     @old_client = StatsD.singleton_client
-    env = StatsD::Instrument::Environment.new('STATSD_IMPLEMENTATION' => 'datadog')
-    StatsD.singleton_client = env.default_client
+    StatsD.singleton_client = StatsD.legacy_singleton_client
 
     test_class = Class.new(Minitest::Test)
     test_class.send(:include, StatsD::Instrument::Assertions)

--- a/test/assertions_on_legacy_client_test.rb
+++ b/test/assertions_on_legacy_client_test.rb
@@ -137,6 +137,46 @@ class AssertionsOnLegacyClientTest < Minitest::Test
     end
   end
 
+  def test_assert_statsd_gauge_call_with_numeric_value
+    @test_case.assert_statsd_gauge('gauge', value: 42) do
+      StatsD.gauge('gauge', 42)
+    end
+
+    @test_case.assert_statsd_gauge('gauge', value: '42') do
+      StatsD.gauge('gauge', 42)
+    end
+
+    assert_raises(Minitest::Assertion) do
+      @test_case.assert_statsd_gauge('gauge', value: 42) do
+        StatsD.gauge('gauge', 45)
+      end
+    end
+  end
+
+  def test_assert_statsd_set_call_with_string_value
+    @test_case.assert_statsd_set('set', value: 12345) do
+      StatsD.set('set', '12345')
+    end
+
+    @test_case.assert_statsd_set('set', value: '12345') do
+      StatsD.set('set', '12345')
+    end
+
+    @test_case.assert_statsd_set('set', value: 12345) do
+      StatsD.set('set', 12345)
+    end
+
+    @test_case.assert_statsd_set('set', value: '12345') do
+      StatsD.set('set', 12345)
+    end
+
+    assert_raises(Minitest::Assertion) do
+      @test_case.assert_statsd_set('set', value: '42') do
+        StatsD.set('set', 45)
+      end
+    end
+  end
+
   def test_tags_will_match_subsets
     @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: { a: 1 }) do
       StatsD.increment('counter', sample_rate: 0.5, tags: { a: 1, b: 2 })

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -233,17 +233,6 @@ class AssertionsTest < Minitest::Test
     end
   end
 
-  def test_assert_statsd_call_with_wrong_sample_rate_type
-    skip("In Strict mode, the StatsD.increment call will raise") if StatsD::Instrument.strict_mode_enabled?
-
-    assertion = assert_raises(Minitest::Assertion) do
-      @test_case.assert_statsd_increment('counter', tags: ['a', 'b']) do
-        StatsD.increment('counter', sample_rate: 'abc', tags: ['a', 'b'])
-      end
-    end
-    assert_equal "Unexpected sample rate type for metric counter, must be numeric", assertion.message
-  end
-
   def test_nested_assertions
     @test_case.assert_statsd_increment('counter1') do
       @test_case.assert_statsd_increment('counter2') do

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -138,6 +138,46 @@ class AssertionsTest < Minitest::Test
     end
   end
 
+  def test_assert_statsd_gauge_call_with_numeric_value
+    @test_case.assert_statsd_gauge('gauge', value: 42) do
+      StatsD.gauge('gauge', 42)
+    end
+
+    @test_case.assert_statsd_gauge('gauge', value: '42') do
+      StatsD.gauge('gauge', 42)
+    end
+
+    assert_raises(Minitest::Assertion) do
+      @test_case.assert_statsd_gauge('gauge', value: 42) do
+        StatsD.gauge('gauge', 45)
+      end
+    end
+  end
+
+  def test_assert_statsd_set_call_with_string_value
+    @test_case.assert_statsd_set('set', value: 12345) do
+      StatsD.set('set', '12345')
+    end
+
+    @test_case.assert_statsd_set('set', value: '12345') do
+      StatsD.set('set', '12345')
+    end
+
+    @test_case.assert_statsd_set('set', value: 12345) do
+      StatsD.set('set', 12345)
+    end
+
+    @test_case.assert_statsd_set('set', value: '12345') do
+      StatsD.set('set', 12345)
+    end
+
+    assert_raises(Minitest::Assertion) do
+      @test_case.assert_statsd_set('set', value: '42') do
+        StatsD.set('set', 45)
+      end
+    end
+  end
+
   def test_tags_will_match_subsets
     @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: { a: 1 }) do
       StatsD.increment('counter', sample_rate: 0.5, tags: { a: 1, b: 2 })

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -22,4 +22,21 @@ class HelpersTest < Minitest::Test
     assert_equal 'gauge', metrics[1].name
     assert_equal 12, metrics[1].value
   end
+
+  def test_capture_metrics_with_new_client
+    @old_client = StatsD.singleton_client
+    StatsD.singleton_client = StatsD.client
+
+    StatsD.increment('counter')
+    metrics = @test_case.capture_statsd_datagrams do
+      StatsD.increment('counter')
+      StatsD.gauge('gauge', 12)
+    end
+    StatsD.gauge('gauge', 15)
+
+    assert_equal 2, metrics.length
+
+  ensure
+    StatsD.singleton_client = @old_client
+  end
 end

--- a/test/logger_backend_test.rb
+++ b/test/logger_backend_test.rb
@@ -15,8 +15,8 @@ class LoggerBackendTest < Minitest::Test
     @backend.collect_metric(@metric1)
     @backend.collect_metric(@metric2)
     assert_equal <<~LOG, @io.string
-      [StatsD] increment mock.counter:1 #a:b #c:d
-      [StatsD] measure mock.measure:123 @0.3
+      [StatsD] mock.counter:1|c|#a:b,c:d
+      [StatsD] mock.measure:123|ms|@0.3
     LOG
   end
 end

--- a/test/statsd_instrumentation_test.rb
+++ b/test/statsd_instrumentation_test.rb
@@ -221,11 +221,11 @@ class StatsDInstrumentationTest < Minitest::Test
     ActiveMerchant::UniqueGateway.statsd_remove_measure :ssl_post, 'ActiveMerchant::Gateway.ssl_post'
   end
 
-  def test_statsd_measure_yells_without_block
+  def test_statsd_measure_raises_without_a_provided_block
     err = assert_raises(ArgumentError) do
       assert_statsd_measure('ActiveMerchant.Gateway.ssl_post')
     end
-    assert_equal "block must be given", err.to_s
+    assert_equal 'assert_statsd_* requires a block', err.message
   end
 
   def test_statsd_measure_with_method_receiving_block
@@ -268,11 +268,11 @@ class StatsDInstrumentationTest < Minitest::Test
     ActiveMerchant::UniqueGateway.statsd_remove_distribution :ssl_post, 'ActiveMerchant::Gateway.ssl_post'
   end
 
-  def test_statsd_distribution_yells_without_block
+  def test_statsd_distribution_raises_without_a_provided_block
     err = assert_raises(ArgumentError) do
       assert_statsd_distribution('ActiveMerchant.Gateway.ssl_post')
     end
-    assert_equal "block must be given", err.to_s
+    assert_equal "assert_statsd_* requires a block", err.to_s
   end
 
   def test_statsd_distribution_with_method_receiving_block


### PR DESCRIPTION
- Set up datagram capturing based on whether the singleton is the legacy singleton, or an instance of the new client.
- Update `assert_statsd_*` methods to work with both clients.
- Run the assertions tests both against the new and the legacy clients.
- Compatibility fixes between `Metric` & `Datagram` and how they interface with `MetricExpectation`.

The big difference is that the old capture method will return a bunch of `StatsD::Instrument::Metric` instances, while the new client will give a bunch of `StatsD::Instrument::Datagram` instances. These objects are not 100% compatible. The behave closely enough to pass the tests that we have for them, but I'll see if I can find a can run the Shopify CI suite to see if we depend on implementation details.