### PR TITLE
Always require new client

### DIFF
--- a/benchmark/datagram-client
+++ b/benchmark/datagram-client
@@ -14,7 +14,6 @@ ENV['STATSD_ADDR'] = "#{legacy_receiver.addr[2]}:#{legacy_receiver.addr[1]}"
 ENV['STATSD_IMPLEMENTATION'] ||= 'datadog'
 
 require 'statsd-instrument'
-require 'statsd/instrument/client'
 
 legacy_client = StatsD
 

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -394,10 +394,7 @@ module StatsD
   end
 
   def client
-    @client ||= begin
-      require 'statsd/instrument/client'
-      StatsD::Instrument::Environment.from_env.default_client
-    end
+    @client ||= StatsD::Instrument::Environment.from_env.default_client
   end
 
   # Singleton methods will be delegated to the singleton client.
@@ -413,6 +410,7 @@ require 'statsd/instrument/version'
 require 'statsd/instrument/metric'
 require 'statsd/instrument/legacy_client'
 require 'statsd/instrument/backend'
+require 'statsd/instrument/client'
 require 'statsd/instrument/environment'
 require 'statsd/instrument/helpers'
 require 'statsd/instrument/assertions'

--- a/test/capture_sink_test.rb
+++ b/test/capture_sink_test.rb
@@ -2,8 +2,6 @@
 
 require 'test_helper'
 
-require 'statsd/instrument/client'
-
 class CaptureSinktest < Minitest::Test
   def test_capture_sink_captures_datagram_instances
     capture_sink = StatsD::Instrument::CaptureSink.new(parent: [])

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -2,8 +2,6 @@
 
 require 'test_helper'
 
-require 'statsd/instrument/client'
-
 class ClientTest < Minitest::Test
   def setup
     @client = StatsD::Instrument::Client.new(datagram_builder_class: StatsD::Instrument::StatsDDatagramBuilder)

--- a/test/compatibility/dogstatsd_datagram_compatibility_test.rb
+++ b/test/compatibility/dogstatsd_datagram_compatibility_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-require 'statsd/instrument/client'
 
 module Compatibility
   class DogStatsDDatagramCompatibilityTest < Minitest::Test

--- a/test/datagram_builder_test.rb
+++ b/test/datagram_builder_test.rb
@@ -2,8 +2,6 @@
 
 require 'test_helper'
 
-require 'statsd/instrument/client'
-
 class DatagramBuilderTest < Minitest::Test
   def setup
     @datagram_builder = StatsD::Instrument::DatagramBuilder.new

--- a/test/datagram_test.rb
+++ b/test/datagram_test.rb
@@ -2,8 +2,6 @@
 
 require 'test_helper'
 
-require 'statsd/instrument/client'
-
 class DatagramTest < Minitest::Test
   def test_parsing_datagrams
     datagram = 'Kernel.Orders.order_creation_path:1|c|' \

--- a/test/dogstatsd_datagram_builder_test.rb
+++ b/test/dogstatsd_datagram_builder_test.rb
@@ -2,8 +2,6 @@
 
 require 'test_helper'
 
-require 'statsd/instrument/client'
-
 class DogStatsDDatagramBuilderTest < Minitest::Test
   def setup
     @datagram_builder = StatsD::Instrument::DogStatsDDatagramBuilder.new

--- a/test/log_sink_test.rb
+++ b/test/log_sink_test.rb
@@ -2,8 +2,6 @@
 
 require 'test_helper'
 
-require 'statsd/instrument/client'
-
 class LogSinktest < Minitest::Test
   def test_log_sink
     logger = Logger.new(log = StringIO.new)

--- a/test/null_sink_test.rb
+++ b/test/null_sink_test.rb
@@ -2,8 +2,6 @@
 
 require 'test_helper'
 
-require 'statsd/instrument/client'
-
 class NullSinktest < Minitest::Test
   def test_null_sink
     null_sink = StatsD::Instrument::NullSink.new

--- a/test/statsd_datagram_builder_test.rb
+++ b/test/statsd_datagram_builder_test.rb
@@ -2,8 +2,6 @@
 
 require 'test_helper'
 
-require 'statsd/instrument/client'
-
 class StatsDDatagramBuilderTest < Minitest::Test
   def setup
     @datagram_builder = StatsD::Instrument::StatsDDatagramBuilder.new

--- a/test/udp_sink_test.rb
+++ b/test/udp_sink_test.rb
@@ -2,8 +2,6 @@
 
 require 'test_helper'
 
-require 'statsd/instrument/client'
-
 class UDPSinktest < Minitest::Test
   def setup
     @receiver = UDPSocket.new


### PR DESCRIPTION
We were only requiring the new client if you would actually use it, which made sense for a beta implementation that people should not rely on.

The next version of this library will really focus on letting people switch to the new client. So it doesn't make much sense anymore to load it conditionally. I've changed the `require` of the new client to always happen when the library is loaded, to simplify things.