### PR TITLE
Update strict mode to also return VOID when calling metric methods.

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -338,6 +338,10 @@ module StatsD
       remove_from_method(method, name, :distribution)
     end
 
+    VoidClass = Class.new(BasicObject)
+    private_constant :VoidClass
+    VOID = VoidClass.new
+
     private
 
     def statsd_instrumentation_for(method, name, action)

--- a/lib/statsd/instrument/client.rb
+++ b/lib/statsd/instrument/client.rb
@@ -106,7 +106,7 @@ class StatsD::Instrument::Client
   # @return [void]
   def increment(name, value = 1, sample_rate: nil, tags: nil, no_prefix: false)
     sample_rate ||= @default_sample_rate
-    return VOID unless sample?(sample_rate)
+    return StatsD::Instrument::VOID unless sample?(sample_rate)
     emit(datagram_builder(no_prefix: no_prefix).c(name, value, sample_rate, tags))
   end
 
@@ -123,7 +123,7 @@ class StatsD::Instrument::Client
     end
 
     sample_rate ||= @default_sample_rate
-    return VOID unless sample?(sample_rate)
+    return StatsD::Instrument::VOID unless sample?(sample_rate)
     emit(datagram_builder(no_prefix: no_prefix).ms(name, value, sample_rate, tags))
   end
 
@@ -142,7 +142,7 @@ class StatsD::Instrument::Client
   # @return [void]
   def gauge(name, value, sample_rate: nil, tags: nil, no_prefix: false)
     sample_rate ||= @default_sample_rate
-    return VOID unless sample?(sample_rate)
+    return StatsD::Instrument::VOID unless sample?(sample_rate)
     emit(datagram_builder(no_prefix: no_prefix).g(name, value, sample_rate, tags))
   end
 
@@ -155,7 +155,7 @@ class StatsD::Instrument::Client
   # @return [void]
   def set(name, value, sample_rate: nil, tags: nil, no_prefix: false)
     sample_rate ||= @default_sample_rate
-    return VOID unless sample?(sample_rate)
+    return StatsD::Instrument::VOID unless sample?(sample_rate)
     emit(datagram_builder(no_prefix: no_prefix).s(name, value, sample_rate, tags))
   end
 
@@ -177,7 +177,7 @@ class StatsD::Instrument::Client
     end
 
     sample_rate ||= @default_sample_rate
-    return VOID unless sample?(sample_rate)
+    return StatsD::Instrument::VOID unless sample?(sample_rate)
     emit(datagram_builder(no_prefix: no_prefix).d(name, value, sample_rate, tags))
   end
 
@@ -194,7 +194,7 @@ class StatsD::Instrument::Client
   # @return [void]
   def histogram(name, value, sample_rate: nil, tags: nil, no_prefix: false)
     sample_rate ||= @default_sample_rate
-    return VOID unless sample?(sample_rate)
+    return StatsD::Instrument::VOID unless sample?(sample_rate)
     emit(datagram_builder(no_prefix: no_prefix).h(name, value, sample_rate, tags))
   end
 
@@ -343,10 +343,6 @@ class StatsD::Instrument::Client
 
   def emit(datagram)
     @sink << datagram
-    VOID
+    StatsD::Instrument::VOID
   end
-
-  VoidClass = Class.new(BasicObject)
-  VOID = VoidClass.new
-  private_constant :VoidClass, :VOID
 end

--- a/lib/statsd/instrument/legacy_client.rb
+++ b/lib/statsd/instrument/legacy_client.rb
@@ -273,7 +273,7 @@ class StatsD::Instrument::LegacyClient
     })
   end
 
-  private
+  protected
 
   def measure_latency(type, key, sample_rate:, tags:, prefix:)
     start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
@@ -296,6 +296,6 @@ class StatsD::Instrument::LegacyClient
     metric = StatsD::Instrument::Metric.new(type: type, name: name, value: value,
       sample_rate: sample_rate, tags: tags, metadata: metadata)
     backend.collect_metric(metric)
-    metric # TODO: return `nil` in the next major version
+    metric
   end
 end

--- a/lib/statsd/instrument/strict.rb
+++ b/lib/statsd/instrument/strict.rb
@@ -99,10 +99,14 @@ module StatsD
           raise ArgumentError, "The tags argument should be a hash or an array, got #{tags.inspect}"
         end
       end
+    end
+
+    module VoidCollectMetric
+      protected
 
       def collect_metric(type, name, value, sample_rate:, tags: nil, prefix:, metadata: nil)
         super
-        nil # We explicitly discard the return value, so people cannot depend on it.
+        StatsD::Instrument::VOID
       end
     end
 
@@ -242,4 +246,5 @@ module StatsD
 end
 
 StatsD.singleton_class.prepend(StatsD::Instrument::Strict)
+StatsD::Instrument::LegacyClient.prepend(StatsD::Instrument::VoidCollectMetric)
 StatsD::Instrument.prepend(StatsD::Instrument::StrictMetaprogramming)


### PR DESCRIPTION
In #237, we updated metrics methods to return a `VOID` value, rather than nil, for backwards compatibility. We forgot to update strict mode to do the same. This fixes that.