### PR TITLE
Inject a client into statsd_* metaprogramming methods

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -139,8 +139,9 @@ module StatsD
     #    callable to dynamically generate a metric name
     # @param metric_options (see StatsD#measure)
     # @return [void]
-    def statsd_measure(method, name, deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil, as_dist: false,
-      sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg, prefix: nil, no_prefix: false)
+    def statsd_measure(method, name, deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,
+      as_dist: false, sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg,
+      prefix: nil, no_prefix: false, client: StatsD.singleton_client)
 
       if as_dist
         return statsd_distribution(method, name, # rubocop:disable StatsD/MetricPrefixArgument
@@ -149,9 +150,9 @@ module StatsD
 
       add_to_method(method, name, :measure) do
         define_method(method) do |*args, &block|
-          prefix ||= StatsD.prefix unless no_prefix
+          prefix ||= client.prefix unless no_prefix
           key = StatsD::Instrument.generate_metric_name(prefix, name, self, *args)
-          StatsD.measure(key, sample_rate: sample_rate, tags: tags, no_prefix: true) do
+          client.measure(key, sample_rate: sample_rate, tags: tags, no_prefix: true) do
             super(*args, &block)
           end
         end
@@ -167,13 +168,14 @@ module StatsD
     # @return [void]
     # @note Supported by the datadog implementation only (in beta)
     def statsd_distribution(method, name, deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,
-      sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg, prefix: nil, no_prefix: false)
+      sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg,
+      prefix: nil, no_prefix: false, client: StatsD.singleton_client)
 
       add_to_method(method, name, :distribution) do
         define_method(method) do |*args, &block|
-          prefix ||= StatsD.prefix unless no_prefix
+          prefix ||= client.prefix unless no_prefix
           key = StatsD::Instrument.generate_metric_name(prefix, name, self, *args)
-          StatsD.distribution(key, sample_rate: sample_rate, tags: tags, no_prefix: true) do
+          client.distribution(key, sample_rate: sample_rate, tags: tags, no_prefix: true) do
             super(*args, &block)
           end
         end
@@ -196,7 +198,8 @@ module StatsD
     # @return [void]
     # @see #statsd_count_if
     def statsd_count_success(method, name, deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,
-      sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg, prefix: nil, no_prefix: false)
+      sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg,
+      prefix: nil, no_prefix: false, client: StatsD.singleton_client)
 
       add_to_method(method, name, :count_success) do
         define_method(method) do |*args, &block|
@@ -216,9 +219,9 @@ module StatsD
             result
           ensure
             suffix = truthiness == false ? 'failure' : 'success'
-            prefix ||= StatsD.prefix unless no_prefix
+            prefix ||= client.prefix unless no_prefix
             key = StatsD::Instrument.generate_metric_name(prefix, name, self, *args)
-            StatsD.increment("#{key}.#{suffix}", sample_rate: sample_rate, tags: tags, no_prefix: true)
+            client.increment("#{key}.#{suffix}", sample_rate: sample_rate, tags: tags, no_prefix: true)
           end
         end
       end
@@ -237,7 +240,8 @@ module StatsD
     # @return [void]
     # @see #statsd_count_success
     def statsd_count_if(method, name, deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,
-      sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg, prefix: nil, no_prefix: false)
+      sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg,
+      prefix: nil, no_prefix: false, client: StatsD.singleton_client)
 
       add_to_method(method, name, :count_if) do
         define_method(method) do |*args, &block|
@@ -257,9 +261,9 @@ module StatsD
             result
           ensure
             if truthiness
-              prefix ||= StatsD.prefix unless no_prefix
+              prefix ||= client.prefix unless no_prefix
               key = StatsD::Instrument.generate_metric_name(prefix, name, self, *args)
-              StatsD.increment(key, sample_rate: sample_rate, tags: tags, no_prefix: true)
+              client.increment(key, sample_rate: sample_rate, tags: tags, no_prefix: true)
             end
           end
         end
@@ -276,13 +280,14 @@ module StatsD
     # @param metric_options (see #statsd_measure)
     # @return [void]
     def statsd_count(method, name, deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,
-      sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg, prefix: nil, no_prefix: false)
+      sample_rate: deprecated_sample_rate_arg, tags: deprecated_tags_arg,
+      prefix: nil, no_prefix: false, client: StatsD.singleton_client)
 
       add_to_method(method, name, :count) do
         define_method(method) do |*args, &block|
-          prefix ||= StatsD.prefix unless no_prefix
+          prefix ||= client.prefix unless no_prefix
           key = StatsD::Instrument.generate_metric_name(prefix, name, self, *args)
-          StatsD.increment(key, sample_rate: sample_rate, tags: tags, no_prefix: true)
+          client.increment(key, sample_rate: sample_rate, tags: tags, no_prefix: true)
           super(*args, &block)
         end
       end

--- a/lib/statsd/instrument/strict.rb
+++ b/lib/statsd/instrument/strict.rb
@@ -107,7 +107,9 @@ module StatsD
     end
 
     module StrictMetaprogramming
-      def statsd_measure(method, name, sample_rate: nil, tags: nil, no_prefix: false)
+      def statsd_measure(method, name, sample_rate: nil, tags: nil,
+        no_prefix: false, client: StatsD.singleton_client)
+
         check_method_and_metric_name(method, name)
 
         # Unfortunately, we have to inline the new method implementation ebcause we have to fix the
@@ -115,14 +117,16 @@ module StatsD
         add_to_method(method, name, :measure) do
           define_method(method) do |*args, &block|
             key = StatsD::Instrument.generate_metric_name(nil, name, self, *args)
-            StatsD.measure(key, sample_rate: sample_rate, tags: tags, no_prefix: no_prefix) do
+            client.measure(key, sample_rate: sample_rate, tags: tags, no_prefix: no_prefix) do
               super(*args, &block)
             end
           end
         end
       end
 
-      def statsd_distribution(method, name, sample_rate: nil, tags: nil, no_prefix: false)
+      def statsd_distribution(method, name, sample_rate: nil, tags: nil,
+        no_prefix: false, client: StatsD.singleton_client)
+
         check_method_and_metric_name(method, name)
 
         # Unfortunately, we have to inline the new method implementation ebcause we have to fix the
@@ -131,14 +135,16 @@ module StatsD
         add_to_method(method, name, :distribution) do
           define_method(method) do |*args, &block|
             key = StatsD::Instrument.generate_metric_name(nil, name, self, *args)
-            StatsD.distribution(key, sample_rate: sample_rate, tags: tags, no_prefix: no_prefix) do
+            client.distribution(key, sample_rate: sample_rate, tags: tags, no_prefix: no_prefix) do
               super(*args, &block)
             end
           end
         end
       end
 
-      def statsd_count_success(method, name, sample_rate: nil, tags: nil, no_prefix: false)
+      def statsd_count_success(method, name, sample_rate: nil, tags: nil,
+        no_prefix: false, client: StatsD.singleton_client)
+
         check_method_and_metric_name(method, name)
 
         # Unfortunately, we have to inline the new method implementation ebcause we have to fix the
@@ -163,13 +169,15 @@ module StatsD
             ensure
               suffix = truthiness == false ? 'failure' : 'success'
               key = "#{StatsD::Instrument.generate_metric_name(nil, name, self, *args)}.#{suffix}"
-              StatsD.increment(key, sample_rate: sample_rate, tags: tags, no_prefix: no_prefix)
+              client.increment(key, sample_rate: sample_rate, tags: tags, no_prefix: no_prefix)
             end
           end
         end
       end
 
-      def statsd_count_if(method, name, sample_rate: nil, tags: nil, no_prefix: false)
+      def statsd_count_if(method, name, sample_rate: nil, tags: nil,
+        no_prefix: false, client: StatsD.singleton_client)
+
         check_method_and_metric_name(method, name)
 
         # Unfortunately, we have to inline the new method implementation ebcause we have to fix the
@@ -194,14 +202,16 @@ module StatsD
             ensure
               if truthiness
                 key = StatsD::Instrument.generate_metric_name(nil, name, self, *args)
-                StatsD.increment(key, sample_rate: sample_rate, tags: tags, no_prefix: no_prefix)
+                client.increment(key, sample_rate: sample_rate, tags: tags, no_prefix: no_prefix)
               end
             end
           end
         end
       end
 
-      def statsd_count(method, name, sample_rate: nil, tags: nil, no_prefix: false)
+      def statsd_count(method, name, sample_rate: nil, tags: nil,
+        no_prefix: false, client: StatsD.singleton_client)
+
         check_method_and_metric_name(method, name)
 
         # Unfortunately, we have to inline the new method implementation ebcause we have to fix the
@@ -210,7 +220,7 @@ module StatsD
         add_to_method(method, name, :count) do
           define_method(method) do |*args, &block|
             key = StatsD::Instrument.generate_metric_name(nil, name, self, *args)
-            StatsD.increment(key, sample_rate: sample_rate, tags: tags, no_prefix: no_prefix)
+            client.increment(key, sample_rate: sample_rate, tags: tags, no_prefix: no_prefix)
             super(*args, &block)
           end
         end

--- a/test/statsd_instrumentation_test.rb
+++ b/test/statsd_instrumentation_test.rb
@@ -443,6 +443,17 @@ class StatsDInstrumentationTest < Minitest::Test
     StatsD.singleton_client = old_client
   end
 
+  def test_statsd_count_with_injected_client
+    client = StatsD::Instrument::Client.new(prefix: 'prefix')
+
+    ActiveMerchant::Gateway.statsd_count(:ssl_post, 'ActiveMerchant.Gateway.ssl_post', client: client)
+    assert_statsd_increment('prefix.ActiveMerchant.Gateway.ssl_post', client: client) do
+      ActiveMerchant::Gateway.new.purchase(true)
+    end
+  ensure
+    ActiveMerchant::Gateway.statsd_remove_count :ssl_post, 'ActiveMerchant.Gateway.ssl_post'
+  end
+
   private
 
   def assert_scope(klass, method, expected_scope)


### PR DESCRIPTION
The client defaults to `StatsD.singleton_client`, but you can now use a different client, e.g. one with a different prefix, to set up instrumentation for your methods using the metaprogramming macros.