### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.6', '2.7', '3.0']
+        ruby: ['2.6', '2.7', '3.0', '3.1']
 
         # Windows on macOS builds started failing, so they are disabled for noew
         # platform: [windows-2019, macOS-10.14, ubuntu-18.04]
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Setup Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
 

--- a/lib/statsd/instrument/matchers.rb
+++ b/lib/statsd/instrument/matchers.rb
@@ -49,7 +49,7 @@ module StatsD
             raise RSpec::Expectations::ExpectationNotMetError, "No StatsD calls for metric #{metric_name} were made."
           elsif options[:times] && options[:times] != metrics.length
             raise RSpec::Expectations::ExpectationNotMetError, "The numbers of StatsD calls for metric " \
-             "#{metric_name} was unexpected. Expected #{options[:times].inspect}, got #{metrics.length}"
+              "#{metric_name} was unexpected. Expected #{options[:times].inspect}, got #{metrics.length}"
           end
 
           [:sample_rate, :value, :tags].each do |expectation|

--- a/lib/statsd/instrument/rubocop/positional_arguments.rb
+++ b/lib/statsd/instrument/rubocop/positional_arguments.rb
@@ -41,7 +41,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          -> (corrector) do
+          ->(corrector) do
             positional_arguments = if node.arguments.last.type == :block_pass
               node.arguments[2...node.arguments.length - 1]
             else

--- a/lib/statsd/instrument/udp_sink.rb
+++ b/lib/statsd/instrument/udp_sink.rb
@@ -26,13 +26,11 @@ module StatsD
       def <<(datagram)
         with_socket { |socket| socket.send(datagram, 0) }
         self
-
       rescue ThreadError
         # In cases where a TERM or KILL signal has been sent, and we send stats as
         # part of a signal handler, locks cannot be acquired, so we do our best
         # to try and send the datagram without a lock.
         socket.send(datagram, 0) > 0
-
       rescue SocketError, IOError, SystemCallError => error
         StatsD.logger.debug do
           "[StatsD::Instrument::UDPSink] Resetting connection because of #{error.class}: #{error.message}"

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -35,7 +35,6 @@ class HelpersTest < Minitest::Test
     StatsD.gauge("gauge", 15)
 
     assert_equal(2, metrics.length)
-
   ensure
     StatsD.singleton_client = @old_client
   end

--- a/test/udp_sink_test.rb
+++ b/test/udp_sink_test.rb
@@ -136,7 +136,7 @@ module UDPSinkTests
 
         assert_equal(
           "[#{@sink_class}] Resetting connection because of " \
-          "Errno::EDESTADDRREQ: Destination address required\n",
+            "Errno::EDESTADDRREQ: Destination address required\n",
           logs.string,
         )
       ensure


### PR DESCRIPTION
This PR:

1. Switches to the supported setup-ruby action
2. Adds Ruby 3.1 to the CI matrix
3. Fixes a few lints so that CI passes