### PR TITLE
Allow # in tag values

### DIFF
--- a/lib/statsd/instrument/datagram.rb
+++ b/lib/statsd/instrument/datagram.rb
@@ -59,7 +59,7 @@ class StatsD::Instrument::Datagram
     \A
     (?<name>[^\:\|\@]+)\:(?<value>[^\:\|\@]+)\|(?<type>c|ms|g|s|h|d)
     (?:\|\@(?<sample_rate>\d*(?:\.\d*)?))?
-    (?:\|\#(?<tags>(?:[^\|\#,]+(?:,[^\|\#,]+)*)))?
+    (?:\|\#(?<tags>(?:[^\|,]+(?:,[^\|,]+)*)))?
     \n? # In some implementations, the datagram may include a trailing newline.
     \z
   }x

--- a/test/datagram_builder_test.rb
+++ b/test/datagram_builder_test.rb
@@ -17,7 +17,7 @@ class DatagramBuilderTest < Minitest::Test
   end
 
   def test_normalize_unsupported_tag_names
-    assert_equal ['ignored'], @datagram_builder.send(:normalize_tags, ['igno|re,d'])
+    assert_equal ['ign#ored'], @datagram_builder.send(:normalize_tags, ['ign#o|re,d'])
     # Note: how this is interpreted by the backend is undefined.
     # We rely on the user to not do stuff like this if they don't want to be surprised.
     # We do not want to take the performance hit of normaling this.

--- a/test/datagram_test.rb
+++ b/test/datagram_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+require 'statsd/instrument/client'
+
+class DatagramTest < Minitest::Test
+  def test_parsing_datagrams
+    datagram = 'Kernel.Orders.order_creation_path:1|c|' \
+      '#order_source:web,code_source:NilController#NilAction,order_builder:false,' \
+      'multi_currency:false,fulfillment_orders_beta_enabled:false'
+
+    parsed = StatsD::Instrument::Datagram.new(datagram)
+    assert_includes parsed.tags, 'code_source:NilController#NilAction'
+  end
+end


### PR DESCRIPTION
The current implementation allows `#` in tag values. The datagram parser was not accepting that, so it failed to parse some of the datagrams that originate from the Shopify codebase. This fixes it.