### PR TITLE
Disable Windows-2019 + Ruby 2.6 CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,17 @@ jobs:
         - platform: windows-2019
           ruby: 2.5
 
+        # Windows started failing on the following command for some reason.
+        #
+        #     gem install bundler && bundle install --jobs 4 --retry 3
+        #                         ~~
+        #     The token '&&' is not a valid statement separator in this version.
+        #
+        # Temporarily disable Windows builds to unblock CI.
+        - platform: windows-2019
+          ruby: 2.6
+
+
         # On macOS, we only test against the Ruby version macOS ships with (2.3)
         - platform: macOS-10.14
           ruby: 2.4


### PR DESCRIPTION
This duplicates #238, since it looks like GitHub actions may be messed up on that PR.

I changed the commit subject to ensure it is a different hash. Hopefully it works on this one 🤞 

#### Original Description
> This disables the CI check against Windows, as per [@wvanbergen's comment on #236](https://github.com/Shopify/statsd-instrument/pull/236#issuecomment-546405005).
>
> For some reason, the Windows check started failing with the following error.
>
> ```
> Run gem install bundler && bundle install --jobs 4 --retry 3
> At D:\a\_temp\48aedf55-2f9e-41d7-893b-70269dfa3633.ps1:2 char:21
> + gem install bundler && bundle install --jobs 4 --retry 3
> +                     ~~
> The token '&&' is not a valid statement separator in this version.
> + CategoryInfo          : ParserError: (:) [], ParseException
> + FullyQualifiedErrorId : InvalidEndOfLine
> ```
>
> Temporarily excluding Windows unblocks CI for other PRs until this is figured out.

----
Closes #238 