### PR TITLE
Release version 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ section below.
 
 ### Unreleased changes
 
+_Nothing yet_
+
+## Version 3.2.0
+
 - Add `tag_error_class` option to `statsd_count_success` which tags the class of a thrown error
 
 ## Version 3.1.2

--- a/lib/statsd/instrument/version.rb
+++ b/lib/statsd/instrument/version.rb
@@ -2,6 +2,6 @@
 
 module StatsD
   module Instrument
-    VERSION = "3.1.2"
+    VERSION = "3.2.0"
   end
 end


### PR DESCRIPTION
Release 3.2.0 that includes `tag_error_class` in `statsd_count_success`.

I can't push on master since it fails with "CLA not signed" which is not a problem via PRs for some reason 🤷 