### PR TITLE
Allow positional value arguments for assert_statsd_ calls 

### DIFF
--- a/lib/statsd/instrument/assertions.rb
+++ b/lib/statsd/instrument/assertions.rb
@@ -71,8 +71,8 @@ module StatsD::Instrument::Assertions
   # @return [void]
   # @raise [Minitest::Assertion] If an exception occurs, or if the metric did
   #   not occur as specified during the execution the block.
-  def assert_statsd_increment(metric_name, datagrams: nil, client: nil, **options, &block)
-    expectation = StatsD::Instrument::Expectation.increment(metric_name, **options)
+  def assert_statsd_increment(metric_name, value = nil, datagrams: nil, client: nil, **options, &block)
+    expectation = StatsD::Instrument::Expectation.increment(metric_name, value, **options)
     assert_statsd_expectation(expectation, datagrams: datagrams, client: client, &block)
   end
 
@@ -83,8 +83,8 @@ module StatsD::Instrument::Assertions
   # @yield (see #assert_statsd_increment)
   # @return [void]
   # @raise (see #assert_statsd_increment)
-  def assert_statsd_measure(metric_name, datagrams: nil, client: nil, **options, &block)
-    expectation = StatsD::Instrument::Expectation.measure(metric_name, **options)
+  def assert_statsd_measure(metric_name, value = nil, datagrams: nil, client: nil, **options, &block)
+    expectation = StatsD::Instrument::Expectation.measure(metric_name, value, **options)
     assert_statsd_expectation(expectation, datagrams: datagrams, client: client, &block)
   end
 
@@ -95,8 +95,8 @@ module StatsD::Instrument::Assertions
   # @yield (see #assert_statsd_increment)
   # @return [void]
   # @raise (see #assert_statsd_increment)
-  def assert_statsd_gauge(metric_name, datagrams: nil, client: nil, **options, &block)
-    expectation = StatsD::Instrument::Expectation.gauge(metric_name, **options)
+  def assert_statsd_gauge(metric_name, value = nil, datagrams: nil, client: nil, **options, &block)
+    expectation = StatsD::Instrument::Expectation.gauge(metric_name, value, **options)
     assert_statsd_expectation(expectation, datagrams: datagrams, client: client, &block)
   end
 
@@ -107,8 +107,8 @@ module StatsD::Instrument::Assertions
   # @yield (see #assert_statsd_increment)
   # @return [void]
   # @raise (see #assert_statsd_increment)
-  def assert_statsd_histogram(metric_name, datagrams: nil, client: nil, **options, &block)
-    expectation = StatsD::Instrument::Expectation.histogram(metric_name, **options)
+  def assert_statsd_histogram(metric_name, value = nil, datagrams: nil, client: nil, **options, &block)
+    expectation = StatsD::Instrument::Expectation.histogram(metric_name, value, **options)
     assert_statsd_expectation(expectation, datagrams: datagrams, client: client, &block)
   end
 
@@ -119,8 +119,8 @@ module StatsD::Instrument::Assertions
   # @yield (see #assert_statsd_increment)
   # @return [void]
   # @raise (see #assert_statsd_increment)
-  def assert_statsd_distribution(metric_name, datagrams: nil, client: nil, **options, &block)
-    expectation = StatsD::Instrument::Expectation.distribution(metric_name, **options)
+  def assert_statsd_distribution(metric_name, value = nil, datagrams: nil, client: nil, **options, &block)
+    expectation = StatsD::Instrument::Expectation.distribution(metric_name, value, **options)
     assert_statsd_expectation(expectation, datagrams: datagrams, client: client, &block)
   end
 
@@ -131,8 +131,8 @@ module StatsD::Instrument::Assertions
   # @yield (see #assert_statsd_increment)
   # @return [void]
   # @raise (see #assert_statsd_increment)
-  def assert_statsd_set(metric_name, datagrams: nil, client: nil, **options, &block)
-    expectation = StatsD::Instrument::Expectation.set(metric_name, **options)
+  def assert_statsd_set(metric_name, value = nil, datagrams: nil, client: nil, **options, &block)
+    expectation = StatsD::Instrument::Expectation.set(metric_name, value, **options)
     assert_statsd_expectation(expectation, datagrams: datagrams, client: client, &block)
   end
 
@@ -143,8 +143,8 @@ module StatsD::Instrument::Assertions
   # @yield (see #assert_statsd_increment)
   # @return [void]
   # @raise (see #assert_statsd_increment)
-  def assert_statsd_key_value(metric_name, datagrams: nil, client: nil, **options, &block)
-    expectation = StatsD::Instrument::Expectation.key_value(metric_name, **options)
+  def assert_statsd_key_value(metric_name, value = nil, datagrams: nil, client: nil, **options, &block)
+    expectation = StatsD::Instrument::Expectation.key_value(metric_name, value, **options)
     assert_statsd_expectation(expectation, datagrams: datagrams, client: client, &block)
   end
 

--- a/lib/statsd/instrument/expectation.rb
+++ b/lib/statsd/instrument/expectation.rb
@@ -3,32 +3,32 @@
 # @private
 class StatsD::Instrument::Expectation
   class << self
-    def increment(name, **options)
-      new(type: :c, name: name, **options)
+    def increment(name, value = nil, **options)
+      new(type: :c, name: name, value: value, **options)
     end
 
-    def measure(name, **options)
-      new(type: :ms, name: name, **options)
+    def measure(name, value = nil, **options)
+      new(type: :ms, name: name, value: value, **options)
     end
 
-    def gauge(name, **options)
-      new(type: :g, name: name, **options)
+    def gauge(name, value = nil, **options)
+      new(type: :g, name: name, value: value, **options)
     end
 
-    def set(name, **options)
-      new(type: :s, name: name, **options)
+    def set(name, value = nil, **options)
+      new(type: :s, name: name, value: value, **options)
     end
 
-    def key_value(name, **options)
-      new(type: :kv, name: name, **options)
+    def key_value(name, value = nil, **options)
+      new(type: :kv, name: name, value: value, **options)
     end
 
-    def distribution(name, **options)
-      new(type: :d, name: name, **options)
+    def distribution(name, value = nil, **options)
+      new(type: :d, name: name, value: value, **options)
     end
 
-    def histogram(name, **options)
-      new(type: :h, name: name, **options)
+    def histogram(name, value = nil, **options)
+      new(type: :h, name: name, value: value, **options)
     end
   end
 

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -132,42 +132,54 @@ class AssertionsTest < Minitest::Test
   end
 
   def test_assert_statsd_gauge_call_with_numeric_value
-    @test_case.assert_statsd_gauge('gauge', value: 42) do
+    @test_case.assert_statsd_gauge('gauge', 42) do
       StatsD.gauge('gauge', 42)
     end
 
-    @test_case.assert_statsd_gauge('gauge', value: '42') do
+    @test_case.assert_statsd_gauge('gauge', '42') do
       StatsD.gauge('gauge', 42)
     end
 
     assert_raises(Minitest::Assertion) do
-      @test_case.assert_statsd_gauge('gauge', value: 42) do
+      @test_case.assert_statsd_gauge('gauge', 42) do
         StatsD.gauge('gauge', 45)
       end
+    end
+
+    @test_case.assert_statsd_gauge('gauge', value: 42) do
+      StatsD.gauge('gauge', 42)
     end
   end
 
   def test_assert_statsd_set_call_with_string_value
-    @test_case.assert_statsd_set('set', value: 12345) do
+    @test_case.assert_statsd_set('set', 12345) do
       StatsD.set('set', '12345')
     end
 
-    @test_case.assert_statsd_set('set', value: '12345') do
+    @test_case.assert_statsd_set('set', '12345') do
       StatsD.set('set', '12345')
     end
 
-    @test_case.assert_statsd_set('set', value: 12345) do
+    @test_case.assert_statsd_set('set', 12345) do
       StatsD.set('set', 12345)
     end
 
-    @test_case.assert_statsd_set('set', value: '12345') do
+    @test_case.assert_statsd_set('set', '12345') do
       StatsD.set('set', 12345)
     end
 
     assert_raises(Minitest::Assertion) do
-      @test_case.assert_statsd_set('set', value: '42') do
+      @test_case.assert_statsd_set('set', '42') do
         StatsD.set('set', 45)
       end
+    end
+
+    @test_case.assert_statsd_set('set', value: 12345) do
+      StatsD.set('set', '12345')
+    end
+
+    @test_case.assert_statsd_set('set', 'wrong_value', value: 12345) do
+      StatsD.set('set', '12345')
     end
   end
 
@@ -285,7 +297,7 @@ class AssertionsTest < Minitest::Test
     end
 
     foo_1_metric = StatsD::Instrument::Expectation.increment('counter', times: 2, tags: ['foo:1'])
-    foo_2_metric = StatsD::Instrument::Expectation.increment('counter', tags: ['foo:2'])
+    foo_2_metric = StatsD::Instrument::Expectation.increment('counter', 1, tags: ['foo:2'])
     @test_case.assert_statsd_expectations([foo_1_metric, foo_2_metric]) do
       StatsD.increment('counter', tags: { foo: 1 })
       StatsD.increment('counter', tags: { foo: 1 })


### PR DESCRIPTION
Allow a positional value arguments for `assert_statsd_*` calls, rather than a keyword argument. Also for `StatsD::Instrument::Expectation` builder methods. This is to be in line with the corresponding `StatsD.metric` calls that also take a positional argument for value.

E.g., you can now do `assert_statsd_increment(‘metric’, 10)` rather than `assert_statsd_increment(‘metric’, value: 10)`

The old value keyword argument is still supported, and takes priority if present.