### PR TITLE
Remove sample_rate from StatsD.event README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ An event is a (title, text) tuple that can be used to correlate metrics with som
 This is a good fit for instance to correlate response time variation with a deploy of the new code.
 
 ```ruby
-StatsD.event('shipit.deploy', 'started', sample_rate: 1.0)
+StatsD.event('shipit.deploy', 'started')
 ```
 
 *Note: This is only supported by the [datadog implementation](https://docs.datadoghq.com/guides/dogstatsd/#events).*


### PR DESCRIPTION
As of a prior PR, `sample_rate` is ignored for `StatsD.event` calls: https://github.com/Shopify/statsd-instrument/pull/199

This PR removes `sample_rate` from the README example for that same method.