### PR TITLE
Make Datadog the default datagram builder.

### DIFF
--- a/lib/statsd/instrument/environment.rb
+++ b/lib/statsd/instrument/environment.rb
@@ -76,7 +76,7 @@ class StatsD::Instrument::Environment
   end
 
   def statsd_implementation
-    env.fetch('STATSD_IMPLEMENTATION', 'statsd')
+    env.fetch('STATSD_IMPLEMENTATION', 'datadog')
   end
 
   def statsd_sample_rate

--- a/test/environment_test.rb
+++ b/test/environment_test.rb
@@ -103,7 +103,7 @@ class EnvironmentTest < Minitest::Test
   def test_default_client_has_sensible_defaults
     env = StatsD::Instrument::Environment.new('STATSD_ENV' => 'production')
 
-    assert_equal StatsD::Instrument::StatsDDatagramBuilder, env.default_client.datagram_builder_class
+    assert_equal StatsD::Instrument::DogStatsDDatagramBuilder, env.default_client.datagram_builder_class
     assert_equal 'localhost', env.default_client.sink.host
     assert_equal 8125, env.default_client.sink.port
     assert_equal 1.0, env.default_client.default_sample_rate


### PR DESCRIPTION
Because the new client is not permissive for features that are not supported compared to the legacy client, it's important that a client is configured with the right datagram builder, even in the development and test environments.

As discussed offline, having Datadog as default will make configuring our development and test environments correctly a lot easier.