### PR TITLE
Make void a regular but frozen object, rather than a basic object

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -344,9 +344,9 @@ module StatsD
       remove_from_method(method, name, :distribution)
     end
 
-    VoidClass = Class.new(BasicObject)
+    VoidClass = Class.new
     private_constant :VoidClass
-    VOID = VoidClass.new
+    VOID = VoidClass.new.freeze
 
     private
 


### PR DESCRIPTION
Using a `BasicObject` for `VOID` return values is a bit too restrictive. Many things that work on object are not supported (e.g. `#tap` and `#class`), which breaks all kinds of instrumentation wrapper methods. Technically that means that those methods depend on the return value of a StatsD metric and should be fixed, but it creates a bit too much pain.