### PR TITLE
Disable Windows CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,6 @@ jobs:
         ruby: [2.3, 2.4, 2.5, 2.6]
 
         exclude:
-        # Windows started failing on the following command for some reason.
-        #
-        #     gem install bundler && bundle install --jobs 4 --retry 3
-        #                         ~~
-        #     The token '&&' is not a valid statement separator in this version.
-        #
-        # Disabling windows builds for the time being.
-        - platform: windows-2019
-
         # The Windows environment does not support older Ruby versions. We only test against the latest version
         - platform: windows-2019
           ruby: 2.3
@@ -29,6 +20,17 @@ jobs:
           ruby: 2.4
         - platform: windows-2019
           ruby: 2.5
+
+        # Windows started failing on the following command for some reason.
+        #
+        #     gem install bundler && bundle install --jobs 4 --retry 3
+        #                         ~~
+        #     The token '&&' is not a valid statement separator in this version.
+        #
+        # Temporarily disable Windows builds to unblock CI.
+        - platform: windows-2019
+          ruby: 2.6
+
 
         # On macOS, we only test against the Ruby version macOS ships with (2.3)
         - platform: macOS-10.14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,15 @@ jobs:
         ruby: [2.3, 2.4, 2.5, 2.6]
 
         exclude:
+        # Windows started failing on the following command for some reason.
+        #
+        #     gem install bundler && bundle install --jobs 4 --retry 3
+        #                         ~~
+        #     The token '&&' is not a valid statement separator in this version.
+        #
+        # Disabling windows builds for the time being.
+        - platform: windows-2019
+
         # The Windows environment does not support older Ruby versions. We only test against the latest version
         - platform: windows-2019
           ruby: 2.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,18 +9,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-18.04, windows-2019, macOS-10.14]
-        ruby: [2.3, 2.4, 2.5, 2.6]
-
-        exclude:
-        # The Windows environment does not support older Ruby versions. We only test against the latest version
-        - platform: windows-2019
-          ruby: 2.3
-        - platform: windows-2019
-          ruby: 2.4
-        - platform: windows-2019
-          ruby: 2.5
-
         # Windows started failing on the following command for some reason.
         #
         #     gem install bundler && bundle install --jobs 4 --retry 3
@@ -28,9 +16,19 @@ jobs:
         #     The token '&&' is not a valid statement separator in this version.
         #
         # Temporarily disable Windows builds to unblock CI.
-        - platform: windows-2019
-          ruby: 2.6
+        #
+        # platform: [ubuntu-18.04, windows-2019, macOS-10.14]
+        platform: [ubuntu-18.04, macOS-10.14]
+        ruby: [2.3, 2.4, 2.5, 2.6]
 
+        exclude:
+        # The Windows environment does not support older Ruby versions. We only test against the latest version
+        # - platform: windows-2019
+        #   ruby: 2.3
+        # - platform: windows-2019
+        #   ruby: 2.4
+        # - platform: windows-2019
+        #   ruby: 2.5
 
         # On macOS, we only test against the Ruby version macOS ships with (2.3)
         - platform: macOS-10.14


### PR DESCRIPTION
This disables the CI check against Windows, as per [@wvanbergen's comment on #236](https://github.com/Shopify/statsd-instrument/pull/236#issuecomment-546405005).

For some reason, the Windows check started failing with the following error.

```
Run gem install bundler && bundle install --jobs 4 --retry 3
At D:\a\_temp\48aedf55-2f9e-41d7-893b-70269dfa3633.ps1:2 char:21
+ gem install bundler && bundle install --jobs 4 --retry 3
+                     ~~
The token '&&' is not a valid statement separator in this version.
+ CategoryInfo          : ParserError: (:) [], ParseException
+ FullyQualifiedErrorId : InvalidEndOfLine
```

Temporarily excluding Windows unblocks CI for other PRs until this is figured out.

----
Closes #239 