### PR TITLE
Deprecate the `StatsD.key_value` metric method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ section below.
 
 ### Unreleased changes
 
+- ⚠️ **DEPRECATION:**  The `StatsD.key_value` metric method is deprecated
+  and will be removed in version 3.0. The new client does not have StatSite
+  support. Due to the lack of active contributors that can port this metric
+  type to the new client, we have decided to drop it until somebody else
+  steps up and re-adds it to the new client.
 - Add support for variadic arguments to `assert_no_statsd_calls`. This allows
   consolidation of assertions about specific metrics. For example:
     ```diff

--- a/lib/statsd/instrument/strict.rb
+++ b/lib/statsd/instrument/strict.rb
@@ -81,6 +81,11 @@ module StatsD
         super
       end
 
+      def key_value(*)
+        raise NotImplementedError, "The key_value metric type will be removed " \
+          "from the next major version of statsd-instrument"
+      end
+
       private
 
       def check_block_or_numeric_value(value)

--- a/test/deprecations_test.rb
+++ b/test/deprecations_test.rb
@@ -122,6 +122,13 @@ class DeprecationsTest < Minitest::Test
   end
   # rubocop:enable StatsD/MetricPrefixArgument
 
+  def test__deprecated__statsd_key_value
+    metric = capture_statsd_call { StatsD.key_value('values.foobar', 42) }
+    assert_equal :kv, metric.type
+    assert_equal 'values.foobar', metric.name
+    assert_equal 42, metric.value
+  end
+
   protected
 
   def capture_statsd_call(&block)

--- a/test/statsd_test.rb
+++ b/test/statsd_test.rb
@@ -189,13 +189,6 @@ class StatsDTest < Minitest::Test
     assert_nil return_value
   end
 
-  def test_statsd_key_value
-    metric = capture_statsd_call { StatsD.key_value('values.foobar', 42) }
-    assert_equal :kv, metric.type
-    assert_equal 'values.foobar', metric.name
-    assert_equal 42, metric.value
-  end
-
   def test_statsd_duration_returns_time_in_seconds
     duration = StatsD::Instrument.duration {}
     assert_kind_of Float, duration

--- a/test/udp_backend_test.rb
+++ b/test/udp_backend_test.rb
@@ -160,6 +160,7 @@ class UDPBackendTest < Minitest::Test
   end
 
   def test_supports_key_value_syntax_on_statsite
+    skip if StatsD::Instrument.strict_mode_enabled?
     @backend.implementation = :statsite
     @backend.expects(:write_packet).with("fooy:42|kv\n")
     StatsD.key_value('fooy', 42)
@@ -173,6 +174,7 @@ class UDPBackendTest < Minitest::Test
 
   # rubocop:disable StatsD/PositionalArguments
   def test_supports_key_value_with_timestamp_on_statsite
+    skip if StatsD::Instrument.strict_mode_enabled?
     @backend.implementation = :statsite
     @backend.expects(:write_packet).with("fooy:42|kv|@123456\n")
     StatsD.key_value('fooy', 42, 123456)
@@ -180,6 +182,7 @@ class UDPBackendTest < Minitest::Test
   # rubocop:enable StatsD/PositionalArguments
 
   def test_warn_when_using_key_value_and_not_on_statsite
+    skip if StatsD::Instrument.strict_mode_enabled?
     @backend.implementation = :other
     @backend.expects(:write_packet).never
     @logger.expects(:warn)


### PR DESCRIPTION
It will be removed in version 3.0. The new client does not have StatSite support. Due to the lack of active contributors that can port this metric type to the new client, we have decided to drop it until somebody else steps up and re-adds it to the new client.