### PR TITLE
Datagram builder as a C extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ doc
 *.gem
 .bundle
 Gemfile.lock
+lib/statsd/instrument/ext/*
 pkg/*
 vendor/
 tmp/*

--- a/Rakefile
+++ b/Rakefile
@@ -3,10 +3,21 @@
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 
+GEMSPEC = eval(File.read('statsd-instrument.gemspec'))
+
+require 'rake/extensiontask'
+Rake::ExtensionTask.new('statsd', GEMSPEC) do |ext|
+  ext.ext_dir = 'ext/statsd'
+  ext.lib_dir = 'lib/statsd/instrument/ext'
+end
+task :build => :compile
+
 Rake::TestTask.new('test') do |t|
   t.ruby_opts << '-r rubygems'
   t.libs << 'lib' << 'test'
   t.test_files = FileList['test/**/*_test.rb']
 end
+
+task :test => :build
 
 task default: :test

--- a/ext/statsd/extconf.rb
+++ b/ext/statsd/extconf.rb
@@ -1,5 +1,12 @@
 require 'mkmf'
 
-$CFLAGS = "-O3"
+append_cflags '-pedantic'
+append_cflags '-Wall'
+if ENV['STATSD_EXT_DEBUG']
+  append_cflags "-Og"
+  append_cflags '-ggdb3'
+else
+  append_cflags "-O3"
+end
 
 create_makefile('statsd/statsd')

--- a/ext/statsd/extconf.rb
+++ b/ext/statsd/extconf.rb
@@ -1,0 +1,5 @@
+require 'mkmf'
+
+$CFLAGS = "-O3"
+
+create_makefile('statsd/statsd')

--- a/ext/statsd/statsd.c
+++ b/ext/statsd/statsd.c
@@ -71,8 +71,6 @@ generate_generic_datagram(VALUE self, VALUE name, VALUE value, VALUE type, VALUE
   int len = 0, tags_len = 0, i = 0;
   long chunk_len = 0;
 
-  MEMZERO(&datagram, char, DATAGRAM_SIZE_MAX);
-
   prefix = rb_ivar_get(self, idPrefix);
   if ((chunk_len = RSTRING_LEN(prefix)) != 0) {
     if (len + chunk_len > DATAGRAM_SIZE_MAX) goto finalize_datagram;

--- a/ext/statsd/statsd.c
+++ b/ext/statsd/statsd.c
@@ -210,7 +210,7 @@ normalized_tags_cached(struct datagram_builder *builder, VALUE self, VALUE tags)
 #endif
 }
 
-inline static int append_normalized_tags(struct datagram_builder *builder, VALUE normalized_tags, int trim_trailing_comma)
+inline static bool append_normalized_tags(struct datagram_builder *builder, VALUE normalized_tags, int trim_trailing_comma)
 {
   VALUE tag;
   int tags_len = 0, chunk_len = 0, i = 0;
@@ -218,16 +218,16 @@ inline static int append_normalized_tags(struct datagram_builder *builder, VALUE
   for (i = 0; i < tags_len; ++i) {
     tag = RARRAY_AREF(normalized_tags, i);
     chunk_len = (int)RSTRING_LEN(tag);
-    if (builder->len + chunk_len > DATAGRAM_SIZE_MAX) return 0;
+    if (builder->len + chunk_len > DATAGRAM_SIZE_MAX) return false;
     memcpy(builder->datagram + builder->len, StringValuePtr(tag), chunk_len);
     builder->len += chunk_len;
     if (!trim_trailing_comma || i < tags_len - 1) {
-      if (builder->len + 1 > DATAGRAM_SIZE_MAX) return 0;
+      if (builder->len + 1 > DATAGRAM_SIZE_MAX) return false;
       memcpy(builder->datagram + builder->len, ",", 1);
       builder->len += 1;
     }
   }
-  return 1;
+  return true;
 }
 
 static VALUE

--- a/ext/statsd/statsd.c
+++ b/ext/statsd/statsd.c
@@ -1,0 +1,43 @@
+#include <ruby.h>
+#include <ruby/encoding.h>
+
+static VALUE idTr;
+static VALUE strNormalizeChars, strNormalizeReplacement;
+
+static VALUE
+normalize_name(VALUE self, VALUE name) {
+  Check_Type(name, T_STRING);
+
+  char *name_start = RSTRING_PTR(name);
+  char *name_end = RSTRING_END(name);
+
+  while (name_start < name_end) {
+    if (*name_start == ':' || *name_start == '|' || *name_start == '@') {
+      break;
+    }
+    name_start++;
+  }
+
+  if (name_start == name_end) {
+    return name;
+  }
+  return rb_funcall(name, idTr, 2, strNormalizeChars, strNormalizeReplacement);
+}
+
+void Init_statsd()
+{
+  VALUE mStatsd, mInstrument, cDatagramBuilder;
+
+  mStatsd = rb_define_module("StatsD");
+  mInstrument = rb_define_module_under(mStatsd, "Instrument");
+  cDatagramBuilder = rb_define_class_under(mInstrument, "DatagramBuilder", rb_cObject);
+
+  idTr = rb_intern("tr");
+  strNormalizeChars = rb_str_new_cstr(":|@");
+  strNormalizeReplacement = rb_str_new_cstr("_");
+
+  rb_global_variable(&strNormalizeChars);
+  rb_global_variable(&strNormalizeReplacement);
+
+  rb_define_protected_method(cDatagramBuilder, "normalize_name", normalize_name, 1);
+}

--- a/ext/statsd/statsd.c
+++ b/ext/statsd/statsd.c
@@ -211,7 +211,7 @@ generate_generic_datagram(VALUE self, VALUE name, VALUE value, VALUE type, VALUE
   long chunk_len = 0;
   get_datagram_builder_struct(self);
 
-  len = builder->prefix_len;
+  len = (int)builder->prefix_len;
 
   if (NIL_P(normalized_name = normalize_name_fast_path(self, name))) {
     normalized_name = normalized_names_cached(builder, self, name);
@@ -268,7 +268,7 @@ generate_generic_datagram(VALUE self, VALUE name, VALUE value, VALUE type, VALUE
     memcpy(builder->datagram + len, "|#", 2);
     len += 2;
 
-    tags_len = RARRAY_LEN(normalized_tags);
+    tags_len = (int)RARRAY_LEN(normalized_tags);
     for (i = 0; i < tags_len; ++i) {
       tag = RARRAY_AREF(normalized_tags, i);
       chunk_len = RSTRING_LEN(tag);

--- a/ext/statsd/statsd.c
+++ b/ext/statsd/statsd.c
@@ -1,15 +1,19 @@
 #include <ruby.h>
 #include <ruby/encoding.h>
 
-static VALUE idTr;
+#define MAX_DATAGRAM_SIZE 4096
+
+static ID idTr, idNormalizeTags, idDefaultTags, idPrefix;
 static VALUE strNormalizeChars, strNormalizeReplacement;
 
 static VALUE
 normalize_name(VALUE self, VALUE name) {
+  char *name_start = NULL;
+  char *name_end = NULL;
   Check_Type(name, T_STRING);
 
-  char *name_start = RSTRING_PTR(name);
-  char *name_end = RSTRING_END(name);
+  name_start = RSTRING_PTR(name);
+  name_end = RSTRING_END(name);
 
   while (name_start < name_end) {
     if (*name_start == ':' || *name_start == '|' || *name_start == '@') {
@@ -24,6 +28,82 @@ normalize_name(VALUE self, VALUE name) {
   return rb_funcall(name, idTr, 2, strNormalizeChars, strNormalizeReplacement);
 }
 
+static VALUE
+generate_generic_datagram(VALUE self, VALUE name, VALUE value, VALUE type, VALUE sample_rate, VALUE tags) {
+  VALUE prefix, normalized_name, str_value, str_sample_rate, default_tags, tag;
+  VALUE normalized_tags = Qnil;
+  char datagram[MAX_DATAGRAM_SIZE];
+  int empty_default_tags = 1, empty_tags = 1;
+  int len = 0, tags_len = 0, i = 0;
+
+  MEMZERO(&datagram, char, MAX_DATAGRAM_SIZE);
+
+  prefix = rb_ivar_get(self, idPrefix);
+  if (RSTRING_LEN(prefix) != 0) {
+    memcpy(datagram, StringValuePtr(prefix), RSTRING_LEN(prefix));
+    len += RSTRING_LEN(prefix);
+  }
+
+  normalized_name = normalize_name(self, name);
+  memcpy(datagram + len, StringValuePtr(normalized_name), RSTRING_LEN(normalized_name));
+  len += RSTRING_LEN(normalized_name);
+
+  memcpy(datagram + len, ":", 1);
+  len += 1;
+  str_value = rb_obj_as_string(value);
+  memcpy(datagram + len, StringValuePtr(str_value), RSTRING_LEN(str_value));
+  len += RSTRING_LEN(str_value);
+
+  memcpy(datagram + len, "|", 1);
+  len += 1;
+  memcpy(datagram + len, StringValuePtr(type), RSTRING_LEN(type));
+  len += RSTRING_LEN(type);
+
+  if (RTEST(sample_rate) && NUM2INT(sample_rate) < 1) {
+    memcpy(datagram + len, "|@", 2);
+    len += 2;
+    str_sample_rate = rb_obj_as_string(sample_rate);
+    memcpy(datagram + len, StringValuePtr(str_sample_rate), RSTRING_LEN(str_sample_rate));
+    len += RSTRING_LEN(str_sample_rate);
+  }
+
+  default_tags = rb_ivar_get(self, idDefaultTags);
+
+  empty_default_tags = (RTEST(default_tags) ? RARRAY_LEN(default_tags) == 0 : 0);
+  if (RB_TYPE_P(tags, T_HASH) && !RHASH_EMPTY_P(tags)) {
+    empty_tags = 0;
+  } else if (RB_TYPE_P(tags, T_ARRAY) && RARRAY_LEN(tags) != 0) {
+    empty_tags = 0;
+  }
+
+  if (empty_default_tags && !empty_tags) {
+    normalized_tags = rb_funcall(self, idNormalizeTags, 1, tags);
+  } else if (!empty_default_tags && !empty_tags) {
+    normalized_tags = rb_ary_concat(rb_funcall(self, idNormalizeTags, 1, tags), default_tags);
+  } else if (!empty_default_tags && empty_tags) {
+    normalized_tags = default_tags;
+  }
+
+  if (RTEST(normalized_tags)) {
+    memcpy(datagram + len, "|#", 2);
+    len += 2;
+
+    tags_len = RARRAY_LEN(normalized_tags);
+    for (i = 0; i < tags_len; ++i) {
+      tag = RARRAY_AREF(normalized_tags, i);
+      memcpy(datagram + len, StringValuePtr(tag), RSTRING_LEN(tag));
+      len += RSTRING_LEN(tag);
+      if (i < tags_len - 1) {
+        memcpy(datagram + len, ",", 1);
+        len += 1;
+      }
+    }
+  }
+
+  return rb_str_new(datagram, len);
+  RB_GC_GUARD(normalized_tags);
+}
+
 void Init_statsd()
 {
   VALUE mStatsd, mInstrument, cDatagramBuilder;
@@ -33,11 +113,14 @@ void Init_statsd()
   cDatagramBuilder = rb_define_class_under(mInstrument, "DatagramBuilder", rb_cObject);
 
   idTr = rb_intern("tr");
+  idNormalizeTags = rb_intern("normalize_tags");
+  idDefaultTags = rb_intern("@default_tags");
+  idPrefix = rb_intern("@prefix");
   strNormalizeChars = rb_str_new_cstr(":|@");
-  strNormalizeReplacement = rb_str_new_cstr("_");
-
   rb_global_variable(&strNormalizeChars);
+  strNormalizeReplacement = rb_str_new_cstr("_");
   rb_global_variable(&strNormalizeReplacement);
 
   rb_define_protected_method(cDatagramBuilder, "normalize_name", normalize_name, 1);
+  rb_define_protected_method(cDatagramBuilder, "generate_generic_datagram", generate_generic_datagram, 5);
 }

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -359,6 +359,7 @@ require 'statsd/instrument/environment'
 require 'statsd/instrument/helpers'
 require 'statsd/instrument/assertions'
 require 'statsd/instrument/expectation'
+require 'statsd/instrument/ext/statsd'
 require 'statsd/instrument/matchers' if defined?(::RSpec)
 require 'statsd/instrument/railtie' if defined?(::Rails::Railtie)
 require 'statsd/instrument/strict' if ENV['STATSD_STRICT_MODE']

--- a/lib/statsd/instrument/datagram_builder.rb
+++ b/lib/statsd/instrument/datagram_builder.rb
@@ -30,7 +30,6 @@ class StatsD::Instrument::DatagramBuilder
   def initialize(prefix: nil, default_tags: nil)
     @prefix = prefix.nil? ? "" : "#{normalize_name(prefix)}."
     @default_tags = normalize_tags(default_tags)
-    @tags_cache = {}
   end
 
   def c(name, value, sample_rate, tags)

--- a/lib/statsd/instrument/datagram_builder.rb
+++ b/lib/statsd/instrument/datagram_builder.rb
@@ -30,6 +30,7 @@ class StatsD::Instrument::DatagramBuilder
   def initialize(prefix: nil, default_tags: nil)
     @prefix = prefix.nil? ? "" : "#{normalize_name(prefix)}."
     @default_tags = normalize_tags(default_tags)
+    @tags_cache = {}
   end
 
   def c(name, value, sample_rate, tags)

--- a/statsd-instrument.gemspec
+++ b/statsd-instrument.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files`.split($/)
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
+  spec.extensions = ['ext/statsd/extconf.rb']
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency 'rake'
@@ -27,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'benchmark-ips'
+  spec.add_development_dependency 'rake-compiler'
 end

--- a/test/datagram_builder_test.rb
+++ b/test/datagram_builder_test.rb
@@ -12,6 +12,7 @@ class DatagramBuilderTest < Minitest::Test
     assert_equal 'fo_o', @datagram_builder.send(:normalize_name, 'fo|o')
     assert_equal 'fo_o', @datagram_builder.send(:normalize_name, 'fo@o')
     assert_equal 'fo_o', @datagram_builder.send(:normalize_name, 'fo:o')
+    assert_equal 'foo_', @datagram_builder.send(:normalize_name, 'foo:')
   end
 
   def test_normalize_unsupported_tag_names

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,3 +17,4 @@ module StatsD::Instrument
 end
 
 StatsD.logger = Logger.new(File::NULL)
+GC.stress = true if ENV['GC_STRESS']


### PR DESCRIPTION
### Why?

The datagram builder is heavy on allocation (and reallocation) and coercing both metric names and tags into normalized and valid statsd wire protocol components.

This extension is also implemented as a wrapped struct without any global state as @hkdsun and @bmansoob expressed interest in how to do that.

* A [simple struct](https://github.com/Shopify/statsd-instrument/compare/datagram-builder-c-extension?expand=1#diff-703d6028f3c214b5fe6ab8682a33195eR15-R31) with mixed native type and `VALUE` (Ruby object reference) members

* GC [mark callback](https://github.com/Shopify/statsd-instrument/compare/datagram-builder-c-extension?expand=1#diff-703d6028f3c214b5fe6ab8682a33195eR33-R48) invoked during the GC tracing phase (we need to let the GC know about Ruby object references we hold on to)

* GC [free callback](https://github.com/Shopify/statsd-instrument/compare/datagram-builder-c-extension?expand=1#diff-703d6028f3c214b5fe6ab8682a33195eR50-R64) invoked during the sweep phase if this object was deemed to not be referenced by any other, the stack etc. . We free the symbol tables for caches and the struct itself.

* It's a good practice to add an [object size accumulator callback](https://github.com/Shopify/statsd-instrument/compare/datagram-builder-c-extension?expand=1#diff-703d6028f3c214b5fe6ab8682a33195eR66-R81) to accurately reflect the size of this object via `Objspace.memsize_of`

* A [data type declaration](https://github.com/Shopify/statsd-instrument/compare/datagram-builder-c-extension?expand=1#diff-703d6028f3c214b5fe6ab8682a33195eR83-R92) defines the shape of the wrapped object and callbacks for the GC

* An [unboxing function](https://github.com/Shopify/statsd-instrument/compare/datagram-builder-c-extension?expand=1#diff-703d6028f3c214b5fe6ab8682a33195eR94) coerces a `VALUE` reference back to a builder struct as per the type definition above

* The [allocator function](https://github.com/Shopify/statsd-instrument/compare/datagram-builder-c-extension?expand=1#diff-703d6028f3c214b5fe6ab8682a33195eR98-R111) prepares the struct for use by initializing members to their appropriate types, caches conditionally etc. and returns a `VALUE` reference to the allocated struct on the heap

### Points of attack

* The prefix is constant, initialized once yet [merged into the output buffer from offset 0](https://github.com/Shopify/statsd-instrument/blob/master/lib/statsd/instrument/datagram_builder.rb#L96) to it's length for every builder call. We can instead [seed](https://github.com/Shopify/statsd-instrument/compare/datagram-builder-c-extension?expand=1#diff-703d6028f3c214b5fe6ab8682a33195eR121-R127) the builder buffer with it and [advance the buffer low water mark](https://github.com/Shopify/statsd-instrument/compare/datagram-builder-c-extension?expand=1#diff-703d6028f3c214b5fe6ab8682a33195eR242) to the end of prefix  on every call

* [Name normalization](https://github.com/Shopify/statsd-instrument/blob/master/lib/statsd/instrument/datagram_builder.rb#L88-L92) is expensive as it involves a regex match for the fast path and an additional function call for the slow path. For the fast path it's more efficient to [walk to string from start to end](https://github.com/Shopify/statsd-instrument/compare/datagram-builder-c-extension?expand=1#diff-703d6028f3c214b5fe6ab8682a33195eR135-R156url) , and for the slow path implement a [bounded size normalized names cache](https://github.com/Shopify/statsd-instrument/compare/datagram-builder-c-extension?expand=1#diff-703d6028f3c214b5fe6ab8682a33195eR165-R186) to save on `String#tr` function calls for invalid metric names.

* [Tags normalization](https://github.com/Shopify/statsd-instrument/blob/master/lib/statsd/instrument/datagram_builder.rb#L78) is expensive and especially with the hybrid `Hash` and `Array` tags API allocates additional objects for the `Hash` based API. This method is not optimized in C as it's mostly iterators and method calls which can become EXTREMELY ugly rewriting in a C extension. Instead another [bounded size normalized tags cache](https://github.com/Shopify/statsd-instrument/compare/datagram-builder-c-extension?expand=1#diff-703d6028f3c214b5fe6ab8682a33195eR188%60-R211) was introduced to bypass this Ruby method for tags collections with a contents hash we've seen before.

* There's always a [new tags Array spawned ](https://github.com/Shopify/statsd-instrument/blob/master/lib/statsd/instrument/datagram_builder.rb#L95) in the `generate_generic_datagram` method. This is wasteful even for cases which don't have any default tags defined. This was flattened out into a [zero alloc append only](https://github.com/Shopify/statsd-instrument/compare/datagram-builder-c-extension?expand=1#diff-703d6028f3c214b5fe6ab8682a33195eR292-R307) pattern instead.

* Sample rate values appended to the buffer [is zero alloc for Fixnum and Float types](https://github.com/Shopify/statsd-instrument/compare/datagram-builder-c-extension?expand=1#diff-703d6028f3c214b5fe6ab8682a33195eR269-R290), but has a fallback path for other object types which would allocate a ruby String. This pattern likely works well for the `value` argument too, but would prefer to get runtime feedback first and consider it as a later optimisation.

* Remove a repeated ivar lookup and size check for default tags in favor of [caching it on the builder struct](https://github.com/Shopify/statsd-instrument/compare/datagram-builder-c-extension?expand=1#diff-703d6028f3c214b5fe6ab8682a33195eR129-R131) instead on init.

* Reduce method dispatch overhead by [calling the builder directly](https://github.com/Shopify/statsd-instrument/compare/datagram-builder-c-extension?expand=1#diff-703d6028f3c214b5fe6ab8682a33195eR314-R347) from the various metric helper methods.

### Configurables

* The buffer size can be changed [compile time](https://github.com/Shopify/statsd-instrument/compare/datagram-builder-c-extension?expand=1#diff-703d6028f3c214b5fe6ab8682a33195eR8-R11)

* Normalized caches are compile time features that can easily be [disabled or changed](https://github.com/Shopify/statsd-instrument/compare/datagram-builder-c-extension?expand=1#diff-703d6028f3c214b5fe6ab8682a33195eR8-R11)

### Resiliency issues covered

* Strict [overflow checks](https://github.com/Shopify/statsd-instrument/compare/datagram-builder-c-extension?expand=1#diff-703d6028f3c214b5fe6ab8682a33195eR286) that finalize the buffer prior to overflow

* Test suite run with [GC.stress = true](https://github.com/Shopify/statsd-instrument/compare/datagram-builder-c-extension?expand=1#diff-f14ca9959ff06f3ca2ee6b9564866954R20)

### Wrapped builder struct layout

Fits within 1 cache line (46 of 64 bytes) with the buffer as the last member. 4kb is very generous, but in reality the vast majority of statsd datagrams would only reach into 1 or 2 more cache lines.

The struct is passed around by reference as it's heap allocated anyways and few things are as bad as large structs passed by value.

```
lourens@CarbonX1:~/src/statsd-instrument/lib/statsd/instrument/ext$ pahole -C datagram_builder ./statsd.so
struct datagram_builder {
	st_table *                 normalized_tags_cache; /*     0     8 */
	st_table *                 normalized_names_cache; /*     8     8 */
	VALUE                      str_normalize_chars;  /*    16     8 */
	VALUE                      str_normalize_replacement; /*    24     8 */
	VALUE                      default_tags;         /*    32     8 */
	_Bool                      empty_default_tags;   /*    40     1 */

	/* XXX 3 bytes hole, try to pack */

	int                        prefix_len;           /*    44     4 */
	int                        len;                  /*    48     4 */
	char                       datagram[4096];       /*    52  4096 */

	/* size: 4152, cachelines: 65, members: 9 */
	/* sum members: 4145, holes: 1, sum holes: 3 */
	/* padding: 4 */
	/* last cacheline: 56 bytes */
};
```

### Future TODO

* Remove the String allocation for the `value` argument
* Evaluate the [hashing function](https://github.com/Shopify/statsd-instrument/compare/datagram-builder-c-extension?expand=1#diff-703d6028f3c214b5fe6ab8682a33195eR198) used for the tags cache (Hash and Array specific are not directly exposed through the extension API)

### Downsides

* This library now becomes dependent of a C compiler and ruby development headers - need to think about decoupling so that is optional.

### Other ideas

* Willem mentioned more Stricter mode linters that can catch invalid metric names and tags enabled for example during CI could work wonders too.


