### PR TITLE
Always sample datagrams handled by a NullSink.

### DIFF
--- a/lib/statsd/instrument/null_sink.rb
+++ b/lib/statsd/instrument/null_sink.rb
@@ -4,7 +4,7 @@
 #   to become the new default in the next major release of this library.
 class StatsD::Instrument::NullSink
   def sample?(_sample_rate)
-    false
+    true
   end
 
   def <<(_datagram)

--- a/test/null_sink_test.rb
+++ b/test/null_sink_test.rb
@@ -8,4 +8,10 @@ class NullSinktest < Minitest::Test
     null_sink << 'foo:1|c' << 'bar:1|c'
     pass # We don't have anything to assert, except that no exception was raised
   end
+
+  def test_null_sink_sample
+    null_sink = StatsD::Instrument::NullSink.new
+    assert null_sink.sample?(0), "The null sink should always sample"
+    assert null_sink.sample?(1), "The null sink should always sample"
+  end
 end


### PR DESCRIPTION
NullSink#sample? currently always returns `false`, which prevents us from generating a datagram unnecessarily. This seems like a simple performance boost, but comes with a price.

The NullSink is primarily used in the test environment. In this environment, it can make a lot of sense to use a custom DatagramBuilder that enforces certain rules about the metrics you are emitting. But because sample? Returns false, this datagram builder is never called (except when capturing datagrams from the NullSink).

Because high performance is not really the main use case for the test environment, it makes more sense to always return true, so we always go through the datagram builder.