### PR TITLE
CHANGELOG addition for 2.7.0 w.r.t. `assert_statsd` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ datagrams coming from a legacy client, or from a new client.
   This makes it easy to run multiple assertions on the set of metrics that
   was emitted without having to nest calls.
 
+- **⚠️ DEPRECATION** The `assert_statsd_*`-family of methods now use keyword
+  arguments, rather than option hashes. This means that calls that use
+  unsupported arguments will raise an `ArgumentError` now, rather than silently
+  ignoring unknown keys.
+
 - **⚠️ DEPRECATION**: The following methods to configure the legacy client
   are deprecated:
 


### PR DESCRIPTION
Explicitly mention that `assert_statsd_*` calls will raise an `ArgumentError` now when they are called with an argument that is not supported, rather than silently ignoring them.