### PR TITLE
Fix delegation for Ruby 2.7 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         # Windows on macOS builds started failing, so they are disabled for noew
 
-        ruby: [2.4, 2.5, 2.6]
+        ruby: [2.4, 2.5, 2.6, 2.7]
         # platform: [windows-2019, macOS-10.14, ubuntu-18.04]
 
         # exclude:
@@ -43,7 +43,7 @@ jobs:
       run: gem install bundler && bundle install --jobs 4 --retry 3
 
     - name: Run test suite
-      run: bin/rake test
+      run: rake test
 
     - name: Run Rubocop
       run: bin/rubocop

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -275,6 +275,9 @@ module StatsD
 
       instrumentation_module.module_eval(&block)
       instrumentation_module.send(method_scope, method)
+      if instrumentation_module.respond_to?(:ruby2_keywords, true)
+        instrumentation_module.send(:ruby2_keywords, method)
+      end
       prepend(instrumentation_module) unless self < instrumentation_module
     end
 


### PR DESCRIPTION
`statsd-instrument` decorators are throwing warnings on Ruby 2.7:

```
DEPRECATION WARNING: /tmp/bundle/ruby/2.7.0/gems/statsd-instrument-2.9.2/lib/statsd/instrument/strict.rb:130: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
xxxxxx:103: warning: The called method `XXXXXX' is defined here
 (called from block (3 levels) in statsd_measure at /tmp/bundle/ruby/2.7.0/gems/statsd-instrument-2.9.2/lib/statsd/instrument/strict.rb:130)
```

While not very elegant, the `ruby2_keywords` modifier is the only proper way to do blind argument forwarding on both 2.6 and 2.7 without warnings.