### PR TITLE
Allow specifying an implementation when instantiating a Client

### DIFF
--- a/lib/statsd/instrument/datagram_builder.rb
+++ b/lib/statsd/instrument/datagram_builder.rb
@@ -23,6 +23,10 @@ class StatsD::Instrument::DatagramBuilder
     end
   end
 
+  def self.datagram_class
+    StatsD::Instrument::Datagram
+  end
+
   def initialize(prefix: nil, default_tags: nil)
     @prefix = prefix.nil? ? "" : "#{normalize_name(prefix)}."
     @default_tags = normalize_tags(default_tags)
@@ -54,10 +58,6 @@ class StatsD::Instrument::DatagramBuilder
 
   def kv(name, value, sample_rate, tags)
     generate_generic_datagram(name, value, 'kv', sample_rate, tags)
-  end
-
-  def datagram_class
-    StatsD::Instrument::Datagram
   end
 
   def latency_metric_type

--- a/lib/statsd/instrument/environment.rb
+++ b/lib/statsd/instrument/environment.rb
@@ -106,22 +106,11 @@ class StatsD::Instrument::Environment
   def default_client
     @default_client ||= StatsD::Instrument::Client.new(
       sink: default_sink_for_environment,
-      datagram_builder_class: default_datagram_builder_class_for_implementation,
+      implementation: statsd_implementation,
       default_sample_rate: statsd_sample_rate,
       prefix: statsd_prefix,
       default_tags: statsd_default_tags,
     )
-  end
-
-  def default_datagram_builder_class_for_implementation
-    case statsd_implementation
-    when 'statsd'
-      StatsD::Instrument::StatsDDatagramBuilder
-    when 'datadog', 'dogstatsd'
-      StatsD::Instrument::DogStatsDDatagramBuilder
-    else
-      raise NotImplementedError, "No implementation for #{statsd_implementation}"
-    end
   end
 
   def default_sink_for_environment

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -5,9 +5,7 @@ require 'test_helper'
 class ClientTest < Minitest::Test
   def setup
     @client = StatsD::Instrument::Client.new(datagram_builder_class: StatsD::Instrument::StatsDDatagramBuilder)
-    @dogstatsd_client = StatsD::Instrument::Client.new(
-      datagram_builder_class: StatsD::Instrument::DogStatsDDatagramBuilder,
-    )
+    @dogstatsd_client = StatsD::Instrument::Client.new(implementation: 'datadog')
   end
 
   def test_capture


### PR DESCRIPTION
An `implementation` is easier to specify than a `datagram_builder_class`, and more closely aligned with how you would configure a client using environment variables.

We will pick the right datagram_builder_class based on the implementation, but you can still specify a datagram_builder_class yourself if you prefer.