### PR TITLE
Fix the gemspec executables prefix

### DIFF
--- a/statsd-instrument.gemspec
+++ b/statsd-instrument.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.license = "MIT"
 
   spec.files = `git ls-files`.split($/)
-  spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 end


### PR DESCRIPTION
I just noticed this because I installed the `3.0.0` for the first time.

A while ago bundler used to register `bin/` as the executables directory, meaning the scripts in that path would be exposed as commands in the `$PATH` of users installing the gem.

The problem is that it's also where binstubs are installed, so now bundler use `exe/` instead.

So in short `statsd-instrument 3.0.0` break `rake` and `rubocop` commands if you install it.