### PR TITLE
Improve flushing of batched datagrams on process exit

### DIFF
--- a/lib/statsd/instrument/batched_udp_sink.rb
+++ b/lib/statsd/instrument/batched_udp_sink.rb
@@ -71,8 +71,13 @@ module StatsD
           self
         end
 
-        def shutdown
+        def shutdown(wait = @flush_interval * 2)
           @interrupted = true
+          if @dispatcher_thread&.alive?
+            @dispatcher_thread.join(wait)
+          else
+            flush
+          end
         end
 
         private


### PR DESCRIPTION
Fix: https://github.com/Shopify/statsd-instrument/issues/287

Of course if the process receive `SIGKILL` there's little we can do, but if the exit handlers are properly executed, the finalizer should be good enough to flush the events.