### PR TITLE
Fix lots of typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ _Nothing yet_
   However, if you are, you can capture StatsD datagrams using the
   `capture_statsd_datagrams` method, and run your own assertions on the list.
 - ⚠️ Remove `StatsD.client`. This was added in version 2.6.0 in order to
-  experiment with the new client. However, at this point thereare better ways
+  experiment with the new client. However, at this point there are better ways
   to do this.
   - You can set `StatsD.singleton_client` to a new client, which causes the
     calls to the StatsD singleton to be handled by a new client. If you set
@@ -36,7 +36,7 @@ This release has some small fixes related to the new client only:
 - Make it easier to instantiate new clients by specifying an implementation
   (e.g. `datadog`) rather than a DatagramBuilder class.
 - Change `NullSink#sample?` to always return `true`, so it's easier to verify
-  business rules by using a different DatabagramBuilder in test suites.
+  business rules by using a different DatagramBuilder in test suites.
 
 ## Version 2.7.0
 
@@ -56,7 +56,7 @@ and fix deprecations in your code base.
   calls on the `StatsD` singleton will be delegated to this legacy client.
 - By setting `STATSD_USE_NEW_CLIENT` as environment variable, these method
   calls will be delegated to an instance of the new client instead. This
-  client is configured using the existing `STATD_*` environment variables,
+  client is configured using the existing `STATSD_*` environment variables,
   like `STATSD_ADDR` and `STATSD_IMPLEMENTATION`.
 - You can also assign a custom client to `StatsD.singleton_client`.
 
@@ -188,7 +188,7 @@ deprecated patterns. See below for more info.
 - Slight behaviour change when using the `assert_statsd_*` assertion methods in
   combination with `assert_raises`: we now do not allow the block passed to the
   `assert_statsd_` call to raise an exception. This may cause tests to fail that
-  previousloy were succeeding.
+  previously were succeeding.
 
   Consider the following example:
 
@@ -318,7 +318,7 @@ s
 
   ``` ruby
   # In your Gemfile
-  gem 'statd-instrument', require: 'statsd/instrument/strict'
+  gem 'statsd-instrument', require: 'statsd/instrument/strict'
 
   # Or, in your test helper:
   require 'statsd/instrument/strict'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ This project is MIT licensed.
 
 > **Note**: this project is currently not actively maintained, but is heavily used in production.
 > As a result, pull requests and issues may not be responded to. Also, due to the limited time we have
-> avaibale to work on this library, we cannot accept PRs that do not maintain backwards compatibility,
+> available to work on this library, we cannot accept PRs that do not maintain backwards compatibility,
 > or PRs that would affect the performance of the hot code paths.
 
 ## Reporting issues
@@ -28,9 +28,9 @@ Some notes:
 - Make sure to follow to coding style. This is enforced by Rubocop
 - Make sure your changes are properly documented using [yardoc syntax](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
 - Add an entry to the "unreleased changes" section of [CHANGELOG.md](./CHANGELOG.md).
-- **Do not** update `StatsD::Instrument::VERSION`. This will be done during the release prodecure.
+- **Do not** update `StatsD::Instrument::VERSION`. This will be done during the release procedure.
 
-### On perfomance & benchmarking
+### On performance & benchmarking
 
 This gem is used in production at Shopify, and is used to instrument some of
 our hottest code paths. This means that we are very careful about not

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ project](http://github.com/etsy/statsd).
 
 ## Configuration
 
-It's recommended to configure this librray by setting environment variables.
+It's recommended to configure this library by setting environment variables.
 The following environment variables are supported:
 
 - `STATSD_ADDR`: (default `localhost:8125`) The address to send the StatsD UDP
@@ -27,7 +27,7 @@ The following environment variables are supported:
   explicitly, this will be determined based on other environment variables,
   like `RAILS_ENV` or `ENV`. The library will behave differently:
 
-  - In the **production** and **staging** environment, thre librray will
+  - In the **production** and **staging** environment, thre library will
     actually send UDP packets.
   - In the **test** environment, it will swallow all calls, but allows you to
     capture them for testing purposes. See below for notes on writing tests.
@@ -41,7 +41,7 @@ The following environment variables are supported:
 - `STATSD_PREFIX`: The prefix to apply to all metric names. This can be
   overridden in a metric method call.
 - `STATSD_DEFAULT_TAGS`: A comma-separated list of tags to apply to all metrics.
-  (Note: tags are not supported by all iomplementations.)
+  (Note: tags are not supported by all implementations.)
 
 ## StatsD keys
 
@@ -110,28 +110,28 @@ StatsD.histogram('Order.value', order.value_in_usd.to_f tags: { source: 'POS' })
 
 Because you are counting unique values, the results of using a sampling value less than 1.0 can lead to unexpected, hard to interpret results.
 
-*Note: This is only supported by the beta datadog implementatation.*
+*Note: This is only supported by the beta datadog implementation.*
 
 #### StatsD.distribution
 
-A modified gauge that submits a distribution of values over a sample period. Arithmetic and statistical calculations (percetiles, average, etc.) on the data set are peformed server side rather than client side like a histogram.
+A modified gauge that submits a distribution of values over a sample period. Arithmetic and statistical calculations (percentiles, average, etc.) on the data set are performed server side rather than client side like a histogram.
 
 ```ruby
 StatsD.distribution('shipit.redis_connection', 3)
 ```
 
-*Note: This is only supported by the beta datadog implementatation.*
+*Note: This is only supported by the beta datadog implementation.*
 
 #### StatsD.event
 
-An event is a (title, text) tuple that can be used to correlate metrics with something that occured within the system.
+An event is a (title, text) tuple that can be used to correlate metrics with something that occurred within the system.
 This is a good fit for instance to correlate response time variation with a deploy of the new code.
 
 ```ruby
 StatsD.event('shipit.deploy', 'started', sample_rate: 1.0)
 ```
 
-*Note: This is only supported by the [datadog implementatation](https://docs.datadoghq.com/guides/dogstatsd/#events).*
+*Note: This is only supported by the [datadog implementation](https://docs.datadoghq.com/guides/dogstatsd/#events).*
 
 Events support additional metadata such as `date_happened`, `hostname`, `aggregation_key`, `priority`, `source_type_name`, `alert_type`.
 
@@ -143,7 +143,7 @@ An event is a (check_name, status) tuple that can be used to monitor the status 
 StatsD.service_check('shipit.redis_connection', 'ok')
 ```
 
-*Note: This is only supported by the [datadog implementatation](https://docs.datadoghq.com/guides/dogstatsd/#service-checks).*
+*Note: This is only supported by the [datadog implementation](https://docs.datadoghq.com/guides/dogstatsd/#service-checks).*
 
 Service checks support additional metadata such as `timestamp`, `hostname`, `message`.
 
@@ -272,12 +272,12 @@ class MyTestcase < Minitest::Test
   end
 
   def test_no_udp_traffic
-    # Verifies no StatsD calls occured at all.
+    # Verifies no StatsD calls occurred at all.
     assert_no_statsd_calls do
       do_some_work
     end
 
-    # Verifies no StatsD calls occured for the given metric.
+    # Verifies no StatsD calls occurred for the given metric.
     assert_no_statsd_calls('metric_name') do
       do_some_work
     end

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -89,7 +89,7 @@ module StatsD
   extend self
 
   # The StatsD::Instrument module provides metaprogramming methods to instrument your methods with
-  # StatsD metrics. E.g., yopu can create counters on how often a method is called, how often it is
+  # StatsD metrics. E.g., you can create counters on how often a method is called, how often it is
   # successful, the duration of the methods call, etc.
   module Instrument
     # @private
@@ -194,7 +194,7 @@ module StatsD
     # @yield You can pass a block to this method if you want to define yourself what is a successful call
     #   based on the return value of the method.
     # @yieldparam result The return value of the instrumented method.
-    # @yieldreturn [Boolean] Return true iff the return value is consisered a success, false otherwise.
+    # @yieldreturn [Boolean] Return true iff the return value is considered a success, false otherwise.
     # @return [void]
     # @see #statsd_count_if
     def statsd_count_success(method, name, deprecated_sample_rate_arg = nil, deprecated_tags_arg = nil,

--- a/lib/statsd/instrument/assertions.rb
+++ b/lib/statsd/instrument/assertions.rb
@@ -5,7 +5,7 @@
 #
 # Every metric type has its own assertion method, like {#assert_statsd_increment}
 # to assert `StatsD.increment` calls. You can also assert other properties of the
-# metric that was emitted, lioke the sample rate or presence of tags.
+# metric that was emitted, like the sample rate or presence of tags.
 # To check for the absence of metrics, use {#assert_no_statsd_calls}.
 #
 # @example Check for metric properties:

--- a/lib/statsd/instrument/backend.rb
+++ b/lib/statsd/instrument/backend.rb
@@ -8,7 +8,7 @@ class StatsD::Instrument::Backend
   # @param metric [StatsD::Instrument::Metric] The metric to collect
   # @return [void]
   def collect_metric(_metric)
-    raise NotImplementedError, "Use a concerete backend implementation"
+    raise NotImplementedError, "Use a concrete backend implementation"
   end
 end
 

--- a/lib/statsd/instrument/client.rb
+++ b/lib/statsd/instrument/client.rb
@@ -163,7 +163,7 @@ class StatsD::Instrument::Client
   # values.
   #
   # @note The distribution metric type is not available on all implementations.
-  #   A `NotImplemetedError` will be raised if you call this method, but
+  #   A `NotImplementedError` will be raised if you call this method, but
   #   the active implementation does not support it.
   #
   # @param name (see #increment)
@@ -184,7 +184,7 @@ class StatsD::Instrument::Client
   # Emits a histogram metric, which builds a histogram of the reported values.
   #
   # @note The histogram metric type is not available on all implementations.
-  #   A `NotImplemetedError` will be raised if you call this method, but
+  #   A `NotImplementedError` will be raised if you call this method, but
   #   the active implementation does not support it.
   #
   # @param name (see #increment)
@@ -209,7 +209,7 @@ class StatsD::Instrument::Client
   #   use the preferred metric type of the implementation. The default is `:ms`.
   #   Generally, you should not have to set this.
   # @yield The latency (execution time) of the block
-  # @return The return value of the proivded block will be passed through.
+  # @return The return value of the provided block will be passed through.
   def latency(name, sample_rate: nil, tags: nil, metric_type: nil, no_prefix: false)
     start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     begin

--- a/lib/statsd/instrument/datagram_builder.rb
+++ b/lib/statsd/instrument/datagram_builder.rb
@@ -18,7 +18,7 @@ class StatsD::Instrument::DatagramBuilder
   def self.unsupported_datagram_types(*types)
     types.each do |type|
       define_method(type) do |_, _, _, _|
-        raise NotImplementedError, "Type #{type} metrics are not suppered by #{self.class.name}."
+        raise NotImplementedError, "Type #{type} metrics are not supported by #{self.class.name}."
       end
     end
   end

--- a/lib/statsd/instrument/legacy_client.rb
+++ b/lib/statsd/instrument/legacy_client.rb
@@ -120,7 +120,7 @@ class StatsD::Instrument::LegacyClient
   #
   # Emits a set metric, which counts the number of distinct values that have occurred.
   #
-  # @example Couning the number of unique visitors
+  # @example Counting the number of unique visitors
   #   StatsD.set('visitors.unique', Current.user.id)
   #
   # @param key [String] The name of the metric.
@@ -222,7 +222,7 @@ class StatsD::Instrument::LegacyClient
   # @param title [String] Title of the event. A configured prefix may be applied to this title.
   # @param text [String] Body of the event. Can contain newlines.
   # @param [String] hostname The hostname to associate with the event.
-  # @param [Time] timestamp The moment the status of the service was checkes. Defaults to now.
+  # @param [Time] timestamp The moment the status of the service was checked. Defaults to now.
   # @param [String] aggregation_key A key to aggregate similar events into groups.
   # @param [String] priority The event's priority, either `"low"` or `"normal"` (default).
   # @param [String] source_type_name The source type.
@@ -254,7 +254,7 @@ class StatsD::Instrument::LegacyClient
   # @param [String] name Name of the service. A configured prefix may be applied to this title.
   # @param [Symbol] status Current status of the service. Either `:ok`, `:warning`, `:critical`, or `:unknown`.
   # @param [String] hostname The hostname to associate with the event.
-  # @param [Time] timestamp The moment the status of the service was checkes. Defaults to now.
+  # @param [Time] timestamp The moment the status of the service was checked. Defaults to now.
   # @param [String] message A message that describes the current status.
   # @param tags (see #increment)
   # @return [void]

--- a/lib/statsd/instrument/metric.rb
+++ b/lib/statsd/instrument/metric.rb
@@ -54,11 +54,11 @@ class StatsD::Instrument::Metric
   # The default value for this metric, which will be used if it is not set.
   #
   # A default value is only defined for counter metrics (<tt>1</tt>). For all other
-  # metric types, this emthod will raise an <tt>ArgumentError</tt>.
+  # metric types, this method will raise an <tt>ArgumentError</tt>.
   #
   #
   # A default value is only defined for counter metrics (<tt>1</tt>). For all other
-  # metric types, this emthod will raise an <tt>ArgumentError</tt>.
+  # metric types, this method will raise an <tt>ArgumentError</tt>.
   #
   # @return [Numeric, String] The default value for this metric.
   # @raise ArgumentError if the metric type doesn't have a default value

--- a/lib/statsd/instrument/rubocop/metaprogramming_positional_arguments.rb
+++ b/lib/statsd/instrument/rubocop/metaprogramming_positional_arguments.rb
@@ -6,7 +6,7 @@ module RuboCop
   module Cop
     module StatsD
       # This Rubocop will check for using the metaprogramming macros for positional
-      # argument usage, which is deprecated. These macros include `statd_count_if`,
+      # argument usage, which is deprecated. These macros include `statsd_count_if`,
       # `statsd_measure`, etc.
       #
       # Use the following Rubocop invocation to check your project's codebase:

--- a/lib/statsd/instrument/rubocop/positional_arguments.rb
+++ b/lib/statsd/instrument/rubocop/positional_arguments.rb
@@ -42,16 +42,16 @@ module RuboCop
 
         def autocorrect(node)
           -> (corrector) do
-            positial_arguments = if node.arguments.last.type == :block_pass
+            positional_arguments = if node.arguments.last.type == :block_pass
               node.arguments[2...node.arguments.length - 1]
             else
               node.arguments[2...node.arguments.length]
             end
 
-            case positial_arguments[0].type
+            case positional_arguments[0].type
             when *UNKNOWN_ARGUMENT_TYPES
               # We don't know whether the method returns a hash, in which case it would be interpreted
-              # as keyword arguments. In this case, the fix would be to add a keywordf splat:
+              # as keyword arguments. In this case, the fix would be to add a keyword splat:
               #
               # `StatsD.instrument('foo', 1, method_call)`
               # => `StatsD.instrument('foo', 1, **method_call)`
@@ -68,17 +68,17 @@ module RuboCop
             when *POSITIONAL_ARGUMENT_TYPES
               value_argument = node.arguments[1]
               from = value_argument.source_range.end_pos
-              to = positial_arguments.last.source_range.end_pos
+              to = positional_arguments.last.source_range.end_pos
               range = Parser::Source::Range.new(node.source_range.source_buffer, from, to)
               corrector.remove(range)
 
               keyword_arguments = []
-              sample_rate = positial_arguments[0]
+              sample_rate = positional_arguments[0]
               if sample_rate && sample_rate.type != :nil
                 keyword_arguments << "sample_rate: #{sample_rate.source}"
               end
 
-              tags = positial_arguments[1]
+              tags = positional_arguments[1]
               if tags && tags.type != :nil
                 keyword_arguments << if tags.type == :hash && tags.source[0] != '{'
                   "tags: { #{tags.source} }"

--- a/lib/statsd/instrument/rubocop/singleton_configuration.rb
+++ b/lib/statsd/instrument/rubocop/singleton_configuration.rb
@@ -5,7 +5,7 @@ require_relative '../rubocop' unless defined?(RuboCop::Cop::StatsD)
 module RuboCop
   module Cop
     module StatsD
-      # This Rubocop will check for calls to StatsD singleton congfiguration methods
+      # This Rubocop will check for calls to StatsD singleton configuration methods
       # (e.g. `StatsD.prefix`). The library is moving away from having just a single
       # singleton client, so these methods are deprecated.
       #

--- a/lib/statsd/instrument/strict.rb
+++ b/lib/statsd/instrument/strict.rb
@@ -15,7 +15,7 @@ module StatsD
     # - Only accept a position argument for value, rather than a keyword argument.
     # - The provided arguments have the right type.
     #
-    # You can enable thois monkeypatch by changing your Gemfile as follows:
+    # You can enable this monkeypatch by changing your Gemfile as follows:
     #
     #     gem 'statsd-instrument', require: 'statsd/instrument/strict'
     #
@@ -112,7 +112,7 @@ module StatsD
 
         check_method_and_metric_name(method, name)
 
-        # Unfortunately, we have to inline the new method implementation ebcause we have to fix the
+        # Unfortunately, we have to inline the new method implementation because we have to fix the
         # Stats.measure call to not use the `as_dist` and `prefix` arguments.
         add_to_method(method, name, :measure) do
           define_method(method) do |*args, &block|
@@ -129,7 +129,7 @@ module StatsD
 
         check_method_and_metric_name(method, name)
 
-        # Unfortunately, we have to inline the new method implementation ebcause we have to fix the
+        # Unfortunately, we have to inline the new method implementation because we have to fix the
         # Stats.distribution call to not use the `prefix` argument.
 
         add_to_method(method, name, :distribution) do
@@ -147,7 +147,7 @@ module StatsD
 
         check_method_and_metric_name(method, name)
 
-        # Unfortunately, we have to inline the new method implementation ebcause we have to fix the
+        # Unfortunately, we have to inline the new method implementation because we have to fix the
         # Stats.increment call to not use the `prefix` argument.
 
         add_to_method(method, name, :count_success) do
@@ -180,7 +180,7 @@ module StatsD
 
         check_method_and_metric_name(method, name)
 
-        # Unfortunately, we have to inline the new method implementation ebcause we have to fix the
+        # Unfortunately, we have to inline the new method implementation because we have to fix the
         # Stats.increment call to not use the `prefix` argument.
 
         add_to_method(method, name, :count_if) do
@@ -214,7 +214,7 @@ module StatsD
 
         check_method_and_metric_name(method, name)
 
-        # Unfortunately, we have to inline the new method implementation ebcause we have to fix the
+        # Unfortunately, we have to inline the new method implementation because we have to fix the
         # Stats.increment call to not use the `prefix` argument.
 
         add_to_method(method, name, :count) do

--- a/test/assertions_on_legacy_client_test.rb
+++ b/test/assertions_on_legacy_client_test.rb
@@ -333,7 +333,7 @@ class AssertionsOnLegacyClientTest < Minitest::Test
   end
 
   def test_assertion_block_with_other_assertion_failures
-    # If another assertion failure happens inside the block, that failrue should have priority
+    # If another assertion failure happens inside the block, that failure should have priority
     assertion = assert_raises(Minitest::Assertion) do
       @test_case.assert_statsd_increment('counter') do
         @test_case.flunk('other assertion failure')

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -363,7 +363,7 @@ class AssertionsTest < Minitest::Test
   end
 
   def test_assertion_block_with_other_assertion_failures
-    # If another assertion failure happens inside the block, that failrue should have priority
+    # If another assertion failure happens inside the block, that failure should have priority
     assertion = assert_raises(Minitest::Assertion) do
       @test_case.assert_statsd_increment('counter') do
         @test_case.flunk('other assertion failure')

--- a/test/capture_sink_test.rb
+++ b/test/capture_sink_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-class CaptureSinktest < Minitest::Test
+class CaptureSinkTest < Minitest::Test
   def test_capture_sink_captures_datagram_instances
     capture_sink = StatsD::Instrument::CaptureSink.new(parent: [])
     capture_sink << 'foo:1|c'

--- a/test/compatibility/dogstatsd_datagram_compatibility_test.rb
+++ b/test/compatibility/dogstatsd_datagram_compatibility_test.rb
@@ -101,7 +101,7 @@ module Compatibility
       assert_equal_datagrams { |client| client.event('foo', "bar\nbaz") }
       assert_equal_datagrams { |client| client.event('foo', "bar\nbaz", no_prefix: true) }
       assert_equal_datagrams do |client|
-        client.event('Something happend', "And it's not good", timestamp: Time.parse('2019-09-09T04:22:17Z'),
+        client.event('Something happened', "And it's not good", timestamp: Time.parse('2019-09-09T04:22:17Z'),
           hostname: 'localhost', tags: ['foo'], alert_type: 'warning', priority: 'low',
           aggregation_key: 'foo', source_type_name: 'logs')
       end

--- a/test/datagram_builder_test.rb
+++ b/test/datagram_builder_test.rb
@@ -18,7 +18,7 @@ class DatagramBuilderTest < Minitest::Test
     assert_equal ['ign#ored'], @datagram_builder.send(:normalize_tags, ['ign#o|re,d'])
     # Note: how this is interpreted by the backend is undefined.
     # We rely on the user to not do stuff like this if they don't want to be surprised.
-    # We do not want to take the performance hit of normaling this.
+    # We do not want to take the performance hit of normalizing this.
     assert_equal ['lol::class:omg::lol'], @datagram_builder.send(:normalize_tags, "lol::class" => "omg::lol")
   end
 

--- a/test/deprecations_test.rb
+++ b/test/deprecations_test.rb
@@ -74,7 +74,7 @@ class DeprecationsTest < Minitest::Test
   # rubocop:enable StatsD/MetricValueKeywordArgument
 
   # rubocop:disable StatsD/MetricReturnValue
-  def test__deprecated__statsd_increment_retuns_metric_instance
+  def test__deprecated__statsd_increment_returns_metric_instance
     metric = StatsD.increment('key')
     assert_kind_of StatsD::Instrument::Metric, metric
     assert_equal 'key', metric.name

--- a/test/environment_test.rb
+++ b/test/environment_test.rb
@@ -67,7 +67,7 @@ class EnvironmentTest < Minitest::Test
     assert_kind_of StatsD::Instrument::LegacyClient, env.client
   end
 
-  def test_client_returns_new_client_if_envcironment_asks_for_it
+  def test_client_returns_new_client_if_environment_asks_for_it
     env = StatsD::Instrument::Environment.new('STATSD_USE_NEW_CLIENT' => '1')
     assert_kind_of StatsD::Instrument::Client, env.client
   end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -35,7 +35,7 @@ class IntegrationTest < Minitest::Test
     Process.kill('TERM', pid)
     _, exit_status = Process.waitpid2(pid)
 
-    assert_equal 0, exit_status, "The foked process did not exit cleanly"
+    assert_equal 0, exit_status, "The forked process did not exit cleanly"
     assert_equal "exiting:1|c", @server.recvfrom_nonblock(100).first
 
   rescue NotImplementedError

--- a/test/log_sink_test.rb
+++ b/test/log_sink_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-class LogSinktest < Minitest::Test
+class LogSinkTest < Minitest::Test
   def test_log_sink
     logger = Logger.new(log = StringIO.new)
     logger.formatter = proc do |severity, _datetime, _progname, msg|

--- a/test/null_sink_test.rb
+++ b/test/null_sink_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-class NullSinktest < Minitest::Test
+class NullSinkTest < Minitest::Test
   def test_null_sink
     null_sink = StatsD::Instrument::NullSink.new
     null_sink << 'foo:1|c' << 'bar:1|c'

--- a/test/rubocop/metric_prefix_argument_test.rb
+++ b/test/rubocop/metric_prefix_argument_test.rb
@@ -19,7 +19,7 @@ module Rubocop
 
     def test_ok_for_metaprogramming_method_without_prefix_argument
       assert_no_offenses("statsd_measure(:method, 'metric_name')")
-      assert_no_offenses("statsd_count(:method, 'metric_name', sample_rate: 1, no_pefix: true)")
+      assert_no_offenses("statsd_count(:method, 'metric_name', sample_rate: 1, no_prefix: true)")
       assert_no_offenses("statsd_count_if(:method, 'metric_name', sample_rate: 1) {}")
     end
 

--- a/test/rubocop/positional_arguments_test.rb
+++ b/test/rubocop/positional_arguments_test.rb
@@ -21,7 +21,7 @@ module Rubocop
       assert_no_offenses("StatsD.gauge('foo', 2, **kwargs)")
     end
 
-    def test_no_offense_for_now_when_using_value_keyword_argumenr
+    def test_no_offense_for_now_when_using_value_keyword_argument
       assert_no_offenses("StatsD.increment 'foo', value: 3")
       assert_no_offenses("StatsD.increment 'foo', value: 3, sample_rate: 0.5")
       assert_no_offenses("StatsD.increment('foo', value: 3, tags: ['foo']) { foo }")
@@ -29,7 +29,7 @@ module Rubocop
 
     def test_offense_when_using_method_or_constant
       assert_offense("StatsD.gauge('foo', 2, SAMPLE_RATE_CONSTANT)")
-      assert_offense("StatsD.gauge('foo', 2, method_ruturning_a_hash)")
+      assert_offense("StatsD.gauge('foo', 2, method_returning_a_hash)")
     end
 
     def test_offense_when_using_local_variable
@@ -46,7 +46,7 @@ module Rubocop
 
     def test_no_autocorrect_when_using_method_or_constant
       assert_no_autocorrect("StatsD.gauge('foo', 2, SAMPLE_RATE_CONSTANT)")
-      assert_no_autocorrect("StatsD.gauge('foo', 2, method_ruturning_a_hash)")
+      assert_no_autocorrect("StatsD.gauge('foo', 2, method_returning_a_hash)")
     end
 
     def test_autocorrect_only_sample_rate

--- a/test/statsd_test.rb
+++ b/test/statsd_test.rb
@@ -196,12 +196,12 @@ class StatsDTest < Minitest::Test
     assert_equal 42, metric.value
   end
 
-  def test_statsd_durarion_returns_time_in_seconds
+  def test_statsd_duration_returns_time_in_seconds
     duration = StatsD::Instrument.duration {}
     assert_kind_of Float, duration
   end
 
-  def test_statsd_durarion_does_not_swallow_exceptions
+  def test_statsd_duration_does_not_swallow_exceptions
     assert_raises(RuntimeError) do
       StatsD::Instrument.duration { raise "Foo" }
     end

--- a/test/udp_sink_test.rb
+++ b/test/udp_sink_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-class UDPSinktest < Minitest::Test
+class UDPSinkTest < Minitest::Test
   def setup
     @receiver = UDPSocket.new
     @receiver.bind('localhost', 0)


### PR DESCRIPTION
This fixes most (if not all) typos in the codebase.

I found them using the [`scspell`](https://github.com/myint/scspell) tool by running

```bash
git ls-files | xargs -o scspell
```

and dealing with each unknown word, one by one. 😅 

Most of the typos were in text files, or in comments. A couple were actual code (e.g. variable names), but those should have had every occurrence replaced.