### PR TITLE
Remove Expectation#ignore_tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ section below.
 
 ### Unreleased changes
 
+- ⚠️ Remove support for `assert_statsd_*(..., ignore_tags: ...)`. This feature
+  was never documented, and the only use case we were aware of has been
+  addressed since. It's highly unlikely that you are using this feature.
+  However, if you are, you can capture StatsD datagrams using the
+  `capture_statsd_datagrams` method, and run your own assertions on the list.
 - Fix some compatibility issues when using `assert_statsd_*` methods when
   using a new client with prefix.
 

--- a/lib/statsd/instrument/expectation.rb
+++ b/lib/statsd/instrument/expectation.rb
@@ -33,17 +33,15 @@ class StatsD::Instrument::Expectation
   end
 
   attr_accessor :times, :type, :name, :value, :sample_rate, :tags
-  attr_reader :ignore_tags
 
-  def initialize(client: StatsD.singleton_client, type:, name:, value: nil, sample_rate: nil,
-    tags: nil, ignore_tags: nil, no_prefix: false, times: 1)
+  def initialize(client: StatsD.singleton_client, type:, name:, value: nil,
+    sample_rate: nil, tags: nil, no_prefix: false, times: 1)
 
     @type = type
     @name = client.prefix ? "#{client.prefix}.#{name}" : name unless no_prefix
     @value = normalized_value_for_type(type, value) if value
     @sample_rate = sample_rate
     @tags = StatsD::Instrument::Metric.normalize_tags(tags)
-    @ignore_tags = StatsD::Instrument::Metric.normalize_tags(ignore_tags)
     @times = times
   end
 
@@ -63,16 +61,6 @@ class StatsD::Instrument::Expectation
     if tags
       expected_tags = Set.new(tags)
       actual_tags = Set.new(actual_metric.tags)
-
-      if ignore_tags
-        ignored_tags = Set.new(ignore_tags) - expected_tags
-        actual_tags -= ignored_tags
-
-        if ignore_tags.is_a?(Array)
-          actual_tags.delete_if { |key| ignore_tags.include?(key.split(":").first) }
-        end
-      end
-
       return expected_tags.subset?(actual_tags)
     end
     true

--- a/test/assertions_on_legacy_client_test.rb
+++ b/test/assertions_on_legacy_client_test.rb
@@ -99,38 +99,6 @@ class AssertionsOnLegacyClientTest < Minitest::Test
     end
 
     assert_raises(Minitest::Assertion) do
-      @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: ['a', 'b'], ignore_tags: ['b']) do
-        StatsD.increment('counter', sample_rate: 0.5, tags: ['a'])
-      end
-    end
-
-    @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: ['a'], ignore_tags: ['b']) do
-      StatsD.increment('counter', sample_rate: 0.5, tags: ['a', 'b'])
-    end
-
-    @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: ['a'], ignore_tags: ['b']) do
-      StatsD.increment('counter', sample_rate: 0.5, tags: ['a'])
-    end
-
-    @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: { a: 1 }, ignore_tags: { b: 2 }) do
-      StatsD.increment('counter', sample_rate: 0.5, tags: { a: 1, b: 2 })
-    end
-
-    @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: { a: 1 }, ignore_tags: { b: 2 }) do
-      StatsD.increment('counter', sample_rate: 0.5, tags: { a: 1, b: 3 })
-    end
-
-    assert_raises(Minitest::Assertion) do
-      @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: { a: 1, b: 3 }, ignore_tags: ['b']) do
-        StatsD.increment('counter', sample_rate: 0.5, tags: { a: 1, b: 2 })
-      end
-    end
-
-    @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: { a: 1 }, ignore_tags: ['b']) do
-      StatsD.increment('counter', sample_rate: 0.5, tags: { a: 1, b: 2 })
-    end
-
-    assert_raises(Minitest::Assertion) do
       @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: ['a', 'b']) do
         StatsD.increment('counter', sample_rate: 0.2, tags: ['c'])
       end

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -100,38 +100,6 @@ class AssertionsTest < Minitest::Test
     end
 
     assert_raises(Minitest::Assertion) do
-      @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: ['a', 'b'], ignore_tags: ['b']) do
-        StatsD.increment('counter', sample_rate: 0.5, tags: ['a'])
-      end
-    end
-
-    @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: ['a'], ignore_tags: ['b']) do
-      StatsD.increment('counter', sample_rate: 0.5, tags: ['a', 'b'])
-    end
-
-    @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: ['a'], ignore_tags: ['b']) do
-      StatsD.increment('counter', sample_rate: 0.5, tags: ['a'])
-    end
-
-    @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: { a: 1 }, ignore_tags: { b: 2 }) do
-      StatsD.increment('counter', sample_rate: 0.5, tags: { a: 1, b: 2 })
-    end
-
-    @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: { a: 1 }, ignore_tags: { b: 2 }) do
-      StatsD.increment('counter', sample_rate: 0.5, tags: { a: 1, b: 3 })
-    end
-
-    assert_raises(Minitest::Assertion) do
-      @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: { a: 1, b: 3 }, ignore_tags: ['b']) do
-        StatsD.increment('counter', sample_rate: 0.5, tags: { a: 1, b: 2 })
-      end
-    end
-
-    @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: { a: 1 }, ignore_tags: ['b']) do
-      StatsD.increment('counter', sample_rate: 0.5, tags: { a: 1, b: 2 })
-    end
-
-    assert_raises(Minitest::Assertion) do
       @test_case.assert_statsd_increment('counter', sample_rate: 0.5, tags: ['a', 'b']) do
         StatsD.increment('counter', sample_rate: 0.2, tags: ['c'])
       end


### PR DESCRIPTION
We should remove support for `ignore_tags` when defining StatsD expectations. It doesn't do what you think it does: by default, `assert_statsd_*` already ignores any unspecified tags. 

`Expectation#ignore_tags` was added in https://github.com/Shopify/statsd-instrument/pull/62. It served a need we had in our codebase at some point of time, but we no longer need it. None of our other codebases are using this feature. Given that this feature was never documented, I think we can remove this without a deprecation cycle.