### PR TITLE
Make assert_no_statsd_calls more flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,18 @@ section below.
 
 ### Unreleased changes
 
-_Nothing yet_
+- Add support for variadic arguments to `assert_no_statsd_calls`. This allows
+  consolidation of assertions about specific metrics. For example:
+    ```diff
+    -assert_no_statsd_calls('foo') do
+    -  assert_no_statsd_calls('bar') do
+    -    assert_no_statsd_calls('biz.baz') do
+    +assert_no_statsd_calls('foo', 'bar', 'biz.baz') do
+           # do work...
+    -    end
+    -  end
+     end
+    ```
 
 ## Version 2.8.0
 

--- a/lib/statsd/instrument/assertions.rb
+++ b/lib/statsd/instrument/assertions.rb
@@ -44,21 +44,21 @@ module StatsD::Instrument::Assertions
 
   # Asserts no metric occurred during the execution of the provided block.
   #
-  # @param [String] metric_name (default: nil) The metric name that is not allowed
-  #   to happen inside the block. If this is set to `nil`, the assertion will fail
-  #   if any metric occurs.
+  # @param [Array<String>] metric_names (default: []) The metric names that are not
+  #   allowed to happen inside the block. If this is set to `[]`, the assertion
+  #   will fail if any metric occurs.
   # @yield A block in which the specified metric should not occur. This block
   #   should not raise any exceptions.
   # @return [void]
   # @raise [Minitest::Assertion] If an exception occurs, or if any metric (with the
-  #   provided name, or any), occurred during the execution of the provided block.
-  def assert_no_statsd_calls(metric_name = nil, datagrams: nil, client: nil, &block)
+  #   provided names, or any), occurred during the execution of the provided block.
+  def assert_no_statsd_calls(*metric_names, datagrams: nil, client: nil, &block)
     if datagrams.nil?
       raise LocalJumpError, "assert_no_statsd_calls requires a block" unless block_given?
       datagrams = capture_statsd_datagrams_with_exception_handling(client: client, &block)
     end
 
-    datagrams.select! { |m| m.name == metric_name } if metric_name
+    datagrams.select! { |metric| metric_names.include?(metric.name) } unless metric_names.empty?
     assert(datagrams.empty?, "No StatsD calls for metric #{datagrams.map(&:name).join(', ')} expected.")
   end
 

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -33,6 +33,31 @@ class AssertionsTest < Minitest::Test
     end
     assert_equal assertion.message, "No StatsD calls for metric counter expected."
 
+    @test_case.assert_no_statsd_calls('counter1', 'counter2') do
+      # noop
+    end
+
+    @test_case.assert_no_statsd_calls('counter1', 'counter2') do
+      StatsD.increment('counter')
+    end
+
+    assertion = assert_raises(Minitest::Assertion) do
+      @test_case.assert_no_statsd_calls('counter1', 'counter2') do
+        StatsD.increment('counter0')
+        StatsD.increment('counter1')
+        StatsD.increment('counter2')
+        StatsD.increment('counter3')
+      end
+    end
+    assert_equal assertion.message, "No StatsD calls for metric counter1, counter2 expected."
+
+    assertion = assert_raises(Minitest::Assertion) do
+      @test_case.assert_no_statsd_calls('counter0', 'counter1', 'counter2') do
+        StatsD.increment('counter1')
+      end
+    end
+    assert_equal assertion.message, "No StatsD calls for metric counter1 expected."
+
     assertion = assert_raises(Minitest::Assertion) do
       @test_case.assert_no_statsd_calls do
         StatsD.increment('other')


### PR DESCRIPTION
Currently, `assert_no_statsd_calls` has two modes:
- match by exact single metric name
    ```ruby
    assert_no_statsd_calls('my.metric')
    ```
- match all metrics
    ```ruby
    assert_no_statsd_calls
    ```

This **adds** flexibility in the following ways:
- **Variadic arguments, to support exact matches against multiple names**
    ```ruby
    assert_no_statsd_calls('my.metric', 'your.metric')
    ```
    This is useful for reducing verbosity when multiple specific metrics need to be detected
<details>
<summary><strike>Support for matching by Regexp pattern</strike></summary>

```ruby
assert_no_statsd_calls(/\.metric/)
 ```
This is useful in cases where the number of metrics to watch out for is impractical, but detecting all metrics would be too restrictive
_e.g. any metric with a certain prefix_

</details>

<details>
<summary><strike>Any combination thereof</strike></summary>

```ruby
assert_no_statsd_calls('my.metric', /your/)
```

</details>