### PR TITLE
Update Readme to correct default settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The following environment variables are supported:
 
 - `STATSD_ADDR`: (default `localhost:8125`) The address to send the StatsD UDP
   datagrams to.
-- `STATSD_IMPLEMENTATION`: (default: `statsd`). The StatsD implementation you
+- `STATSD_IMPLEMENTATION`: (default: `datadog`). The StatsD implementation you
   are using. `statsd`, `statsite` and `datadog` are supported. Some features
   are only available on certain implementations,
 - `STATSD_ENV`: The environment StatsD will run in. If this is not set


### PR DESCRIPTION
The documentation says that the default implementation is `statsd`, but it appears to actually be `datadog`. This updates the README.

https://github.com/Shopify/statsd-instrument/blob/02e682d463eba0043db1935d15c0ab1b523e9dd5/lib/statsd/instrument/environment.rb#L61