### PR TITLE
Refactor metric/datagram expectations to have more flexibility

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -414,7 +414,7 @@ require 'statsd/instrument/client'
 require 'statsd/instrument/environment'
 require 'statsd/instrument/helpers'
 require 'statsd/instrument/assertions'
-require 'statsd/instrument/metric_expectation'
+require 'statsd/instrument/expectation'
 require 'statsd/instrument/matchers' if defined?(::RSpec)
 require 'statsd/instrument/railtie' if defined?(::Rails::Railtie)
 require 'statsd/instrument/strict' if ENV['STATSD_STRICT_MODE']

--- a/lib/statsd/instrument/assertions.rb
+++ b/lib/statsd/instrument/assertions.rb
@@ -72,7 +72,8 @@ module StatsD::Instrument::Assertions
   # @raise [Minitest::Assertion] If an exception occurs, or if the metric did
   #   not occur as specified during the execution the block.
   def assert_statsd_increment(metric_name, **options, &block)
-    assert_statsd_expectation(:c, metric_name, **options, &block)
+    expectation = StatsD::Instrument::Expectation.increment(metric_name, **options)
+    assert_statsd_expectations([expectation], &block)
   end
 
   # Asserts that a given timing metric occurred inside the provided block.
@@ -83,7 +84,8 @@ module StatsD::Instrument::Assertions
   # @return [void]
   # @raise (see #assert_statsd_increment)
   def assert_statsd_measure(metric_name, **options, &block)
-    assert_statsd_expectation(:ms, metric_name, **options, &block)
+    expectation = StatsD::Instrument::Expectation.measure(metric_name, **options)
+    assert_statsd_expectations([expectation], &block)
   end
 
   # Asserts that a given gauge metric occurred inside the provided block.
@@ -94,7 +96,8 @@ module StatsD::Instrument::Assertions
   # @return [void]
   # @raise (see #assert_statsd_increment)
   def assert_statsd_gauge(metric_name, **options, &block)
-    assert_statsd_expectation(:g, metric_name, **options, &block)
+    expectation = StatsD::Instrument::Expectation.gauge(metric_name, **options)
+    assert_statsd_expectations([expectation], &block)
   end
 
   # Asserts that a given histogram metric occurred inside the provided block.
@@ -105,7 +108,8 @@ module StatsD::Instrument::Assertions
   # @return [void]
   # @raise (see #assert_statsd_increment)
   def assert_statsd_histogram(metric_name, **options, &block)
-    assert_statsd_expectation(:h, metric_name, **options, &block)
+    expectation = StatsD::Instrument::Expectation.histogram(metric_name, **options)
+    assert_statsd_expectations([expectation], &block)
   end
 
   # Asserts that a given distribution metric occurred inside the provided block.
@@ -116,7 +120,8 @@ module StatsD::Instrument::Assertions
   # @return [void]
   # @raise (see #assert_statsd_increment)
   def assert_statsd_distribution(metric_name, **options, &block)
-    assert_statsd_expectation(:d, metric_name, **options, &block)
+    expectation = StatsD::Instrument::Expectation.distribution(metric_name, **options)
+    assert_statsd_expectations([expectation], &block)
   end
 
   # Asserts that a given set metric occurred inside the provided block.
@@ -127,7 +132,8 @@ module StatsD::Instrument::Assertions
   # @return [void]
   # @raise (see #assert_statsd_increment)
   def assert_statsd_set(metric_name, **options, &block)
-    assert_statsd_expectation(:s, metric_name, **options, &block)
+    expectation = StatsD::Instrument::Expectation.set(metric_name, **options)
+    assert_statsd_expectations([expectation], &block)
   end
 
   # Asserts that a given key/value metric occurred inside the provided block.
@@ -138,7 +144,8 @@ module StatsD::Instrument::Assertions
   # @return [void]
   # @raise (see #assert_statsd_increment)
   def assert_statsd_key_value(metric_name, **options, &block)
-    assert_statsd_expectation(:kv, metric_name, **options, &block)
+    expectation = StatsD::Instrument::Expectation.key_value(metric_name, **options)
+    assert_statsd_expectations([expectation], &block)
   end
 
   # Asserts that the set of provided metric expectations came true.
@@ -218,10 +225,5 @@ module StatsD::Instrument::Assertions
       If this exception is expected, make sure to handle it using `assert_raises`
       inside the block provided to the StatsD assertion.
     MESSAGE
-  end
-
-  def assert_statsd_expectation(type, name, **options, &block)
-    expectation = StatsD::Instrument::Expectation.new(type: type, name: name, **options)
-    assert_statsd_expectations([expectation], &block)
   end
 end

--- a/lib/statsd/instrument/assertions.rb
+++ b/lib/statsd/instrument/assertions.rb
@@ -71,9 +71,9 @@ module StatsD::Instrument::Assertions
   # @return [void]
   # @raise [Minitest::Assertion] If an exception occurs, or if the metric did
   #   not occur as specified during the execution the block.
-  def assert_statsd_increment(metric_name, **options, &block)
+  def assert_statsd_increment(metric_name, datagrams: nil, **options, &block)
     expectation = StatsD::Instrument::Expectation.increment(metric_name, **options)
-    assert_statsd_expectations([expectation], &block)
+    assert_statsd_expectation(expectation, datagrams: datagrams, &block)
   end
 
   # Asserts that a given timing metric occurred inside the provided block.
@@ -83,9 +83,9 @@ module StatsD::Instrument::Assertions
   # @yield (see #assert_statsd_increment)
   # @return [void]
   # @raise (see #assert_statsd_increment)
-  def assert_statsd_measure(metric_name, **options, &block)
+  def assert_statsd_measure(metric_name, datagrams: nil, **options, &block)
     expectation = StatsD::Instrument::Expectation.measure(metric_name, **options)
-    assert_statsd_expectations([expectation], &block)
+    assert_statsd_expectation(expectation, datagrams: datagrams, &block)
   end
 
   # Asserts that a given gauge metric occurred inside the provided block.
@@ -95,9 +95,9 @@ module StatsD::Instrument::Assertions
   # @yield (see #assert_statsd_increment)
   # @return [void]
   # @raise (see #assert_statsd_increment)
-  def assert_statsd_gauge(metric_name, **options, &block)
+  def assert_statsd_gauge(metric_name, datagrams: nil, **options, &block)
     expectation = StatsD::Instrument::Expectation.gauge(metric_name, **options)
-    assert_statsd_expectations([expectation], &block)
+    assert_statsd_expectation(expectation, datagrams: datagrams, &block)
   end
 
   # Asserts that a given histogram metric occurred inside the provided block.
@@ -107,9 +107,9 @@ module StatsD::Instrument::Assertions
   # @yield (see #assert_statsd_increment)
   # @return [void]
   # @raise (see #assert_statsd_increment)
-  def assert_statsd_histogram(metric_name, **options, &block)
+  def assert_statsd_histogram(metric_name, datagrams: nil, **options, &block)
     expectation = StatsD::Instrument::Expectation.histogram(metric_name, **options)
-    assert_statsd_expectations([expectation], &block)
+    assert_statsd_expectation(expectation, datagrams: datagrams, &block)
   end
 
   # Asserts that a given distribution metric occurred inside the provided block.
@@ -119,9 +119,9 @@ module StatsD::Instrument::Assertions
   # @yield (see #assert_statsd_increment)
   # @return [void]
   # @raise (see #assert_statsd_increment)
-  def assert_statsd_distribution(metric_name, **options, &block)
+  def assert_statsd_distribution(metric_name, datagrams: nil, **options, &block)
     expectation = StatsD::Instrument::Expectation.distribution(metric_name, **options)
-    assert_statsd_expectations([expectation], &block)
+    assert_statsd_expectation(expectation, datagrams: datagrams, &block)
   end
 
   # Asserts that a given set metric occurred inside the provided block.
@@ -131,9 +131,9 @@ module StatsD::Instrument::Assertions
   # @yield (see #assert_statsd_increment)
   # @return [void]
   # @raise (see #assert_statsd_increment)
-  def assert_statsd_set(metric_name, **options, &block)
+  def assert_statsd_set(metric_name, datagrams: nil, **options, &block)
     expectation = StatsD::Instrument::Expectation.set(metric_name, **options)
-    assert_statsd_expectations([expectation], &block)
+    assert_statsd_expectation(expectation, datagrams: datagrams, &block)
   end
 
   # Asserts that a given key/value metric occurred inside the provided block.
@@ -143,9 +143,9 @@ module StatsD::Instrument::Assertions
   # @yield (see #assert_statsd_increment)
   # @return [void]
   # @raise (see #assert_statsd_increment)
-  def assert_statsd_key_value(metric_name, **options, &block)
+  def assert_statsd_key_value(metric_name, datagrams: nil, **options, &block)
     expectation = StatsD::Instrument::Expectation.key_value(metric_name, **options)
-    assert_statsd_expectations([expectation], &block)
+    assert_statsd_expectation(expectation, datagrams: datagrams, &block)
   end
 
   # Asserts that the set of provided metric expectations came true.
@@ -165,6 +165,7 @@ module StatsD::Instrument::Assertions
       datagrams = capture_statsd_datagrams_with_exception_handling(&block)
     end
 
+    expectations = Array(expectations)
     matched_expectations = []
     expectations.each do |expectation|
       expectation_times = expectation.times
@@ -210,6 +211,7 @@ module StatsD::Instrument::Assertions
 
   # For backwards compatibility
   alias_method :assert_statsd_calls, :assert_statsd_expectations
+  alias_method :assert_statsd_expectation, :assert_statsd_expectations
 
   private
 

--- a/lib/statsd/instrument/assertions.rb
+++ b/lib/statsd/instrument/assertions.rb
@@ -52,10 +52,10 @@ module StatsD::Instrument::Assertions
   # @return [void]
   # @raise [Minitest::Assertion] If an exception occurs, or if any metric (with the
   #   provided name, or any), occurred during the execution of the provided block.
-  def assert_no_statsd_calls(metric_name = nil, datagrams: nil, &block)
+  def assert_no_statsd_calls(metric_name = nil, datagrams: nil, client: nil, &block)
     if datagrams.nil?
       raise LocalJumpError, "assert_no_statsd_calls requires a block" unless block_given?
-      datagrams = capture_statsd_datagrams_with_exception_handling(&block)
+      datagrams = capture_statsd_datagrams_with_exception_handling(client: client, &block)
     end
 
     datagrams.select! { |m| m.name == metric_name } if metric_name
@@ -71,9 +71,9 @@ module StatsD::Instrument::Assertions
   # @return [void]
   # @raise [Minitest::Assertion] If an exception occurs, or if the metric did
   #   not occur as specified during the execution the block.
-  def assert_statsd_increment(metric_name, datagrams: nil, **options, &block)
+  def assert_statsd_increment(metric_name, datagrams: nil, client: nil, **options, &block)
     expectation = StatsD::Instrument::Expectation.increment(metric_name, **options)
-    assert_statsd_expectation(expectation, datagrams: datagrams, &block)
+    assert_statsd_expectation(expectation, datagrams: datagrams, client: client, &block)
   end
 
   # Asserts that a given timing metric occurred inside the provided block.
@@ -83,9 +83,9 @@ module StatsD::Instrument::Assertions
   # @yield (see #assert_statsd_increment)
   # @return [void]
   # @raise (see #assert_statsd_increment)
-  def assert_statsd_measure(metric_name, datagrams: nil, **options, &block)
+  def assert_statsd_measure(metric_name, datagrams: nil, client: nil, **options, &block)
     expectation = StatsD::Instrument::Expectation.measure(metric_name, **options)
-    assert_statsd_expectation(expectation, datagrams: datagrams, &block)
+    assert_statsd_expectation(expectation, datagrams: datagrams, client: client, &block)
   end
 
   # Asserts that a given gauge metric occurred inside the provided block.
@@ -95,9 +95,9 @@ module StatsD::Instrument::Assertions
   # @yield (see #assert_statsd_increment)
   # @return [void]
   # @raise (see #assert_statsd_increment)
-  def assert_statsd_gauge(metric_name, datagrams: nil, **options, &block)
+  def assert_statsd_gauge(metric_name, datagrams: nil, client: nil, **options, &block)
     expectation = StatsD::Instrument::Expectation.gauge(metric_name, **options)
-    assert_statsd_expectation(expectation, datagrams: datagrams, &block)
+    assert_statsd_expectation(expectation, datagrams: datagrams, client: client, &block)
   end
 
   # Asserts that a given histogram metric occurred inside the provided block.
@@ -107,9 +107,9 @@ module StatsD::Instrument::Assertions
   # @yield (see #assert_statsd_increment)
   # @return [void]
   # @raise (see #assert_statsd_increment)
-  def assert_statsd_histogram(metric_name, datagrams: nil, **options, &block)
+  def assert_statsd_histogram(metric_name, datagrams: nil, client: nil, **options, &block)
     expectation = StatsD::Instrument::Expectation.histogram(metric_name, **options)
-    assert_statsd_expectation(expectation, datagrams: datagrams, &block)
+    assert_statsd_expectation(expectation, datagrams: datagrams, client: client, &block)
   end
 
   # Asserts that a given distribution metric occurred inside the provided block.
@@ -119,9 +119,9 @@ module StatsD::Instrument::Assertions
   # @yield (see #assert_statsd_increment)
   # @return [void]
   # @raise (see #assert_statsd_increment)
-  def assert_statsd_distribution(metric_name, datagrams: nil, **options, &block)
+  def assert_statsd_distribution(metric_name, datagrams: nil, client: nil, **options, &block)
     expectation = StatsD::Instrument::Expectation.distribution(metric_name, **options)
-    assert_statsd_expectation(expectation, datagrams: datagrams, &block)
+    assert_statsd_expectation(expectation, datagrams: datagrams, client: client, &block)
   end
 
   # Asserts that a given set metric occurred inside the provided block.
@@ -131,9 +131,9 @@ module StatsD::Instrument::Assertions
   # @yield (see #assert_statsd_increment)
   # @return [void]
   # @raise (see #assert_statsd_increment)
-  def assert_statsd_set(metric_name, datagrams: nil, **options, &block)
+  def assert_statsd_set(metric_name, datagrams: nil, client: nil, **options, &block)
     expectation = StatsD::Instrument::Expectation.set(metric_name, **options)
-    assert_statsd_expectation(expectation, datagrams: datagrams, &block)
+    assert_statsd_expectation(expectation, datagrams: datagrams, client: client, &block)
   end
 
   # Asserts that a given key/value metric occurred inside the provided block.
@@ -143,9 +143,9 @@ module StatsD::Instrument::Assertions
   # @yield (see #assert_statsd_increment)
   # @return [void]
   # @raise (see #assert_statsd_increment)
-  def assert_statsd_key_value(metric_name, datagrams: nil, **options, &block)
+  def assert_statsd_key_value(metric_name, datagrams: nil, client: nil, **options, &block)
     expectation = StatsD::Instrument::Expectation.key_value(metric_name, **options)
-    assert_statsd_expectation(expectation, datagrams: datagrams, &block)
+    assert_statsd_expectation(expectation, datagrams: datagrams, client: client, &block)
   end
 
   # Asserts that the set of provided metric expectations came true.
@@ -159,10 +159,10 @@ module StatsD::Instrument::Assertions
   # @yield (see #assert_statsd_increment)
   # @return [void]
   # @raise (see #assert_statsd_increment)
-  def assert_statsd_expectations(expectations, datagrams: nil, &block)
+  def assert_statsd_expectations(expectations, datagrams: nil, client: nil, &block)
     if datagrams.nil?
       raise LocalJumpError, "assert_statsd_expectations requires a block" unless block_given?
-      datagrams = capture_statsd_datagrams_with_exception_handling(&block)
+      datagrams = capture_statsd_datagrams_with_exception_handling(client: client, &block)
     end
 
     expectations = Array(expectations)
@@ -215,8 +215,8 @@ module StatsD::Instrument::Assertions
 
   private
 
-  def capture_statsd_datagrams_with_exception_handling(&block)
-    capture_statsd_datagrams(&block)
+  def capture_statsd_datagrams_with_exception_handling(client:, &block)
+    capture_statsd_datagrams(client: client, &block)
   rescue => exception
     flunk(<<~MESSAGE)
       An exception occurred in the block provided to the StatsD assertion.

--- a/lib/statsd/instrument/expectation.rb
+++ b/lib/statsd/instrument/expectation.rb
@@ -2,6 +2,36 @@
 
 # @private
 class StatsD::Instrument::Expectation
+  class << self
+    def increment(name, **options)
+      new(type: :c, name: name, **options)
+    end
+
+    def measure(name, **options)
+      new(type: :ms, name: name, **options)
+    end
+
+    def gauge(name, **options)
+      new(type: :g, name: name, **options)
+    end
+
+    def set(name, **options)
+      new(type: :s, name: name, **options)
+    end
+
+    def key_value(name, **options)
+      new(type: :kv, name: name, **options)
+    end
+
+    def distribution(name, **options)
+      new(type: :d, name: name, **options)
+    end
+
+    def histogram(name, **options)
+      new(type: :h, name: name, **options)
+    end
+  end
+
   attr_accessor :times, :type, :name, :value, :sample_rate, :tags
   attr_reader :ignore_tags
 
@@ -52,7 +82,7 @@ class StatsD::Instrument::Expectation
 
   def to_s
     str = +"#{name}:#{value || '<anything>'}|#{type}"
-    str << "|@#{sample_rate}" if sample_rate && sample_rate != 1.0
+    str << "|@#{sample_rate}" if sample_rate
     str << "|#" << tags.join(',') if tags
     str << " (expected #{times} times)" if times > 1
     str

--- a/lib/statsd/instrument/expectation.rb
+++ b/lib/statsd/instrument/expectation.rb
@@ -76,10 +76,6 @@ class StatsD::Instrument::Expectation
     true
   end
 
-  def default_value
-    1 if type == :c
-  end
-
   def to_s
     str = +"#{name}:#{value || '<anything>'}|#{type}"
     str << "|@#{sample_rate}" if sample_rate

--- a/lib/statsd/instrument/expectation.rb
+++ b/lib/statsd/instrument/expectation.rb
@@ -1,34 +1,18 @@
 # frozen_string_literal: true
 
 # @private
-class StatsD::Instrument::MetricExpectation
+class StatsD::Instrument::Expectation
   attr_accessor :times, :type, :name, :value, :sample_rate, :tags
   attr_reader :ignore_tags
 
-  def initialize(options = {})
-    if options[:type]
-      @type = options[:type]
-    else
-      raise ArgumentError, "Metric :type is required."
-    end
-
-    if options[:name]
-      @name = options[:name].to_s
-    else
-      raise ArgumentError, "Metric :name is required."
-    end
-
-    if options[:times]
-      @times = options[:times]
-    else
-      raise ArgumentError, "Metric :times is required."
-    end
-
-    @name = StatsD.prefix ? "#{StatsD.prefix}.#{@name}" : @name unless options[:no_prefix]
-    @tags = StatsD::Instrument::Metric.normalize_tags(options[:tags])
-    @sample_rate = options[:sample_rate]
-    @value = normalized_value_for_type(type, options[:value]) if options[:value]
-    @ignore_tags = StatsD::Instrument::Metric.normalize_tags(options[:ignore_tags])
+  def initialize(type:, name:, value: nil, sample_rate: nil, tags: nil, ignore_tags: nil, no_prefix: false, times: 1)
+    @type = type
+    @name = StatsD.prefix ? "#{StatsD.prefix}.#{name}" : name unless no_prefix
+    @value = normalized_value_for_type(type, value) if value
+    @sample_rate = sample_rate
+    @tags = StatsD::Instrument::Metric.normalize_tags(tags)
+    @ignore_tags = StatsD::Instrument::Metric.normalize_tags(ignore_tags)
+    @times = times
   end
 
   def normalized_value_for_type(type, value)
@@ -75,6 +59,9 @@ class StatsD::Instrument::MetricExpectation
   end
 
   def inspect
-    "#<StatsD::Instrument::MetricExpectation:\"#{self}\">"
+    "#<StatsD::Instrument::Expectation:\"#{self}\">"
   end
 end
+
+# For backwards compatibility
+StatsD::Instrument::MetricExpectation = StatsD::Instrument::Expectation

--- a/lib/statsd/instrument/helpers.rb
+++ b/lib/statsd/instrument/helpers.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
 module StatsD::Instrument::Helpers
-  def capture_statsd_datagrams(&block)
-    if StatsD.singleton_client == StatsD.legacy_singleton_client
+  def capture_statsd_datagrams(client: nil, &block)
+    client ||= StatsD.singleton_client
+    case client
+    when StatsD.legacy_singleton_client
       capture_statsd_metrics_on_legacy_client(&block)
+    when StatsD::Instrument::Client
+      client.capture(&block)
     else
-      StatsD.singleton_client.capture(&block)
+      raise ArgumentError, "Don't know how to capture StatsD datagrams from #{client.inspect}!"
     end
   end
 

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -201,6 +201,16 @@ class AssertionsTest < Minitest::Test
     assert_includes assertion.message, "MyJob"
   end
 
+  def test_capture_and_assert
+    datagrams = @test_case.capture_statsd_datagrams do
+      StatsD.increment('counter', tags: { foo: 1 })
+      StatsD.increment('counter', tags: { foo: 2 })
+    end
+
+    @test_case.assert_statsd_increment('counter', tags: ['foo:1'], datagrams: datagrams)
+    @test_case.assert_statsd_increment('counter', tags: ['foo:2'], datagrams: datagrams)
+  end
+
   def test_multiple_expectations_are_not_order_dependent
     foo_1_metric = StatsD::Instrument::Expectation.increment('counter', tags: ['foo:1'])
     foo_2_metric = StatsD::Instrument::Expectation.increment('counter', tags: ['foo:2'])

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -202,38 +202,38 @@ class AssertionsTest < Minitest::Test
   end
 
   def test_multiple_expectations_are_not_order_dependent
-    foo_1_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:1'])
-    foo_2_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
+    foo_1_metric = StatsD::Instrument::Expectation.increment('counter', tags: ['foo:1'])
+    foo_2_metric = StatsD::Instrument::Expectation.increment('counter', tags: ['foo:2'])
     @test_case.assert_statsd_expectations([foo_1_metric, foo_2_metric]) do
       StatsD.increment('counter', tags: { foo: 1 })
       StatsD.increment('counter', tags: { foo: 2 })
     end
 
-    foo_1_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:1'])
-    foo_2_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
+    foo_1_metric = StatsD::Instrument::Expectation.increment('counter', tags: ['foo:1'])
+    foo_2_metric = StatsD::Instrument::Expectation.increment('counter', tags: ['foo:2'])
     @test_case.assert_statsd_expectations([foo_2_metric, foo_1_metric]) do
       StatsD.increment('counter', tags: { foo: 1 })
       StatsD.increment('counter', tags: { foo: 2 })
     end
 
-    foo_1_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
-    foo_2_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
+    foo_1_metric = StatsD::Instrument::Expectation.increment('counter', times: 2, tags: ['foo:1'])
+    foo_2_metric = StatsD::Instrument::Expectation.increment('counter', tags: ['foo:2'])
     @test_case.assert_statsd_expectations([foo_1_metric, foo_2_metric]) do
       StatsD.increment('counter', tags: { foo: 1 })
       StatsD.increment('counter', tags: { foo: 1 })
       StatsD.increment('counter', tags: { foo: 2 })
     end
 
-    foo_1_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
-    foo_2_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
+    foo_1_metric = StatsD::Instrument::Expectation.increment('counter', times: 2, tags: ['foo:1'])
+    foo_2_metric = StatsD::Instrument::Expectation.increment('counter', tags: ['foo:2'])
     @test_case.assert_statsd_expectations([foo_2_metric, foo_1_metric]) do
       StatsD.increment('counter', tags: { foo: 1 })
       StatsD.increment('counter', tags: { foo: 1 })
       StatsD.increment('counter', tags: { foo: 2 })
     end
 
-    foo_1_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
-    foo_2_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
+    foo_1_metric = StatsD::Instrument::Expectation.increment('counter', times: 2, tags: ['foo:1'])
+    foo_2_metric = StatsD::Instrument::Expectation.increment('counter', tags: ['foo:2'])
     @test_case.assert_statsd_expectations([foo_2_metric, foo_1_metric]) do
       StatsD.increment('counter', tags: { foo: 1 })
       StatsD.increment('counter', tags: { foo: 2 })
@@ -243,8 +243,8 @@ class AssertionsTest < Minitest::Test
 
   def test_assert_multiple_statsd_expectations
     assert_raises(Minitest::Assertion) do
-      foo_1_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
-      foo_2_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
+      foo_1_metric = StatsD::Instrument::Expectation.increment('counter', times: 2, tags: ['foo:1'])
+      foo_2_metric = StatsD::Instrument::Expectation.increment('counter', tags: ['foo:2'])
       @test_case.assert_statsd_expectations([foo_1_metric, foo_2_metric]) do
         StatsD.increment('counter', tags: { foo: 1 })
         StatsD.increment('counter', tags: { foo: 2 })
@@ -252,8 +252,8 @@ class AssertionsTest < Minitest::Test
     end
 
     assert_raises(Minitest::Assertion) do
-      foo_1_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
-      foo_2_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
+      foo_1_metric = StatsD::Instrument::Expectation.increment('counter', times: 2, tags: ['foo:1'])
+      foo_2_metric = StatsD::Instrument::Expectation.increment('counter', tags: ['foo:2'])
       @test_case.assert_statsd_expectations([foo_1_metric, foo_2_metric]) do
         StatsD.increment('counter', tags: { foo: 1 })
         StatsD.increment('counter', tags: { foo: 1 })
@@ -262,8 +262,8 @@ class AssertionsTest < Minitest::Test
       end
     end
 
-    foo_1_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
-    foo_2_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
+    foo_1_metric = StatsD::Instrument::Expectation.increment('counter', times: 2, tags: ['foo:1'])
+    foo_2_metric = StatsD::Instrument::Expectation.increment('counter', tags: ['foo:2'])
     @test_case.assert_statsd_expectations([foo_1_metric, foo_2_metric]) do
       StatsD.increment('counter', tags: { foo: 1 })
       StatsD.increment('counter', tags: { foo: 1 })

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -49,7 +49,7 @@ class AssertionsTest < Minitest::Test
     assert_equal assertion.message, "No StatsD calls for metric other, another expected."
   end
 
-  def test_assert_statsd_call
+  def test_assert_statsd
     @test_case.assert_statsd_increment('counter') do
       StatsD.increment('counter')
     end
@@ -201,60 +201,60 @@ class AssertionsTest < Minitest::Test
     assert_includes assertion.message, "MyJob"
   end
 
-  def test_multiple_metrics_are_not_order_dependent
-    foo_1_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:1'])
-    foo_2_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
-    @test_case.assert_statsd_calls([foo_1_metric, foo_2_metric]) do
+  def test_multiple_expectations_are_not_order_dependent
+    foo_1_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:1'])
+    foo_2_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
+    @test_case.assert_statsd_expectations([foo_1_metric, foo_2_metric]) do
       StatsD.increment('counter', tags: { foo: 1 })
       StatsD.increment('counter', tags: { foo: 2 })
     end
 
-    foo_1_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:1'])
-    foo_2_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
-    @test_case.assert_statsd_calls([foo_2_metric, foo_1_metric]) do
+    foo_1_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:1'])
+    foo_2_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
+    @test_case.assert_statsd_expectations([foo_2_metric, foo_1_metric]) do
       StatsD.increment('counter', tags: { foo: 1 })
       StatsD.increment('counter', tags: { foo: 2 })
     end
 
-    foo_1_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
-    foo_2_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
-    @test_case.assert_statsd_calls([foo_1_metric, foo_2_metric]) do
-      StatsD.increment('counter', tags: { foo: 1 })
-      StatsD.increment('counter', tags: { foo: 1 })
-      StatsD.increment('counter', tags: { foo: 2 })
-    end
-
-    foo_1_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
-    foo_2_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
-    @test_case.assert_statsd_calls([foo_2_metric, foo_1_metric]) do
+    foo_1_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
+    foo_2_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
+    @test_case.assert_statsd_expectations([foo_1_metric, foo_2_metric]) do
       StatsD.increment('counter', tags: { foo: 1 })
       StatsD.increment('counter', tags: { foo: 1 })
       StatsD.increment('counter', tags: { foo: 2 })
     end
 
-    foo_1_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
-    foo_2_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
-    @test_case.assert_statsd_calls([foo_2_metric, foo_1_metric]) do
+    foo_1_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
+    foo_2_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
+    @test_case.assert_statsd_expectations([foo_2_metric, foo_1_metric]) do
+      StatsD.increment('counter', tags: { foo: 1 })
+      StatsD.increment('counter', tags: { foo: 1 })
+      StatsD.increment('counter', tags: { foo: 2 })
+    end
+
+    foo_1_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
+    foo_2_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
+    @test_case.assert_statsd_expectations([foo_2_metric, foo_1_metric]) do
       StatsD.increment('counter', tags: { foo: 1 })
       StatsD.increment('counter', tags: { foo: 2 })
       StatsD.increment('counter', tags: { foo: 1 })
     end
   end
 
-  def test_assert_multiple_statsd_calls
+  def test_assert_multiple_statsd_expectations
     assert_raises(Minitest::Assertion) do
-      foo_1_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
-      foo_2_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
-      @test_case.assert_statsd_calls([foo_1_metric, foo_2_metric]) do
+      foo_1_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
+      foo_2_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
+      @test_case.assert_statsd_expectations([foo_1_metric, foo_2_metric]) do
         StatsD.increment('counter', tags: { foo: 1 })
         StatsD.increment('counter', tags: { foo: 2 })
       end
     end
 
     assert_raises(Minitest::Assertion) do
-      foo_1_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
-      foo_2_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
-      @test_case.assert_statsd_calls([foo_1_metric, foo_2_metric]) do
+      foo_1_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
+      foo_2_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
+      @test_case.assert_statsd_expectations([foo_1_metric, foo_2_metric]) do
         StatsD.increment('counter', tags: { foo: 1 })
         StatsD.increment('counter', tags: { foo: 1 })
         StatsD.increment('counter', tags: { foo: 2 })
@@ -262,16 +262,16 @@ class AssertionsTest < Minitest::Test
       end
     end
 
-    foo_1_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
-    foo_2_metric = StatsD::Instrument::MetricExpectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
-    @test_case.assert_statsd_calls([foo_1_metric, foo_2_metric]) do
+    foo_1_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 2, tags: ['foo:1'])
+    foo_2_metric = StatsD::Instrument::Expectation.new(type: :c, name: 'counter', times: 1, tags: ['foo:2'])
+    @test_case.assert_statsd_expectations([foo_1_metric, foo_2_metric]) do
       StatsD.increment('counter', tags: { foo: 1 })
       StatsD.increment('counter', tags: { foo: 1 })
       StatsD.increment('counter', tags: { foo: 2 })
     end
   end
 
-  def test_assert_statsd_call_with_tags
+  def test_assert_statsd_increment_with_tags
     @test_case.assert_statsd_increment('counter', tags: ['a:b', 'c:d']) do
       StatsD.increment('counter', tags: { a: 'b', c: 'd' })
     end

--- a/test/statsd_instrumentation_test.rb
+++ b/test/statsd_instrumentation_test.rb
@@ -222,10 +222,9 @@ class StatsDInstrumentationTest < Minitest::Test
   end
 
   def test_statsd_measure_raises_without_a_provided_block
-    err = assert_raises(ArgumentError) do
+    assert_raises(LocalJumpError) do
       assert_statsd_measure('ActiveMerchant.Gateway.ssl_post')
     end
-    assert_equal 'assert_statsd_* requires a block', err.message
   end
 
   def test_statsd_measure_with_method_receiving_block
@@ -269,10 +268,9 @@ class StatsDInstrumentationTest < Minitest::Test
   end
 
   def test_statsd_distribution_raises_without_a_provided_block
-    err = assert_raises(ArgumentError) do
+    assert_raises(LocalJumpError) do
       assert_statsd_distribution('ActiveMerchant.Gateway.ssl_post')
     end
-    assert_equal "assert_statsd_* requires a block", err.to_s
   end
 
   def test_statsd_distribution_with_method_receiving_block


### PR DESCRIPTION
This makes it easier / more natural to construct StatsD expectations, which can be used to assert that the emitted datagrams are as expected.

``` ruby
expectations = []
expectations << StatsD::Instrument::Expectation.increment('counter')
expectations << StatsD::Instrument::Expectation.gauge('gauge', value: 44)
assert_statsd_expectations(expectations) do
  # ...
end
```

You can also first capture the datagrams, and then run multiple assertion on it:

``` ruby
datagrams = capture_statsd_datagrams do
  # ...
end

# Inject the captured datagrams into the assertion methods.
assert_statsd_measure('duration', datagrams: datagrams)
# Or use the lower level `assert_statsd_expectation` method
assert_statsd_expectation(StatsD::Instrument::Expectation.increment('counter'), datagrams: datagrams)
assert_statsd_expectation(StatsD::Instrument::Expectation.gauge('gauge', value: 44), datagrams: datagrams)

```

This can be cleaner than having nested `assert_statsd_*` blocks.

As followups, I will also add:
- ~Using a different client to capture datagrams from~ DONE
- More flexibility for the amount of times a metric is expected.

This is based on use cases I found in Shopiofy's test suite, where the current `assert_statsd_*` methods are not up for the task and people have to revert to running their own custom assertions on a list of captured metrics.