### PR TITLE
Refactor BatchedUDPSink so that it can properly be GCed

### DIFF
--- a/lib/statsd/instrument/batched_udp_sink.rb
+++ b/lib/statsd/instrument/batched_udp_sink.rb
@@ -7,17 +7,6 @@ module StatsD
     class BatchedUDPSink
       DEFAULT_FLUSH_INTERVAL = 1.0
       MAX_PACKET_SIZE = 508
-      BUFFER_CLASS = if !::Object.const_defined?(:RUBY_ENGINE) || RUBY_ENGINE == "ruby"
-        ::Array
-      else
-        begin
-          gem("concurrent-ruby")
-        rescue Gem::MissingSpecError
-          raise Gem::MissingSpecError, "statsd-instrument depends on `concurrent-ruby` on #{RUBY_ENGINE}"
-        end
-        require "concurrent/array"
-        Concurrent::Array
-      end
 
       def self.for_addr(addr, flush_interval: DEFAULT_FLUSH_INTERVAL)
         host, port_as_string = addr.split(":", 2)
@@ -26,17 +15,17 @@ module StatsD
 
       attr_reader :host, :port
 
+      class << self
+        def finalize(dispatcher)
+          proc { dispatcher.shutdown }
+        end
+      end
+
       def initialize(host, port, flush_interval: DEFAULT_FLUSH_INTERVAL)
         @host = host
         @port = port
-        @socket = nil
-        @flush_interval = flush_interval
-
-        require "concurrent/array"
-        @buffer = BUFFER_CLASS.new
-        @dispatcher_thread = nil
-        @interrupted = false
-        spawn_dispatcher
+        @dispatcher = Dispatcher.new(host, port, flush_interval)
+        ObjectSpace.define_finalizer(self, self.class.finalize(@dispatcher))
       end
 
       def sample?(sample_rate)
@@ -44,94 +33,121 @@ module StatsD
       end
 
       def <<(datagram)
-        unless @dispatcher_thread&.alive?
-          @buffer.clear
-          spawn_dispatcher
-        end
-
-        @buffer << datagram
+        @dispatcher << datagram
         self
       end
 
-      def shutdown
-        @interrupted = true
-        @dispatcher_thread&.join
-        invalidate_socket
-      end
-
-      private
-
-      def spawn_dispatcher
-        @dispatcher_thread = Thread.new { dispatch }
-      end
-
-      NEWLINE = "\n".b.freeze
-      def flush
-        return if @buffer.empty?
-
-        datagrams = @buffer.shift(@buffer.size)
-
-        until datagrams.empty?
-          packet = String.new(datagrams.pop, encoding: Encoding::BINARY, capacity: MAX_PACKET_SIZE)
-
-          until datagrams.empty? || packet.bytesize + datagrams.first.bytesize + 1 > MAX_PACKET_SIZE
-            packet << NEWLINE << datagrams.shift
-          end
-
-          send_packet(packet)
-        end
-      end
-
-      def dispatch
-        until @interrupted
-          begin
-            start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-            flush
-            next_sleep_duration = @flush_interval - (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start)
-
-            sleep(next_sleep_duration) if next_sleep_duration > 0
-          rescue => error
-            report_error(error)
-          end
-        end
-      end
-
-      def report_error(error)
-        StatsD.logger.error do
-          "[#{self.class.name}] The dispatcher thread encountered an error #{error.class}: #{error.message}"
-        end
-      end
-
-      def send_packet(packet)
-        retried = false
-        socket.send(packet, 0)
-      rescue SocketError, IOError, SystemCallError => error
-        StatsD.logger.debug do
-          "[#{self.class.name}] Resetting connection because of #{error.class}: #{error.message}"
-        end
-        invalidate_socket
-        if retried
-          StatsD.logger.warning do
-            "[#{self.class.name}] Events were dropped because of #{error.class}: #{error.message}"
-          end
+      class Dispatcher
+        BUFFER_CLASS = if !::Object.const_defined?(:RUBY_ENGINE) || RUBY_ENGINE == "ruby"
+          ::Array
         else
-          retried = true
-          retry
+          begin
+            gem("concurrent-ruby")
+          rescue Gem::MissingSpecError
+            raise Gem::MissingSpecError, "statsd-instrument depends on `concurrent-ruby` on #{RUBY_ENGINE}"
+          end
+          require "concurrent/array"
+          Concurrent::Array
         end
-      end
 
-      def socket
-        @socket ||= begin
-          socket = UDPSocket.new
-          socket.connect(@host, @port)
-          socket
+        def initialize(host, port, flush_interval)
+          @host = host
+          @port = port
+          @interrupted = false
+          @flush_interval = flush_interval
+          @buffer = BUFFER_CLASS.new
+          @dispatcher_thread = Thread.new { dispatch }
         end
-      end
 
-      def invalidate_socket
-        @socket&.close
-      ensure
-        @socket = nil
+        def <<(datagram)
+          unless @dispatcher_thread&.alive?
+            # If the dispatcher thread is dead, we assume it is because
+            # the process was forked. So to avoid ending datagrams twice
+            # we clear the buffer.
+            @buffer.clear
+            @dispatcher_thread = Thread.new { dispatch }
+          end
+          @buffer << datagram
+          self
+        end
+
+        def shutdown
+          @interrupted = true
+        end
+
+        private
+
+        NEWLINE = "\n".b.freeze
+        def flush
+          return if @buffer.empty?
+
+          datagrams = @buffer.shift(@buffer.size)
+
+          until datagrams.empty?
+            packet = String.new(datagrams.pop, encoding: Encoding::BINARY, capacity: MAX_PACKET_SIZE)
+
+            until datagrams.empty? || packet.bytesize + datagrams.first.bytesize + 1 > MAX_PACKET_SIZE
+              packet << NEWLINE << datagrams.shift
+            end
+
+            send_packet(packet)
+          end
+        end
+
+        def dispatch
+          until @interrupted
+            begin
+              start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+              flush
+              next_sleep_duration = @flush_interval - (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start)
+
+              sleep(next_sleep_duration) if next_sleep_duration > 0
+            rescue => error
+              report_error(error)
+            end
+          end
+
+          flush
+          invalidate_socket
+        end
+
+        def report_error(error)
+          StatsD.logger.error do
+            "[#{self.class.name}] The dispatcher thread encountered an error #{error.class}: #{error.message}"
+          end
+        end
+
+        def send_packet(packet)
+          retried = false
+          socket.send(packet, 0)
+        rescue SocketError, IOError, SystemCallError => error
+          StatsD.logger.debug do
+            "[#{self.class.name}] Resetting connection because of #{error.class}: #{error.message}"
+          end
+          invalidate_socket
+          if retried
+            StatsD.logger.warning do
+              "[#{self.class.name}] Events were dropped because of #{error.class}: #{error.message}"
+            end
+          else
+            retried = true
+            retry
+          end
+        end
+
+        def socket
+          @socket ||= begin
+            socket = UDPSocket.new
+            socket.connect(@host, @port)
+            socket
+          end
+        end
+
+        def invalidate_socket
+          @socket&.close
+        ensure
+          @socket = nil
+        end
       end
     end
   end

--- a/test/udp_sink_test.rb
+++ b/test/udp_sink_test.rb
@@ -72,9 +72,7 @@ module UDPSinkTests
   private
 
   def build_sink(host = @host, port = @port)
-    @__last_sink ||= nil
-    @__last_sink.shutdown if @__last_sink.respond_to?(:shutdown)
-    @__last_sink = @sink_class.new(host, port)
+    @sink_class.new(host, port)
   end
 
   class UDPSinkTest < Minitest::Test
@@ -133,7 +131,6 @@ module UDPSinkTests
     end
 
     def teardown
-      @__last_sink&.shutdown
       @receiver.close
     end
 


### PR DESCRIPTION
By moving the thread and the socket in another object, the thread no longer keep a reference on the `BatchedUDPSink`, which means it can be GCed, and it turn it can signal the dispatcher object to shutdown.