### PR TITLE
Inject client into Expectation object so we can find the correct prefix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ section below.
 
 ### Unreleased changes
 
-_Nothing yet!_
+- Fix some compatibility issues when using `assert_statsd_*` methods when
+  using a new client with prefix.
 
 ## Version 2.7.1
 

--- a/lib/statsd/instrument/expectation.rb
+++ b/lib/statsd/instrument/expectation.rb
@@ -35,9 +35,11 @@ class StatsD::Instrument::Expectation
   attr_accessor :times, :type, :name, :value, :sample_rate, :tags
   attr_reader :ignore_tags
 
-  def initialize(type:, name:, value: nil, sample_rate: nil, tags: nil, ignore_tags: nil, no_prefix: false, times: 1)
+  def initialize(client: StatsD.singleton_client, type:, name:, value: nil, sample_rate: nil,
+    tags: nil, ignore_tags: nil, no_prefix: false, times: 1)
+
     @type = type
-    @name = StatsD.prefix ? "#{StatsD.prefix}.#{name}" : name unless no_prefix
+    @name = client.prefix ? "#{client.prefix}.#{name}" : name unless no_prefix
     @value = normalized_value_for_type(type, value) if value
     @sample_rate = sample_rate
     @tags = StatsD::Instrument::Metric.normalize_tags(tags)


### PR DESCRIPTION
The Expectation object still has some dependencies on the singleton. This fixes one of them.

In the future, I am not sure if I actually want to keep automatically adding the StatsD prefix. I kind of like having to explicitly add it to the metric names in your tests, to really assert that the metrics you are emitting are what you expect them to be. However, that would break many tests, so for now I decided to go for this simple fix.