### PR TITLE
Only run rubocop once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,3 @@ jobs:
 
     - name: Run test suite
       run: rake test
-
-    - name: Run Rubocop
-      run: bin/rubocop

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: Lint
+
+on: push
+
+jobs:
+  test:
+    name: Rubocop
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Setup Ruby
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.4
+
+    - name: Install dependencies
+      run: gem install bundler && bundle install --jobs 4 --retry 3
+
+    - name: Run Rubocop
+      run: bin/rubocop


### PR DESCRIPTION
There is little value on running rubocop against every version, and it's annoying to have all jobs fail because of it.

