### PR TITLE
Remove`match?` backport: we no longer support Ruby 2.3

### DIFF
--- a/lib/statsd/instrument/datagram_builder.rb
+++ b/lib/statsd/instrument/datagram_builder.rb
@@ -5,18 +5,6 @@ module StatsD
     # @note This class is part of the new Client implementation that is intended
     #   to become the new default in the next major release of this library.
     class DatagramBuilder
-      unless Regexp.method_defined?(:match?) # for ruby 2.3
-        module RubyBackports
-          refine Regexp do
-            def match?(str)
-              match(str) != nil
-            end
-          end
-        end
-
-        using(RubyBackports)
-      end
-
       def self.unsupported_datagram_types(*types)
         types.each do |type|
           define_method(type) do |_, _, _, _|

--- a/lib/statsd/instrument/expectation.rb
+++ b/lib/statsd/instrument/expectation.rb
@@ -78,19 +78,6 @@ module StatsD
 
       private
 
-      # Needed for normalize_tags
-      unless Regexp.method_defined?(:match?) # for ruby 2.3
-        module RubyBackports
-          refine Regexp do
-            def match?(str)
-              (self =~ str) != nil
-            end
-          end
-        end
-
-        using(RubyBackports)
-      end
-
       # @private
       #
       # Utility function to convert tags to the canonical form.


### PR DESCRIPTION
This backport is no longer needed.