### PR TITLE
Fix new custom client not being passed to expectations bug

### DIFF
--- a/lib/statsd/instrument/assertions.rb
+++ b/lib/statsd/instrument/assertions.rb
@@ -74,7 +74,7 @@ module StatsD
       # @raise [Minitest::Assertion] If an exception occurs, or if the metric did
       #   not occur as specified during the execution the block.
       def assert_statsd_increment(metric_name, value = nil, datagrams: nil, client: nil, **options, &block)
-        expectation = StatsD::Instrument::Expectation.increment(metric_name, value, **options)
+        expectation = StatsD::Instrument::Expectation.increment(metric_name, value, client: client, **options)
         assert_statsd_expectation(expectation, datagrams: datagrams, client: client, &block)
       end
 
@@ -86,7 +86,7 @@ module StatsD
       # @return [void]
       # @raise (see #assert_statsd_increment)
       def assert_statsd_measure(metric_name, value = nil, datagrams: nil, client: nil, **options, &block)
-        expectation = StatsD::Instrument::Expectation.measure(metric_name, value, **options)
+        expectation = StatsD::Instrument::Expectation.measure(metric_name, value, client: client, **options)
         assert_statsd_expectation(expectation, datagrams: datagrams, client: client, &block)
       end
 
@@ -98,7 +98,7 @@ module StatsD
       # @return [void]
       # @raise (see #assert_statsd_increment)
       def assert_statsd_gauge(metric_name, value = nil, datagrams: nil, client: nil, **options, &block)
-        expectation = StatsD::Instrument::Expectation.gauge(metric_name, value, **options)
+        expectation = StatsD::Instrument::Expectation.gauge(metric_name, value, client: client, **options)
         assert_statsd_expectation(expectation, datagrams: datagrams, client: client, &block)
       end
 
@@ -110,7 +110,7 @@ module StatsD
       # @return [void]
       # @raise (see #assert_statsd_increment)
       def assert_statsd_histogram(metric_name, value = nil, datagrams: nil, client: nil, **options, &block)
-        expectation = StatsD::Instrument::Expectation.histogram(metric_name, value, **options)
+        expectation = StatsD::Instrument::Expectation.histogram(metric_name, value, client: client, **options)
         assert_statsd_expectation(expectation, datagrams: datagrams, client: client, &block)
       end
 
@@ -122,7 +122,7 @@ module StatsD
       # @return [void]
       # @raise (see #assert_statsd_increment)
       def assert_statsd_distribution(metric_name, value = nil, datagrams: nil, client: nil, **options, &block)
-        expectation = StatsD::Instrument::Expectation.distribution(metric_name, value, **options)
+        expectation = StatsD::Instrument::Expectation.distribution(metric_name, value, client: client, **options)
         assert_statsd_expectation(expectation, datagrams: datagrams, client: client, &block)
       end
 
@@ -134,7 +134,7 @@ module StatsD
       # @return [void]
       # @raise (see #assert_statsd_increment)
       def assert_statsd_set(metric_name, value = nil, datagrams: nil, client: nil, **options, &block)
-        expectation = StatsD::Instrument::Expectation.set(metric_name, value, **options)
+        expectation = StatsD::Instrument::Expectation.set(metric_name, value, client: client, **options)
         assert_statsd_expectation(expectation, datagrams: datagrams, client: client, &block)
       end
 

--- a/lib/statsd/instrument/expectation.rb
+++ b/lib/statsd/instrument/expectation.rb
@@ -32,9 +32,10 @@ module StatsD
 
       attr_accessor :times, :type, :name, :value, :sample_rate, :tags
 
-      def initialize(client: StatsD.singleton_client, type:, name:, value: nil,
+      def initialize(client: nil, type:, name:, value: nil,
         sample_rate: nil, tags: nil, no_prefix: false, times: 1)
 
+        client ||= StatsD.singleton_client
         @type = type
         @name = no_prefix || !client.prefix ? name : "#{client.prefix}.#{name}"
         @value = normalized_value_for_type(type, value) if value

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -440,4 +440,17 @@ class AssertionsTest < Minitest::Test
       StatsD.increment("incr", no_prefix: true)
     end
   end
+
+  def test_client_propagation_to_expectations
+    foo_1_metric = StatsD::Instrument::Expectation.increment("foo")
+    @test_case.assert_statsd_expectations([foo_1_metric]) do
+      StatsD.increment("foo")
+    end
+
+    client = StatsD::Instrument::Client.new(prefix: "prefix")
+    foo_2_metric = StatsD::Instrument::Expectation.increment("foo", client: client)
+    @test_case.assert_statsd_expectations([foo_2_metric]) do
+      StatsD.increment("prefix.foo")
+    end
+  end
 end

--- a/test/statsd_instrumentation_test.rb
+++ b/test/statsd_instrumentation_test.rb
@@ -345,7 +345,7 @@ class StatsDInstrumentationTest < Minitest::Test
     client = StatsD::Instrument::Client.new(prefix: "prefix")
 
     ActiveMerchant::Gateway.statsd_count(:ssl_post, "ActiveMerchant.Gateway.ssl_post", client: client)
-    assert_statsd_increment("prefix.ActiveMerchant.Gateway.ssl_post", client: client) do
+    assert_statsd_increment("ActiveMerchant.Gateway.ssl_post", client: client) do
       ActiveMerchant::Gateway.new.purchase(true)
     end
   ensure


### PR DESCRIPTION
While trying to use a custom StatsD client for our project (see https://github.com/Shopify/help/pull/24350) we discovered a bug. The new client was being set properly but the new custom client was not being passed into expectations so there ends up being a discrepancy with the result and the expectation. This is because there is no separate parameter for client when initializing a new expectation and the options that are being passed into `StatsD::Instrument::Expectation` do not contain the new client and so the expectation ends up defaulting to `StatsD.singleton_client`. 

Explicitly adding the new client to the options as such, and initializing it, ensures that the new client is passed up to expectations: 
```
expectation = StatsD::Instrument::Expectation.increment(metric_name, value, client: client, **options)
```