### PR TITLE
Automatically switch to the new client if STATSD_USE_NEW_CLIENT is set.

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -390,7 +390,7 @@ module StatsD
   end
 
   def singleton_client
-    @singleton_client ||= legacy_singleton_client
+    @singleton_client ||= StatsD::Instrument::Environment.from_env.client
   end
 
   def client

--- a/lib/statsd/instrument/environment.rb
+++ b/lib/statsd/instrument/environment.rb
@@ -97,6 +97,15 @@ class StatsD::Instrument::Environment
     env.key?('STATSD_DEFAULT_TAGS') ? env.fetch('STATSD_DEFAULT_TAGS').split(',') : nil
   end
 
+  def client
+    if env.key?('STATSD_USE_NEW_CLIENT')
+      require 'statsd/instrument/client'
+      default_client
+    else
+      StatsD::Instrument::LegacyClient.singleton
+    end
+  end
+
   def default_client
     @default_client ||= StatsD::Instrument::Client.new(
       sink: default_sink_for_environment,


### PR DESCRIPTION
Initialize `StatsD.singleton_client` (which handles method calls to the StatsD singleton) to a new client if `STATSD_USE_NEW_CLIENT` is set, rather than the legacy singleton client.

This makes it easy to test the new client on an existing codebase to verify compatibility.