### PR TITLE
Fix mocha deprecation warning

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,7 @@ ENV['ENV'] = 'test'
 
 require 'minitest/autorun'
 require 'minitest/pride'
-require 'mocha/setup'
+require 'mocha/minitest'
 require 'statsd-instrument'
 
 require_relative 'helpers/rubocop_helper'


### PR DESCRIPTION
Requiring 'mocha/setup' was deprecated in mocha v1.10.0.