### PR TITLE
Release 3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ section below.
 
 _Nothing yet_
 
+## Version 3.0.2
+
+- Properly handle no_prefix when using StatsD assertions.
+
 ## Version 3.0.1
 
 - Fix metaprograming methods to not print keyword argument warnings on

--- a/lib/statsd/instrument/version.rb
+++ b/lib/statsd/instrument/version.rb
@@ -2,6 +2,6 @@
 
 module StatsD
   module Instrument
-    VERSION = "3.0.1"
+    VERSION = "3.0.2"
   end
 end


### PR DESCRIPTION
Releases the fix merged in https://github.com/Shopify/statsd-instrument/pull/268. I will use this new version of statsd for Storefront Renderer. https://github.com/Shopify/storefront-renderer/pull/5209


I have followed the [release procedure](bundle exec rake release) except for step 4, Run `bundle exec rake release`.
