### PR TITLE
Let the UDP sink use a dispatcher thread

### DIFF
--- a/lib/statsd/instrument/udp_sink.rb
+++ b/lib/statsd/instrument/udp_sink.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'objspace'
+require 'thread'
+
 # @note This class is part of the new Client implementation that is intended
 #   to become the new default in the next major release of this library.
 class StatsD::Instrument::UDPSink
@@ -8,13 +11,62 @@ class StatsD::Instrument::UDPSink
     new(host, Integer(port_as_string))
   end
 
+  class Dispatcher
+    def initialize(host, port, queue)
+      @host = host
+      @port = port
+      @queue = queue
+      @socket = nil
+      @thread = nil
+      ObjectSpace.define_finalizer(self, Proc.new { |o| o.stop })
+    end
+
+    def start
+      @thread = Thread.new { dispatcher_loop }
+      self
+    end
+
+    def stop
+      @queue.close
+      @thread.join(0.1)
+    rescue ThreadError
+    end
+
+    private
+    def dispatcher_loop
+      loop do
+        datagram = @queue.pop(false)
+        begin
+          socket.send(datagram, 0)
+        rescue ThreadError
+          socket.send(datagram, 0)
+        rescue SocketError, IOError, SystemCallError
+          # TODO: log?
+          invalidate_socket
+        end
+      end
+    end
+
+    def socket
+      if @socket.nil?
+        @socket = UDPSocket.new
+        @socket.connect(@host, @port)
+      end
+      @socket
+    end
+
+    def invalidate_socket
+      @socket = nil
+    end
+  end
+
   attr_reader :host, :port
 
   def initialize(host, port)
     @host = host
     @port = port
-    @mutex = Mutex.new
-    @socket = nil
+    @queue = Queue.new
+    @dispatcher = Dispatcher.new(host, port, @queue).start
   end
 
   def sample?(sample_rate)
@@ -22,41 +74,11 @@ class StatsD::Instrument::UDPSink
   end
 
   def <<(datagram)
-    with_socket { |socket| socket.send(datagram, 0) > 0 }
+    @queue << datagram
     self
-
-  rescue ThreadError
-    # In cases where a TERM or KILL signal has been sent, and we send stats as
-    # part of a signal handler, locks cannot be acquired, so we do our best
-    # to try and send the datagram without a lock.
-    socket.send(datagram, 0) > 0
-
-  rescue SocketError, IOError, SystemCallError
-    # TODO: log?
-    invalidate_socket
   end
 
   def addr
     "#{host}:#{port}"
-  end
-
-  private
-
-  def with_socket
-    @mutex.synchronize { yield(socket) }
-  end
-
-  def socket
-    if @socket.nil?
-      @socket = UDPSocket.new
-      @socket.connect(@host, @port)
-    end
-    @socket
-  end
-
-  def invalidate_socket
-    @mutex.synchronize do
-      @socket = nil
-    end
   end
 end

--- a/test/udp_sink_test.rb
+++ b/test/udp_sink_test.rb
@@ -58,6 +58,8 @@ class UDPSinkTest < Minitest::Test
     udp_sink = StatsD::Instrument::UDPSink.new('localhost', 8125)
     udp_sink << 'foo:1|c'
     udp_sink << 'bar:1|c'
+    # Let the dispatcher thread emit
+    sleep 0.1
   end
 
   def test_sends_datagram_in_signal_handler


### PR DESCRIPTION
### Why?

Although UDP uses a connectionless communication model, the following user space code paths aren't free:

* [Mutex](https://github.com/ruby/ruby/blob/115fec062ccf7c6d72c8d5f64b7a5d84c9fb2dd8/thread_sync.c#L237-L317) held on the socket
* Sending datagrams still incurs a [system call](https://github.com/ruby/ruby/blob/1663d347c993debf7ed83e11e291e7a21e14ed03/ext/socket/udpsocket.c#L199-L220)

Using a `Queue` as contract with a simple dispatch Thread reduce datagram dispatch for the producer to an [array push](https://github.com/ruby/ruby/blob/115fec062ccf7c6d72c8d5f64b7a5d84c9fb2dd8/thread_sync.c#L784) and a user space [thread interrupt](https://github.com/ruby/ruby/blob/0256e4f0f5e10f0a15cbba2cd64e252dfa864e4a/vm_core.h#L1791 ) 

Master:

```
methodmissing:statsd-instrument lourens$ benchmark/send-metrics-to-local-udp-receiver
Warming up --------------------------------------
StatsD metrics to local UDP receiver (branch: master, sha: 07fb158)
                         1.213k i/100ms
Calculating -------------------------------------
StatsD metrics to local UDP receiver (branch: master, sha: 07fb158)
                         11.876k (± 3.9%) i/s -     59.437k in   5.012616s

To compare the performance of this revision against another revision (e.g. master),
check out a different branch and run this benchmark script again.
```

This PR:

```
methodmissing:statsd-instrument lourens$ benchmark/send-metrics-to-local-udp-receiver
Warming up --------------------------------------
StatsD metrics to local UDP receiver (branch: dispatch-thread, sha: 3137f7e)
                         4.199k i/100ms
Calculating -------------------------------------
StatsD metrics to local UDP receiver (branch: dispatch-thread, sha: 3137f7e)
                         44.251k (±25.9%) i/s -    201.552k in   5.042619s

Comparison:
StatsD metrics to local UDP receiver (branch: dispatch-thread, sha: 3137f7e):    44251.3 i/s
StatsD metrics to local UDP receiver (branch: master, sha: 07fb158):    11921.7 i/s - 3.71x  (± 0.00) slower
```

### Why not?

Threads 😄 The dispatcher is very thin and cleanly separates IO and socket init + teardown on error from the metrics producer thread. Cleanup is handled with a GC finalizer (which of course only fires on clean exit, but this is true for ObjectSpace in general too). See the throwaway section below

### Why this is throwaway

Queues do not work X process because https://github.com/ruby/ruby/blob/115fec062ccf7c6d72c8d5f64b7a5d84c9fb2dd8/thread_sync.c#L606-L619 and therefore test https://github.com/Shopify/statsd-instrument/blob/master/test/udp_sink_test.rb#L63-L82 would always fail because https://github.com/Shopify/statsd-instrument/blob/master/test/udp_sink_test.rb#L67 is enq'ed but `num_waiting` is reset to 0, with the dispatcher thread effectively never seeing the datagram as the queue has no waiters.