### PR TITLE
Use published version of benchmark-ips

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,4 @@ gem 'mocha'
 gem 'yard'
 gem 'rubocop', '>= 1.0'
 gem 'rubocop-shopify', require: false
-
-# benchmark-ips save! method is not part of a released version yet.
-gem 'benchmark-ips', git: 'https://github.com/evanphx/benchmark-ips', branch: 'master'
+gem 'benchmark-ips'


### PR DESCRIPTION
The released versions now include `save!`, as per [`History.txt`](https://github.com/evanphx/benchmark-ips/blob/5a2dc713fede28e0c08d2c9d43efad967cba6019/History.txt#L11).