### PR TITLE
Implement batching of datagrams in UDPSink

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,29 @@ The following environment variables are supported:
   overridden in a metric method call.
 - `STATSD_DEFAULT_TAGS`: A comma-separated list of tags to apply to all metrics.
   (Note: tags are not supported by all implementations.)
+- `STATSD_FLUSH_INTERVAL`: (default: `0.0`) The interval at which events are sent
+  in batch. Only applicable to the UDP configuration. If set to `0.0`, metrics
+  are sent immediately.
+
+### Forking setups
+
+If you use some kind of forking server, you must call `StatsD.after_fork` after each fork.
+
+For instance if you use Puma:
+
+```ruby
+on_worker_boot do
+  StatsD.after_fork
+end
+```
+
+Or if you use Unicorn:
+
+```ruby
+after_fork do
+  StatsD.after_fork
+end
+```
 
 ## StatsD keys
 

--- a/README.md
+++ b/README.md
@@ -46,26 +46,6 @@ The following environment variables are supported:
   in batch. Only applicable to the UDP configuration. If set to `0.0`, metrics
   are sent immediately.
 
-### Forking setups
-
-If you use some kind of forking server, you must call `StatsD.after_fork` after each fork.
-
-For instance if you use Puma:
-
-```ruby
-on_worker_boot do
-  StatsD.after_fork
-end
-```
-
-Or if you use Unicorn:
-
-```ruby
-after_fork do
-  StatsD.after_fork
-end
-```
-
 ## StatsD keys
 
 StatsD keys look like 'admin.logins.api.success'. Dots are used as namespace separators.

--- a/benchmark/send-metrics-to-local-udp-receiver
+++ b/benchmark/send-metrics-to-local-udp-receiver
@@ -26,6 +26,7 @@ StatsD.singleton_client = StatsD::Instrument::Environment.new(
   "STATSD_ADDR" => "#{receiver.addr[2]}:#{receiver.addr[1]}",
   "STATSD_IMPLEMENTATION" => "dogstatsd",
   "STATSD_ENV" => "production",
+  "STATSD_FLUSH_INTERVAL" => ENV.fetch("STATSD_FLUSH_INTERVAL", "0.0"),
 ).client
 
 report = Benchmark.ips do |bench|

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -343,7 +343,7 @@ module StatsD
     #   (see StatsD::Instrument::Client#service_check)
 
     def_delegators :singleton_client, :increment, :gauge, :set, :measure,
-      :histogram, :distribution, :event, :service_check
+      :histogram, :distribution, :event, :service_check, :after_fork
   end
 end
 
@@ -356,6 +356,7 @@ require "statsd/instrument/statsd_datagram_builder"
 require "statsd/instrument/dogstatsd_datagram_builder"
 require "statsd/instrument/null_sink"
 require "statsd/instrument/udp_sink"
+require "statsd/instrument/batched_udp_sink"
 require "statsd/instrument/capture_sink"
 require "statsd/instrument/log_sink"
 require "statsd/instrument/environment"

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -343,7 +343,7 @@ module StatsD
     #   (see StatsD::Instrument::Client#service_check)
 
     def_delegators :singleton_client, :increment, :gauge, :set, :measure,
-      :histogram, :distribution, :event, :service_check, :after_fork
+      :histogram, :distribution, :event, :service_check
   end
 end
 

--- a/lib/statsd/instrument/batched_udp_sink.rb
+++ b/lib/statsd/instrument/batched_udp_sink.rb
@@ -28,17 +28,13 @@ module StatsD
         spawn_dispatcher
       end
 
-      def after_fork
-        @buffer.clear
-        spawn_dispatcher
-      end
-
       def sample?(sample_rate)
         sample_rate == 1 || rand < sample_rate
       end
 
       def <<(datagram)
         @buffer << datagram
+        spawn_dispatcher unless @dispatcher_thread&.alive?
         self
       end
 
@@ -49,9 +45,7 @@ module StatsD
       private
 
       def spawn_dispatcher
-        unless @dispatcher_thread&.alive?
-          @dispatcher_thread = Thread.new { dispatch }
-        end
+        @dispatcher_thread = Thread.new { dispatch }
       end
 
       NEWLINE = "\n".b.freeze

--- a/lib/statsd/instrument/batched_udp_sink.rb
+++ b/lib/statsd/instrument/batched_udp_sink.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+module StatsD
+  module Instrument
+    # @note This class is part of the new Client implementation that is intended
+    #   to become the new default in the next major release of this library.
+    class BatchedUDPSink
+      DEFAULT_FLUSH_INTERVAL = 1.0
+      MAX_PACKET_SIZE = 508
+
+      def self.for_addr(addr, flush_interval: DEFAULT_FLUSH_INTERVAL)
+        host, port_as_string = addr.split(":", 2)
+        new(host, Integer(port_as_string), flush_interval: flush_interval)
+      end
+
+      attr_reader :host, :port
+
+      def initialize(host, port, flush_interval: DEFAULT_FLUSH_INTERVAL)
+        @host = host
+        @port = port
+        @mutex = Mutex.new
+        @socket = nil
+        @flush_interval = flush_interval
+
+        require "concurrent/array"
+        @buffer = Concurrent::Array.new
+        @dispatcher_thread = nil
+        spawn_dispatcher
+      end
+
+      def after_fork
+        @buffer.clear
+        spawn_dispatcher
+      end
+
+      def sample?(sample_rate)
+        sample_rate == 1 || rand < sample_rate
+      end
+
+      def <<(datagram)
+        @buffer << datagram
+        self
+      end
+
+      def shutdown
+        @dispatcher_thread&.kill
+      end
+
+      private
+
+      def spawn_dispatcher
+        unless @dispatcher_thread&.alive?
+          @dispatcher_thread = Thread.new { dispatch }
+        end
+      end
+
+      NEWLINE = "\n".b.freeze
+      def flush
+        return if @buffer.empty?
+
+        datagrams = @buffer.shift(@buffer.size)
+
+        until datagrams.empty?
+          packet = String.new(datagrams.pop, encoding: Encoding::BINARY, capacity: MAX_PACKET_SIZE)
+
+          until datagrams.empty? || packet.bytesize + datagrams.first.bytesize + 1 > MAX_PACKET_SIZE
+            packet << NEWLINE << datagrams.shift
+          end
+
+          send_packet(packet)
+        end
+      end
+
+      def dispatch
+        loop do
+          begin
+            start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+            flush
+            next_sleep_duration = @flush_interval - (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start)
+            sleep(next_sleep_duration) if next_sleep_duration > 0
+          rescue => error
+            report_error(error)
+          end
+        end
+      end
+
+      def report_error(error)
+        StatsD.logger.error do
+          "[#{self.class.name}] The dispatcher thread encountered an error #{error.class}: #{error.message}"
+        end
+      end
+
+      def send_packet(packet)
+        retried = false
+        socket.send(packet, 0)
+      rescue SocketError, IOError, SystemCallError => error
+        StatsD.logger.debug do
+          "[#{self.class.name}] Resseting connection because of #{error.class}: #{error.message}"
+        end
+        invalidate_socket
+        if retried
+          StatsD.logger.warning do
+            "[#{self.class.name}] Events were dropped because of #{error.class}: #{error.message}"
+          end
+        else
+          retried = true
+          retry
+        end
+      end
+
+      def socket
+        @socket ||= begin
+          socket = UDPSocket.new
+          socket.connect(@host, @port)
+          socket
+        end
+      end
+
+      def invalidate_socket
+        @socket = nil
+      end
+    end
+  end
+end

--- a/lib/statsd/instrument/client.rb
+++ b/lib/statsd/instrument/client.rb
@@ -395,10 +395,6 @@ module StatsD
         )
       end
 
-      def after_fork
-        @sink.after_fork if @sink.respond_to?(:after_fork)
-      end
-
       def capture_sink
         StatsD::Instrument::CaptureSink.new(
           parent: @sink,

--- a/lib/statsd/instrument/client.rb
+++ b/lib/statsd/instrument/client.rb
@@ -395,6 +395,10 @@ module StatsD
         )
       end
 
+      def after_fork
+        @sink.after_fork if @sink.respond_to?(:after_fork)
+      end
+
       def capture_sink
         StatsD::Instrument::CaptureSink.new(
           parent: @sink,

--- a/lib/statsd/instrument/environment.rb
+++ b/lib/statsd/instrument/environment.rb
@@ -89,7 +89,7 @@ module StatsD
       def default_sink_for_environment
         case environment
         when "production", "staging"
-          if statsd_flush_interval > 0
+          if statsd_flush_interval > 0.0
             StatsD::Instrument::BatchedUDPSink.for_addr(statsd_addr, flush_interval: statsd_flush_interval)
           else
             StatsD::Instrument::UDPSink.for_addr(statsd_addr)

--- a/lib/statsd/instrument/udp_sink.rb
+++ b/lib/statsd/instrument/udp_sink.rb
@@ -35,7 +35,7 @@ module StatsD
 
       rescue SocketError, IOError, SystemCallError => error
         StatsD.logger.debug do
-          "[StatsD::Instrument::UDPSink] Resseting connection because of #{error.class}: #{error.message}"
+          "[StatsD::Instrument::UDPSink] Resetting connection because of #{error.class}: #{error.message}"
         end
         invalidate_socket
       end

--- a/lib/statsd/instrument/udp_sink.rb
+++ b/lib/statsd/instrument/udp_sink.rb
@@ -19,6 +19,10 @@ module StatsD
         @socket = nil
       end
 
+      def after_fork
+        # noop
+      end
+
       def sample?(sample_rate)
         sample_rate == 1 || rand < sample_rate
       end
@@ -35,7 +39,7 @@ module StatsD
 
       rescue SocketError, IOError, SystemCallError => error
         StatsD.logger.debug do
-          "[StatsD::Instrument::UDPSink] Reseting connection because of #{error.class}: #{error.message}"
+          "[StatsD::Instrument::UDPSink] Resseting connection because of #{error.class}: #{error.message}"
         end
         invalidate_socket
       end

--- a/lib/statsd/instrument/udp_sink.rb
+++ b/lib/statsd/instrument/udp_sink.rb
@@ -19,10 +19,6 @@ module StatsD
         @socket = nil
       end
 
-      def after_fork
-        # noop
-      end
-
       def sample?(sample_rate)
         sample_rate == 1 || rand < sample_rate
       end

--- a/statsd-instrument.gemspec
+++ b/statsd-instrument.gemspec
@@ -21,4 +21,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.metadata['allowed_push_host'] = "https://rubygems.org"
+
+  spec.add_runtime_dependency 'concurrent-ruby'
 end

--- a/statsd-instrument.gemspec
+++ b/statsd-instrument.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
 
   spec.metadata['allowed_push_host'] = "https://rubygems.org"
 
-  spec.add_runtime_dependency 'concurrent-ruby'
+  spec.add_development_dependency 'concurrent-ruby'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,3 +23,6 @@ module StatsD
 end
 
 StatsD.logger = Logger.new(File::NULL)
+
+Thread.abort_on_exception = true
+Thread.report_on_exception = true

--- a/test/udp_sink_test.rb
+++ b/test/udp_sink_test.rb
@@ -111,7 +111,7 @@ module UDPSinkTests
         udp_sink << "bar:1|c"
 
         assert_equal(
-          "[#{@sink_class}] Resseting connection because of " \
+          "[#{@sink_class}] Resetting connection because of " \
           "Errno::EDESTADDRREQ: Destination address required\n",
           logs.string,
         )

--- a/test/udp_sink_test.rb
+++ b/test/udp_sink_test.rb
@@ -11,6 +11,15 @@ module UDPSinkTests
     assert_equal("foo:1|c", datagram)
   end
 
+  def large_datagram
+    datagram = "#{"a" * 1000}:1|c"
+    udp_sink = build_sink(@host, @port)
+    udp_sink << datagram
+
+    datagram, _source = @receiver.recvfrom(1500)
+    assert_equal(datagram, datagram)
+  end
+
   def test_sample?
     udp_sink = build_sink(@host, @port)
     assert(udp_sink.sample?(1))

--- a/test/udp_sink_test.rb
+++ b/test/udp_sink_test.rb
@@ -2,20 +2,9 @@
 
 require "test_helper"
 
-class UDPSinkTest < Minitest::Test
-  def setup
-    @receiver = UDPSocket.new
-    @receiver.bind("localhost", 0)
-    @host = @receiver.addr[2]
-    @port = @receiver.addr[1]
-  end
-
-  def teardown
-    @receiver.close
-  end
-
+module UDPSinkTests
   def test_udp_sink_sends_data_over_udp
-    udp_sink = StatsD::Instrument::UDPSink.new(@host, @port)
+    udp_sink = build_sink(@host, @port)
     udp_sink << "foo:1|c"
 
     datagram, _source = @receiver.recvfrom(100)
@@ -23,7 +12,7 @@ class UDPSinkTest < Minitest::Test
   end
 
   def test_sample?
-    udp_sink = StatsD::Instrument::UDPSink.new(@host, @port)
+    udp_sink = build_sink(@host, @port)
     assert(udp_sink.sample?(1))
     refute(udp_sink.sample?(0))
 
@@ -35,12 +24,13 @@ class UDPSinkTest < Minitest::Test
   end
 
   def test_parallelism
-    udp_sink = StatsD::Instrument::UDPSink.new(@host, @port)
-    50.times { |i| Thread.new { udp_sink << "foo:#{i}|c" << "bar:#{i}|c" } }
+    udp_sink = build_sink(@host, @port)
+    50.times.map { |i| Thread.new { udp_sink << "foo:#{i}|c" << "bar:#{i}|c" } }
     datagrams = []
-    100.times do
-      datagram, _source = @receiver.recvfrom(100)
-      datagrams << datagram
+
+    while @receiver.wait_readable(2)
+      datagram, _source = @receiver.recvfrom(4000)
+      datagrams += datagram.split("\n")
     end
 
     assert_equal(100, datagrams.size)
@@ -52,52 +42,109 @@ class UDPSinkTest < Minitest::Test
     end
   end
 
-  def test_socket_error_should_invalidate_socket
-    previous_logger = StatsD.logger
-    begin
-      logs = StringIO.new
-      StatsD.logger = Logger.new(logs)
-      StatsD.logger.formatter = SimpleFormatter.new
-      UDPSocket.stubs(:new).returns(socket = mock("socket"))
+  def test_sends_datagram_in_signal_handler
+    udp_sink = build_sink(@host, @port)
+    Signal.trap("USR1") { udp_sink << "exiting:1|c" }
 
-      seq = sequence("connect_fail_connect_succeed")
-      socket.expects(:connect).with("localhost", 8125).in_sequence(seq)
-      socket.expects(:send).raises(Errno::EDESTADDRREQ).in_sequence(seq)
-      socket.expects(:connect).with("localhost", 8125).in_sequence(seq)
-      socket.expects(:send).returns(1).in_sequence(seq)
+    pid = fork do
+      udp_sink.after_fork
+      sleep(5)
+    end
 
-      udp_sink = StatsD::Instrument::UDPSink.new("localhost", 8125)
-      udp_sink << "foo:1|c"
-      udp_sink << "bar:1|c"
+    Signal.trap("USR1", "DEFAULT")
 
-      assert_equal(
-        "[StatsD::Instrument::UDPSink] Reseting connection because of " \
-        "Errno::EDESTADDRREQ: Destination address required\n",
-        logs.string,
-      )
-    ensure
-      StatsD.logger = previous_logger
+    Process.kill("USR1", pid)
+    @receiver.wait_readable(1)
+    assert_equal("exiting:1|c", @receiver.recvfrom_nonblock(100).first)
+    Process.kill("KILL", pid)
+  rescue NotImplementedError
+    pass("Fork is not implemented on #{RUBY_PLATFORM}")
+  end
+
+  private
+
+  def build_sink(host = @host, port = @port)
+    @__last_sink ||= nil
+    @__last_sink.shutdown if @__last_sink.respond_to?(:shutdown)
+    @__last_sink = @sink_class.new(host, port)
+  end
+
+  class UDPSinkTest < Minitest::Test
+    include UDPSinkTests
+
+    def setup
+      @receiver = UDPSocket.new
+      @receiver.bind("localhost", 0)
+      @host = @receiver.addr[2]
+      @port = @receiver.addr[1]
+      @sink_class = StatsD::Instrument::UDPSink
+    end
+
+    def teardown
+      @receiver.close
+    end
+
+    def test_socket_error_should_invalidate_socket
+      previous_logger = StatsD.logger
+      begin
+        logs = StringIO.new
+        StatsD.logger = Logger.new(logs)
+        StatsD.logger.formatter = SimpleFormatter.new
+        UDPSocket.stubs(:new).returns(socket = mock("socket"))
+
+        seq = sequence("connect_fail_connect_succeed")
+        socket.expects(:connect).with("localhost", 8125).in_sequence(seq)
+        socket.expects(:send).raises(Errno::EDESTADDRREQ).in_sequence(seq)
+        socket.expects(:connect).with("localhost", 8125).in_sequence(seq)
+        socket.expects(:send).returns(1).in_sequence(seq)
+
+        udp_sink = build_sink("localhost", 8125)
+        udp_sink << "foo:1|c"
+        udp_sink << "bar:1|c"
+
+        assert_equal(
+          "[#{@sink_class}] Resseting connection because of " \
+          "Errno::EDESTADDRREQ: Destination address required\n",
+          logs.string,
+        )
+      ensure
+        StatsD.logger = previous_logger
+      end
     end
   end
 
-  def test_sends_datagram_in_signal_handler
-    udp_sink = StatsD::Instrument::UDPSink.new(@host, @port)
-    pid = fork do
-      Signal.trap("TERM") do
-        udp_sink << "exiting:1|c"
-        Process.exit!(0)
-      end
+  class BatchedUDPSinkTest < Minitest::Test
+    include UDPSinkTests
 
-      sleep(10)
+    def setup
+      @receiver = UDPSocket.new
+      @receiver.bind("localhost", 0)
+      @host = @receiver.addr[2]
+      @port = @receiver.addr[1]
+      @sink_class = StatsD::Instrument::BatchedUDPSink
     end
 
-    Process.kill("TERM", pid)
-    _, exit_status = Process.waitpid2(pid)
+    def teardown
+      @__last_sink&.shutdown
+      @receiver.close
+    end
 
-    assert_equal(0, exit_status, "The forked process did not exit cleanly")
-    assert_equal("exiting:1|c", @receiver.recvfrom_nonblock(100).first)
+    def test_parallelism_buffering
+      udp_sink = build_sink(@host, @port)
+      50.times.map do |i|
+        Thread.new do
+          udp_sink << "foo:#{i}|c" << "bar:#{i}|c" << "baz:#{i}|c" << "plop:#{i}|c"
+        end
+      end
 
-  rescue NotImplementedError
-    pass("Fork is not implemented on #{RUBY_PLATFORM}")
+      datagrams = []
+
+      while @receiver.wait_readable(2)
+        datagram, _source = @receiver.recvfrom(1000)
+        datagrams += datagram.split("\n")
+      end
+
+      assert_equal(200, datagrams.size)
+    end
   end
 end

--- a/test/udp_sink_test.rb
+++ b/test/udp_sink_test.rb
@@ -47,7 +47,6 @@ module UDPSinkTests
     Signal.trap("USR1") { udp_sink << "exiting:1|c" }
 
     pid = fork do
-      udp_sink.after_fork
       sleep(5)
     end
 


### PR DESCRIPTION
This is kind of an alternative to https://github.com/Shopify/statsd-instrument/pull/257 (actually we could combine both, but...)

With a batch size of one, this is a bit slower than master, however with an arbitrary batch size of 50, it's about twice faster:

```
StatsD metrics to local UDP receiver (branch: master, sha: a9fae17)
                          5.142k (± 4.2%) i/s -     26.000k in   5.067016s

Comparison:
StatsD metrics to local UDP receiver (branch: udp-batching, sha: 0f436b2):    10458.0 i/s
StatsD metrics to local UDP receiver (branch: master, sha: a9fae17):     5141.5 i/s - 2.03x  (± 0.00) slower
```

Thread safety wise, I believe `Concurrent::Array` should have us covered (it's a regular Array on MRI, so little perf overhead).

What I'm not too sure about is the flushing. I'm worried some datagrams could stay in memory for quite long. The finalizer should ensure that they are sent at some point, however they could end up delayed a lot of a process stay idle for long with some datagrams.

So maybe it could make sense to combine this with the dispatcher thread PR, to have a background thread empty the queue every seconds or something.

@wvanbergen @dylanahsmith any thoughts?