### PR TITLE
Enable UDP batching by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ The following environment variables are supported:
   overridden in a metric method call.
 - `STATSD_DEFAULT_TAGS`: A comma-separated list of tags to apply to all metrics.
   (Note: tags are not supported by all implementations.)
-- `STATSD_FLUSH_INTERVAL`: (default: `0.0`) The interval at which events are sent
-  in batch. Only applicable to the UDP configuration. If set to `0.0`, metrics
-  are sent immediately.
+- `STATSD_FLUSH_INTERVAL`: (default: `1.0`) The interval in seconds at which
+  events are sent in batch. Only applicable to the UDP configuration. If set
+  to `0.0`, metrics are sent immediately.
 
 ## StatsD keys
 

--- a/lib/statsd/instrument/environment.rb
+++ b/lib/statsd/instrument/environment.rb
@@ -79,7 +79,7 @@ module StatsD
       end
 
       def statsd_flush_interval
-        Float(env.fetch("STATSD_FLUSH_INTERVAL", 0.0))
+        Float(env.fetch("STATSD_FLUSH_INTERVAL", 1.0))
       end
 
       def client

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -24,7 +24,7 @@ class ClientTest < Minitest::Test
     assert_equal(["shard:1", "env:production"], client.default_tags)
     assert_equal(StatsD::Instrument::StatsDDatagramBuilder, client.datagram_builder_class)
 
-    assert_kind_of(StatsD::Instrument::UDPSink, client.sink)
+    assert_kind_of(StatsD::Instrument::BatchedUDPSink, client.sink)
     assert_equal("1.2.3.4", client.sink.host)
     assert_equal(8125, client.sink.port)
   end

--- a/test/environment_test.rb
+++ b/test/environment_test.rb
@@ -46,13 +46,22 @@ class EnvironmentTest < Minitest::Test
     assert_kind_of(StatsD::Instrument::NullSink, env.client.sink)
   end
 
-  def test_client_from_env_uses_udp_sink_in_staging_environment
+  def test_client_from_env_uses_batched_udp_sink_in_staging_environment
     env = StatsD::Instrument::Environment.new("STATSD_USE_NEW_CLIENT" => "1", "STATSD_ENV" => "staging")
-    assert_kind_of(StatsD::Instrument::UDPSink, env.client.sink)
+    assert_kind_of(StatsD::Instrument::BatchedUDPSink, env.client.sink)
   end
 
-  def test_client_from_env_uses_udp_sink_in_production_environment
+  def test_client_from_env_uses_batched_udp_sink_in_production_environment
     env = StatsD::Instrument::Environment.new("STATSD_USE_NEW_CLIENT" => "1", "STATSD_ENV" => "production")
+    assert_kind_of(StatsD::Instrument::BatchedUDPSink, env.client.sink)
+  end
+
+  def test_client_from_env_uses_regular_udp_sink_when_flush_interval_is_0
+    env = StatsD::Instrument::Environment.new(
+      "STATSD_USE_NEW_CLIENT" => "1",
+      "STATSD_ENV" => "staging",
+      "STATSD_FLUSH_INTERVAL" => "0.0",
+    )
     assert_kind_of(StatsD::Instrument::UDPSink, env.client.sink)
   end
 end


### PR DESCRIPTION
So we deployed https://github.com/Shopify/statsd-instrument/pull/280 in production and the result are very good, and we didn't notice any issue.

Given the perf improvement, and that it no longer need an `after_fork` callback, I think we should enable it by default so that people get the perf improvement simply by updating.

@wvanbergen @dylanahsmith thoughts?