### PR TITLE
Refactor constructing a client based on environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ section below.
   addressed since. It's highly unlikely that you are using this feature.
   However, if you are, you can capture StatsD datagrams using the
   `capture_statsd_datagrams` method, and run your own assertions on the list.
+- ⚠️ Remove `StatsD.client`. This was added in version 2.6.0 in order to
+  experiment with the new client. However, at this point thereare better ways
+  to do this.
+  - You can set `StatsD.singleton_client` to a new client, which causes the
+    calls to the StatsD singleton to be handled by a new client. If you set
+    `STATSD_USE_NEW_CLIENT`, it will be initialized to a new client.
+  - If that doesn't work for you, you can instantiate a client using
+    `StatsD::Instrument::Client.from_env` and assign it to a variable of your
+    own choosing.
 - Fix some compatibility issues when using `assert_statsd_*` methods when
   using a new client with prefix.
 

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -394,7 +394,7 @@ module StatsD
   end
 
   def client
-    @client ||= StatsD::Instrument::Environment.current.default_client
+    @client ||= StatsD::Instrument::Client.from_env
   end
 
   # Singleton methods will be delegated to the singleton client.

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -390,11 +390,11 @@ module StatsD
   end
 
   def singleton_client
-    @singleton_client ||= StatsD::Instrument::Environment.from_env.client
+    @singleton_client ||= StatsD::Instrument::Environment.current.client
   end
 
   def client
-    @client ||= StatsD::Instrument::Environment.from_env.default_client
+    @client ||= StatsD::Instrument::Environment.current.default_client
   end
 
   # Singleton methods will be delegated to the singleton client.

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -381,7 +381,7 @@ module StatsD
   end
 
   attr_accessor :logger
-  attr_writer :client, :singleton_client
+  attr_writer :singleton_client
 
   extend Forwardable
 
@@ -391,10 +391,6 @@ module StatsD
 
   def singleton_client
     @singleton_client ||= StatsD::Instrument::Environment.current.client
-  end
-
-  def client
-    @client ||= StatsD::Instrument::Client.from_env
   end
 
   # Singleton methods will be delegated to the singleton client.

--- a/lib/statsd/instrument/environment.rb
+++ b/lib/statsd/instrument/environment.rb
@@ -97,20 +97,10 @@ class StatsD::Instrument::Environment
 
   def client
     if env.key?('STATSD_USE_NEW_CLIENT')
-      default_client
+      StatsD::Instrument::Client.from_env(self)
     else
       StatsD::Instrument::LegacyClient.singleton
     end
-  end
-
-  def default_client
-    @default_client ||= StatsD::Instrument::Client.new(
-      sink: default_sink_for_environment,
-      implementation: statsd_implementation,
-      default_sample_rate: statsd_sample_rate,
-      prefix: statsd_prefix,
-      default_tags: statsd_default_tags,
-    )
   end
 
   def default_sink_for_environment

--- a/lib/statsd/instrument/environment.rb
+++ b/lib/statsd/instrument/environment.rb
@@ -4,8 +4,8 @@
 # which this library is active. It will use different default values based on the environment.
 class StatsD::Instrument::Environment
   class << self
-    def from_env
-      @from_env ||= StatsD::Instrument::Environment.new(ENV)
+    def current
+      @current ||= StatsD::Instrument::Environment.new(ENV)
     end
 
     # Detects the current environment, either by asking Rails, or by inspecting environment variables.
@@ -16,7 +16,7 @@ class StatsD::Instrument::Environment
     #
     # @return [String] The detected environment.
     def environment
-      from_env.environment
+      current.environment
     end
 
     # Instantiates a default backend for the current environment.
@@ -26,7 +26,7 @@ class StatsD::Instrument::Environment
     def default_backend
       case environment
       when 'production', 'staging'
-        StatsD::Instrument::Backends::UDPBackend.new(from_env.statsd_addr, from_env.statsd_implementation)
+        StatsD::Instrument::Backends::UDPBackend.new(current.statsd_addr, current.statsd_implementation)
       when 'test'
         StatsD::Instrument::Backends::NullBackend.new
       else
@@ -45,9 +45,9 @@ class StatsD::Instrument::Environment
     #
     # @return [void]
     def setup
-      StatsD.prefix = from_env.statsd_prefix
-      StatsD.default_tags = from_env.statsd_default_tags
-      StatsD.default_sample_rate = from_env.statsd_sample_rate
+      StatsD.prefix = current.statsd_prefix
+      StatsD.default_tags = current.statsd_default_tags
+      StatsD.default_sample_rate = current.statsd_sample_rate
       StatsD.logger = Logger.new($stderr)
     end
   end

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -6,7 +6,7 @@ class AssertionsTest < Minitest::Test
   def setup
     @old_client = StatsD.singleton_client
     env = StatsD::Instrument::Environment.new('STATSD_IMPLEMENTATION' => 'datadog')
-    StatsD.singleton_client = env.default_client
+    StatsD.singleton_client = StatsD::Instrument::Client.from_env(env)
 
     test_class = Class.new(Minitest::Test)
     test_class.send(:include, StatsD::Instrument::Assertions)

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -8,7 +8,7 @@ class ClientTest < Minitest::Test
     @dogstatsd_client = StatsD::Instrument::Client.new(implementation: 'datadog')
   end
 
-  def test_from_env
+  def test_client_from_env
     env = StatsD::Instrument::Environment.new(
       'STATSD_ENV' => 'production',
       'STATSD_SAMPLE_RATE' => '0.1',
@@ -29,7 +29,18 @@ class ClientTest < Minitest::Test
     assert_equal 8125, client.sink.port
   end
 
-  def test_from_env_with_overrides
+  def test_client_from_env_has_sensible_defaults
+    env = StatsD::Instrument::Environment.new({})
+    client = StatsD::Instrument::Client.from_env(env)
+
+    assert_equal 1.0, client.default_sample_rate
+    assert_nil client.prefix
+    assert_nil client.default_tags
+    assert_equal StatsD::Instrument::DogStatsDDatagramBuilder, client.datagram_builder_class
+    assert_kind_of StatsD::Instrument::LogSink, client.sink
+  end
+
+  def test_client_from_env_with_overrides
     env = StatsD::Instrument::Environment.new(
       'STATSD_SAMPLE_RATE' => '0.1',
       'STATSD_PREFIX' => 'foo',

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -8,6 +8,46 @@ class ClientTest < Minitest::Test
     @dogstatsd_client = StatsD::Instrument::Client.new(implementation: 'datadog')
   end
 
+  def test_from_env
+    env = StatsD::Instrument::Environment.new(
+      'STATSD_ENV' => 'production',
+      'STATSD_SAMPLE_RATE' => '0.1',
+      'STATSD_PREFIX' => 'foo',
+      'STATSD_DEFAULT_TAGS' => 'shard:1,env:production',
+      'STATSD_IMPLEMENTATION' => 'statsd',
+      'STATSD_ADDR' => '1.2.3.4:8125',
+    )
+    client = StatsD::Instrument::Client.from_env(env)
+
+    assert_equal 0.1, client.default_sample_rate
+    assert_equal 'foo', client.prefix
+    assert_equal ['shard:1', 'env:production'], client.default_tags
+    assert_equal StatsD::Instrument::StatsDDatagramBuilder, client.datagram_builder_class
+
+    assert_kind_of StatsD::Instrument::UDPSink, client.sink
+    assert_equal '1.2.3.4', client.sink.host
+    assert_equal 8125, client.sink.port
+  end
+
+  def test_from_env_with_overrides
+    env = StatsD::Instrument::Environment.new(
+      'STATSD_SAMPLE_RATE' => '0.1',
+      'STATSD_PREFIX' => 'foo',
+      'STATSD_DEFAULT_TAGS' => 'shard:1,env:production',
+      'STATSD_IMPLEMENTATION' => 'statsd',
+      'STATSD_ADDR' => '1.2.3.4:8125',
+    )
+    client = StatsD::Instrument::Client.from_env(env,
+      prefix: 'bar', implementation: 'dogstatsd', sink: StatsD::Instrument::NullSink.new)
+
+    assert_equal 0.1, client.default_sample_rate
+    assert_equal 'bar', client.prefix
+    assert_equal ['shard:1', 'env:production'], client.default_tags
+    assert_equal StatsD::Instrument::DogStatsDDatagramBuilder, client.datagram_builder_class
+
+    assert_kind_of StatsD::Instrument::NullSink, client.sink
+  end
+
   def test_capture
     inner_datagrams = nil
 

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -25,7 +25,7 @@ class HelpersTest < Minitest::Test
 
   def test_capture_metrics_with_new_client
     @old_client = StatsD.singleton_client
-    StatsD.singleton_client = StatsD.client
+    StatsD.singleton_client = StatsD::Instrument::Client.new
 
     StatsD.increment('counter')
     metrics = @test_case.capture_statsd_datagrams do


### PR DESCRIPTION
Right now, you can instantiate a client based on the environment, or you can instantiate a client from scratch. What is not easy to to instantiate a client that uses most characteristics from the environment, but overrides some settings.

To do this you can either do:
- `Client.new`, and set all the keyword argument that you don't want to override with the values from the Environment object. This is painful, and if we ever add new keyword arguments that can be set based on the environment,  people need to update their code.
- `Environment.current.default_client.clone_with_options(...)`. This kind of works the way we want it to, but is not very discoverable and verbose.

The specific use case I have in mind is that for many apps, we instantiate the client from environment, but want to set a prefix manually based on the name of the application.

To make this easier, I have updated the default values for `Client#initialize` to not be hardcoded, but coming from the environment instead.

I am not quite sure if this is the right way of doing this, so feel free to disagree with this approach