### PR TITLE
Change custom cop tests to emulate using Ruby 2.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       run: gem install bundler && bundle install --jobs 4 --retry 3
 
     - name: Run test suite
-      run: bundle exec rake
+      run: bin/rake test
 
     - name: Run Rubocop
-      run: bundle exec rubocop
+      run: bin/rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
   - ./lib/statsd/instrument/rubocop.rb
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   UseCache: true
   CacheRootDirectory: tmp/rubocop
   Exclude:

--- a/test/helpers/rubocop_helper.rb
+++ b/test/helpers/rubocop_helper.rb
@@ -7,13 +7,16 @@ module RubocopHelper
 
   private
 
+  RUBY_VERSION = 2.5
+  private_constant :RUBY_VERSION
+
   def assert_no_offenses(source)
-    investigate(RuboCop::ProcessedSource.new(source, 2.3, nil))
+    investigate(RuboCop::ProcessedSource.new(source, RUBY_VERSION, nil))
     assert_predicate(cop.offenses, :empty?, "Did not expect Rubocop to find offenses")
   end
 
   def assert_offense(source)
-    investigate(RuboCop::ProcessedSource.new(source, 2.3, nil))
+    investigate(RuboCop::ProcessedSource.new(source, RUBY_VERSION, nil))
     refute_predicate(cop.offenses, :empty?, "Expected Rubocop to find offenses")
   end
 
@@ -27,7 +30,7 @@ module RubocopHelper
     RuboCop::Formatter::DisabledConfigFormatter.detected_styles = {}
     cop.instance_variable_get(:@options)[:auto_correct] = true
 
-    processed_source = RuboCop::ProcessedSource.new(source, 2.3, nil)
+    processed_source = RuboCop::ProcessedSource.new(source, RUBY_VERSION, nil)
     investigate(processed_source)
 
     corrector = RuboCop::Cop::Corrector.new(processed_source.buffer, cop.corrections)


### PR DESCRIPTION
Rubocop dropped support for version 2.3, which caused our Rubocop tests to fail. The test harness pretends that a Ruby 2.3 source file is being tested. The fix is to simple pretend we are using a newer version.