### PR TITLE
Properly handle no_prefix when using StatsD assertions.

### DIFF
--- a/lib/statsd/instrument/expectation.rb
+++ b/lib/statsd/instrument/expectation.rb
@@ -36,7 +36,7 @@ module StatsD
         sample_rate: nil, tags: nil, no_prefix: false, times: 1)
 
         @type = type
-        @name = client.prefix ? "#{client.prefix}.#{name}" : name unless no_prefix
+        @name = client.prefix && !no_prefix ? "#{client.prefix}.#{name}" : name
         @value = normalized_value_for_type(type, value) if value
         @sample_rate = sample_rate
         @tags = normalize_tags(tags)

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -408,4 +408,38 @@ class AssertionsTest < Minitest::Test
     end
     assert_equal("other assertion failure", assertion.message)
   end
+
+  def test_assert_when_using_no_prefix
+    env = StatsD::Instrument::Environment.new('STATSD_PREFIX' => nil)
+    StatsD.singleton_client = StatsD::Instrument::Client.from_env(env)
+
+    @test_case.assert_statsd_increment('incr', no_prefix: false) do
+      StatsD.increment('incr')
+    end
+
+    @test_case.assert_statsd_increment('incr', no_prefix: true) do
+      StatsD.increment('incr')
+    end
+
+    env = StatsD::Instrument::Environment.new('STATSD_PREFIX' => 'prefix')
+    StatsD.singleton_client = StatsD::Instrument::Client.from_env(env)
+
+    @test_case.assert_statsd_increment('incr', no_prefix: false) do
+      StatsD.increment('incr')
+    end
+
+    assert_raises(Minitest::Assertion) do
+      @test_case.assert_statsd_increment('incr', no_prefix: true) do
+        StatsD.increment('incr')
+      end
+    end
+
+    @test_case.assert_statsd_increment('prefix.incr', no_prefix: true) do
+      StatsD.increment('incr')
+    end
+
+    @test_case.assert_statsd_increment('incr', no_prefix: true) do
+      StatsD.increment('incr', no_prefix: true)
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/Shopify/statsd-instrument/issues/267.