### PR TITLE
Support using matcher in examples without a string

### DIFF
--- a/lib/statsd/instrument/matchers.rb
+++ b/lib/statsd/instrument/matchers.rb
@@ -34,6 +34,10 @@ module StatsD
         def supports_block_expectations?
           true
         end
+        
+        def description
+          "trigger a statsd call for metric #{@metric_name}"
+        end
 
         private
 


### PR DESCRIPTION
Fixes an issue when trying to use the matchers in one line expectations without a string description.

This fix has been tested with rspec-has to write it like this:
```ruby
it { has.to trigger_statsd_increment("metric") } 
```

Original error:
```
When you call a matcher in an example without a String, like this:

specify { expect(object).to matcher }

or this:

it { is_expected.to matcher }

RSpec expects the matcher to have a #description method. You should either
add a String to the example this matcher is being used in, or give it a
description method. Then you won't have to suffer this lengthy warning again.
```