### PR TITLE
Add Rubocop rule that finds uses of StatsD singleton configuration methods

### DIFF
--- a/lib/statsd/instrument/rubocop.rb
+++ b/lib/statsd/instrument/rubocop.rb
@@ -21,6 +21,17 @@ module RuboCop
         statsd_count
       }
 
+      SINGLETON_CONFIGURATION_METHODS = %i{
+        backend
+        backend=
+        prefix
+        prefix=
+        default_tags
+        default_tags=
+        default_sample_rate
+        default_sample_rate=
+      }
+
       private
 
       def metaprogramming_method?(node)
@@ -31,6 +42,12 @@ module RuboCop
         node.receiver&.type == :const &&
           node.receiver&.const_name == "StatsD" &&
           METRIC_METHODS.include?(node.method_name)
+      end
+
+      def singleton_configuration_method?(node)
+        node.receiver&.type == :const &&
+          node.receiver&.const_name == "StatsD" &&
+          SINGLETON_CONFIGURATION_METHODS.include?(node.method_name)
       end
 
       def has_keyword_argument?(node, sym)
@@ -62,3 +79,4 @@ require_relative 'rubocop/positional_arguments'
 require_relative 'rubocop/splat_arguments'
 require_relative 'rubocop/measure_as_dist_argument'
 require_relative 'rubocop/metric_prefix_argument'
+require_relative 'rubocop/singleton_configuration'

--- a/lib/statsd/instrument/rubocop/singleton_configuration.rb
+++ b/lib/statsd/instrument/rubocop/singleton_configuration.rb
@@ -24,7 +24,7 @@ module RuboCop
       #   and assign it to `StatsD.singleton_client`. The client constructor accepts many of the
       #   same options.
       # - If you have to, you can call the old methods on `StatsD.legacy_singleton_client`. Note
-      #   that thios option will go away in the next major version.
+      #   that this option will go away in the next major version.
       class SingletonConfiguration < Cop
         include RuboCop::Cop::StatsD
 

--- a/lib/statsd/instrument/rubocop/singleton_configuration.rb
+++ b/lib/statsd/instrument/rubocop/singleton_configuration.rb
@@ -1,0 +1,53 @@
+# frozen-string-literal: true
+
+require_relative '../rubocop' unless defined?(RuboCop::Cop::StatsD)
+
+module RuboCop
+  module Cop
+    module StatsD
+      # This Rubocop will check for calls to StatsD singleton congfiguration methods
+      # (e.g. `StatsD.prefix`). The library is moving away from having just a single
+      # singleton client, so these methods are deprecated.
+      #
+      # Use the following Rubocop invocation to check your project's codebase:
+      #
+      #     rubocop --require `bundle show statsd-instrument`/lib/statsd/instrument/rubocop.rb \
+      #       --only StatsD/SingletonConfiguration
+      #
+      # This cop will not autocorrect violations. There are several ways of fixing the violation.
+      #
+      # - The best option is to configure the library using environment variables, like
+      #   `STATSD_ADDR`, `STATSD_IMPLEMENTATION`, `STATSD_PREFIX`, and `STATSD_DEFAULT_TAGS`.
+      #   Metric methods called on the StatsD singleton (e.g. `StatsD.increment`) will by default
+      #   be delegated to a client that is configured using these environment variables.
+      # - Alternatively, you can instantiate your own client using `StatsD::Instrument::Client.new`,
+      #   and assign it to `StatsD.singleton_client`. The client constructor accepts many of the
+      #   same options.
+      # - If you have to, you can call the old methods on `StatsD.legacy_singleton_client`. Note
+      #   that thios option will go away in the next major version.
+      class SingletonConfiguration < Cop
+        include RuboCop::Cop::StatsD
+
+        MSG = <<~MESSAGE
+          Singleton methods to configure StatsD are deprecated.
+
+          - The best option is to configure the library using environment variables, like
+            `STATSD_ADDR`, `STATSD_IMPLEMENTATION`, `STATSD_PREFIX`, and `STATSD_DEFAULT_TAGS`.
+            Metric methods called on the StatsD singleton (e.g. `StatsD.increment`) will by default
+            be delegated to a client that is configured using these environment variables.
+          - Alternatively, you can instantiate your own client using `StatsD::Instrument::Client.new`,
+            and assign it to `StatsD.singleton_client`. The client constructor accepts many of the
+            same options.
+          - If you have to, you can call the old methods on `StatsD.legacy_singleton_client`. Note
+            that thios option will go away in the next major version.
+        MESSAGE
+
+        def on_send(node)
+          if singleton_configuration_method?(node)
+            add_offense(node)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/statsd/instrument/rubocop/singleton_configuration.rb
+++ b/lib/statsd/instrument/rubocop/singleton_configuration.rb
@@ -39,7 +39,7 @@ module RuboCop
             and assign it to `StatsD.singleton_client`. The client constructor accepts many of the
             same options.
           - If you have to, you can call the old methods on `StatsD.legacy_singleton_client`. Note
-            that thios option will go away in the next major version.
+            that this option will go away in the next major version.
         MESSAGE
 
         def on_send(node)

--- a/test/rubocop/singleton_configuration_test.rb
+++ b/test/rubocop/singleton_configuration_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'statsd/instrument/rubocop'
+
+module Rubocop
+  class SingletonConfigurationTest < Minitest::Test
+    include RubocopHelper
+
+    def setup
+      @cop = RuboCop::Cop::StatsD::SingletonConfiguration.new
+    end
+
+    def test_offense_statsd_backend
+      assert_offense('StatsD.backend = "foo"')
+      assert_offense('old_backend = StatsD.backend')
+    end
+
+    def test_offense_statsd_prefix
+      assert_offense('StatsD.prefix = "foo"')
+      assert_offense('"#{StatsD.prefix}.foo"')
+    end
+
+    def test_offense_statsd_default_tags
+      assert_offense('StatsD.default_tags = ["foo"]')
+      assert_offense('StatsD.default_tags.empty?')
+    end
+
+    def test_offense_statsd_default_sample_rate
+      assert_offense('StatsD.default_sample_rate = 1.0')
+      assert_offense('should_sample = StatsD.default_sample_rate > rand')
+    end
+
+    def test_no_offense_for_other_methods
+      assert_no_offenses('StatsD.singleton_client = my_client')
+      assert_no_offenses('StatsD.logger.info("foo")')
+    end
+
+    def test_no_offense_for_constant_reference
+      assert_no_offenses('legacy_client = StatsD')
+    end
+  end
+end


### PR DESCRIPTION
The following methods are deprecated because they configure the singleton, which we are moving away from:

- `StatsD.prefix`
- `StatsD.backend`
- `StatsD.default_sample_rate`
- `StatsD.default_tags`

This Rubocop rule finds uses of these methods and tells you how to fix.
