### PR TITLE
Remove dependency on StatsD::Instrument::Metric in Expectation.

### DIFF
--- a/lib/statsd/instrument/expectation.rb
+++ b/lib/statsd/instrument/expectation.rb
@@ -41,7 +41,7 @@ class StatsD::Instrument::Expectation
     @name = client.prefix ? "#{client.prefix}.#{name}" : name unless no_prefix
     @value = normalized_value_for_type(type, value) if value
     @sample_rate = sample_rate
-    @tags = StatsD::Instrument::Metric.normalize_tags(tags)
+    @tags = normalize_tags(tags)
     @times = times
   end
 
@@ -76,6 +76,42 @@ class StatsD::Instrument::Expectation
 
   def inspect
     "#<StatsD::Instrument::Expectation:\"#{self}\">"
+  end
+
+  private
+
+  # Needed for normalize_tags
+  unless Regexp.method_defined?(:match?) # for ruby 2.3
+    module RubyBackports
+      refine Regexp do
+        def match?(str)
+          (self =~ str) != nil
+        end
+      end
+    end
+
+    using RubyBackports
+  end
+
+  # @private
+  #
+  # Utility function to convert tags to the canonical form.
+  #
+  # - Tags specified as key value pairs will be converted into an array
+  # - Tags are normalized to remove unsupported characters
+  #
+  # @param tags [Array<String>, Hash<String, String>, nil] Tags specified in any form.
+  # @return [Array<String>, nil] the list of tags in canonical form.
+  #
+  # @todo We should delegate this to thje datagram builder of the current client,
+  #   to ensure that this logic matches the logic of the active datagram builder.
+  def normalize_tags(tags)
+    return [] unless tags
+    tags = tags.map { |k, v| "#{k}:#{v}" } if tags.is_a?(Hash)
+
+    # Fast path when no string replacement is needed
+    return tags unless tags.any? { |tag| /[|,]/.match?(tag) }
+    tags.map { |tag| tag.tr('|,', '') }
   end
 end
 


### PR DESCRIPTION
In the next major version `StatsD::Instrument::Metric` will be removed. So we should not depend on it.

In an ideal world, we should call `normalize_tags` on the datagram builder of the client on which we want to run the expectation, so people can use different implementations.That's something I will leave for a future PR.