### PR TITLE
Wake up the dispatch thread once the buffer is past a threshold

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,12 @@ Naming/FileName:
   Exclude:
     - lib/statsd-instrument.rb
 
+Metrics/ParameterLists:
+  Enabled: false
+
+Style/WhileUntilModifier:
+  Enabled: false
+
 # Enable our own cops on our own repo
 
 StatsD/MetricReturnValue:

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ The following environment variables are supported:
   may be buffered before emitting threads will start to block. Increasing this
   value may help for application generating spikes of events. However if the
   application emit events faster than they can be sent, increasing it won't help.
+- `STATSD_MAX_PACKET_SIZE`: (default: `1472`) The maximum size of UDP packets.
+  If your network is properly configured to handle larger packets you may try
+  to increase this value for better performance, but most network can't handle
+  larger packets.
 
 ## StatsD keys
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ The following environment variables are supported:
 - `STATSD_FLUSH_INTERVAL`: (default: `1.0`) The interval in seconds at which
   events are sent in batch. Only applicable to the UDP configuration. If set
   to `0.0`, metrics are sent immediately.
+- `STATSD_BUFFER_CAPACITY`: (default: `5000`) The maximum amount of events that
+  may be buffered before emitting threads will start to block. Increasing this
+  value may help for application generating spikes of events. However if the
+  application emit events faster than they can be sent, increasing it won't help.
 
 ## StatsD keys
 

--- a/benchmark/send-metrics-to-local-udp-receiver
+++ b/benchmark/send-metrics-to-local-udp-receiver
@@ -16,28 +16,48 @@ else
 end
 
 intermediate_results_filename = "#{Dir.tmpdir}/statsd-instrument-benchmarks/#{File.basename($PROGRAM_NAME)}"
+log_filename = "#{Dir.tmpdir}/statsd-instrument-benchmarks/#{File.basename($PROGRAM_NAME)}.log"
 FileUtils.mkdir_p(File.dirname(intermediate_results_filename))
 
 # Set up an UDP listener to which we can send StatsD packets
 receiver = UDPSocket.new
 receiver.bind("localhost", 0)
 
-StatsD.singleton_client = StatsD::Instrument::Environment.new(
+log_file = File.open(log_filename, "w+", level: Logger::WARN)
+StatsD.logger = Logger.new(log_file)
+
+udp_client = StatsD::Instrument::Environment.new(
+  "STATSD_ADDR" => "#{receiver.addr[2]}:#{receiver.addr[1]}",
+  "STATSD_IMPLEMENTATION" => "dogstatsd",
+  "STATSD_ENV" => "production",
+  "STATSD_FLUSH_INTERVAL" => "0",
+).client
+
+batched_udp_client = StatsD::Instrument::Environment.new(
   "STATSD_ADDR" => "#{receiver.addr[2]}:#{receiver.addr[1]}",
   "STATSD_IMPLEMENTATION" => "dogstatsd",
   "STATSD_ENV" => "production",
 ).client
 
+
+def send_metrics(client)
+  client.increment("StatsD.increment", 10)
+  client.measure("StatsD.measure") { 1 + 1 }
+  client.gauge("StatsD.gauge", 12.0, tags: ["foo:bar", "quc"])
+  client.set("StatsD.set", "value", tags: { foo: "bar", baz: "quc" })
+  if client.datagram_builder_class == StatsD::Instrument::DogStatsDDatagramBuilder
+    client.event("StasD.event", "12345")
+    client.service_check("StatsD.service_check", "ok")
+  end
+end
+
 report = Benchmark.ips do |bench|
-  bench.report("StatsD metrics to local UDP receiver (branch: #{branch}, sha: #{revision[0, 7]})") do
-    StatsD.increment("StatsD.increment", 10)
-    StatsD.measure("StatsD.measure") { 1 + 1 }
-    StatsD.gauge("StatsD.gauge", 12.0, tags: ["foo:bar", "quc"])
-    StatsD.set("StatsD.set", "value", tags: { foo: "bar", baz: "quc" })
-    if StatsD.singleton_client.datagram_builder_class == StatsD::Instrument::DogStatsDDatagramBuilder
-      StatsD.event("StasD.event", "12345")
-      StatsD.service_check("StatsD.service_check", "ok")
-    end
+  bench.report("local UDP sync (branch: #{branch}, sha: #{revision[0, 7]})") do
+    send_metrics(udp_client)
+  end
+
+  bench.report("local UDP batched (branch: #{branch}, sha: #{revision[0, 7]})") do
+    send_metrics(batched_udp_client)
   end
 
   # Store the results in between runs
@@ -56,4 +76,12 @@ elsif ENV["KEEP_RESULTS"]
   puts "The intermediate results have been stored in #{intermediate_results_filename}"
 else
   File.unlink(intermediate_results_filename)
+end
+
+log_file.close
+logs = File.read(log_filename)
+unless logs.empty?
+  puts
+  puts "==== logs ===="
+  puts logs 
 end

--- a/benchmark/send-metrics-to-local-udp-receiver
+++ b/benchmark/send-metrics-to-local-udp-receiver
@@ -26,19 +26,18 @@ receiver.bind("localhost", 0)
 log_file = File.open(log_filename, "w+", level: Logger::WARN)
 StatsD.logger = Logger.new(log_file)
 
-udp_client = StatsD::Instrument::Environment.new(
+udp_client = StatsD::Instrument::Environment.new(ENV.to_h.merge(
   "STATSD_ADDR" => "#{receiver.addr[2]}:#{receiver.addr[1]}",
   "STATSD_IMPLEMENTATION" => "dogstatsd",
   "STATSD_ENV" => "production",
   "STATSD_FLUSH_INTERVAL" => "0",
-).client
+)).client
 
-batched_udp_client = StatsD::Instrument::Environment.new(
+batched_udp_client = StatsD::Instrument::Environment.new(ENV.to_h.merge(
   "STATSD_ADDR" => "#{receiver.addr[2]}:#{receiver.addr[1]}",
   "STATSD_IMPLEMENTATION" => "dogstatsd",
   "STATSD_ENV" => "production",
-).client
-
+)).client
 
 def send_metrics(client)
   client.increment("StatsD.increment", 10)
@@ -83,5 +82,5 @@ logs = File.read(log_filename)
 unless logs.empty?
   puts
   puts "==== logs ===="
-  puts logs 
+  puts logs
 end

--- a/lib/statsd/instrument/batched_udp_sink.rb
+++ b/lib/statsd/instrument/batched_udp_sink.rb
@@ -23,7 +23,8 @@ module StatsD
         end
       end
 
-      def initialize(host, port, flush_interval: DEFAULT_FLUSH_INTERVAL, thread_priority: DEFAULT_THREAD_PRIORITY, flush_threshold: DEFAULT_FLUSH_THRESHOLD)
+      def initialize(host, port, flush_interval: DEFAULT_FLUSH_INTERVAL, thread_priority: DEFAULT_THREAD_PRIORITY,
+        flush_threshold: DEFAULT_FLUSH_THRESHOLD)
         @host = host
         @port = port
         @dispatcher = Dispatcher.new(host, port, flush_interval, flush_threshold, thread_priority)
@@ -184,19 +185,21 @@ module StatsD
 
         def send_packet(packet)
           retried = false
-          socket.send(packet, 0)
-        rescue SocketError, IOError, SystemCallError => error
-          StatsD.logger.debug do
-            "[#{self.class.name}] Resetting connection because of #{error.class}: #{error.message}"
-          end
-          invalidate_socket
-          if retried
-            StatsD.logger.warning do
-              "[#{self.class.name}] Events were dropped because of #{error.class}: #{error.message}"
+          begin
+            socket.send(packet, 0)
+          rescue SocketError, IOError, SystemCallError => error
+            StatsD.logger.debug do
+              "[#{self.class.name}] Resetting connection because of #{error.class}: #{error.message}"
             end
-          else
-            retried = true
-            retry
+            invalidate_socket
+            if retried
+              StatsD.logger.warning do
+                "[#{self.class.name}] Events were dropped because of #{error.class}: #{error.message}"
+              end
+            else
+              retried = true
+              retry
+            end
           end
         end
 

--- a/lib/statsd/instrument/batched_udp_sink.rb
+++ b/lib/statsd/instrument/batched_udp_sink.rb
@@ -6,11 +6,13 @@ module StatsD
     #   to become the new default in the next major release of this library.
     class BatchedUDPSink
       DEFAULT_FLUSH_INTERVAL = 1.0
+      DEFAULT_THREAD_PRIORITY = 100
+      DEFAULT_FLUSH_THRESHOLD = 50
       MAX_PACKET_SIZE = 508
 
-      def self.for_addr(addr, flush_interval: DEFAULT_FLUSH_INTERVAL)
+      def self.for_addr(addr, **kwargs)
         host, port_as_string = addr.split(":", 2)
-        new(host, Integer(port_as_string), flush_interval: flush_interval)
+        new(host, Integer(port_as_string), **kwargs)
       end
 
       attr_reader :host, :port
@@ -21,10 +23,10 @@ module StatsD
         end
       end
 
-      def initialize(host, port, flush_interval: DEFAULT_FLUSH_INTERVAL)
+      def initialize(host, port, flush_interval: DEFAULT_FLUSH_INTERVAL, thread_priority: DEFAULT_THREAD_PRIORITY, flush_threshold: DEFAULT_FLUSH_THRESHOLD)
         @host = host
         @port = port
-        @dispatcher = Dispatcher.new(host, port, flush_interval)
+        @dispatcher = Dispatcher.new(host, port, flush_interval, flush_threshold, thread_priority)
         ObjectSpace.define_finalizer(self, self.class.finalize(@dispatcher))
       end
 
@@ -35,6 +37,10 @@ module StatsD
       def <<(datagram)
         @dispatcher << datagram
         self
+      end
+
+      def shutdown(*args)
+        @dispatcher.shutdown(*args)
       end
 
       class Dispatcher
@@ -50,33 +56,33 @@ module StatsD
           Concurrent::Array
         end
 
-        def initialize(host, port, flush_interval)
+        def initialize(host, port, flush_interval, flush_threshold, thread_priority)
           @host = host
           @port = port
           @interrupted = false
           @flush_interval = flush_interval
+          @flush_threshold = flush_threshold
+          @thread_priority = thread_priority
           @buffer = BUFFER_CLASS.new
           @dispatcher_thread = Thread.new { dispatch }
+          @pid = Process.pid
+          @monitor = Monitor.new
+          @condition = @monitor.new_cond
         end
 
         def <<(datagram)
-          unless @dispatcher_thread&.alive?
-            # If the dispatcher thread is dead, we assume it is because
-            # the process was forked. So to avoid ending datagrams twice
-            # we clear the buffer.
-            # However if the main the main thread is dead, we won't be able
-            # to spawn a new thread, so we fallback to sending our datagram directly.
-            if Thread.main.alive?
-              @buffer.clear
-              @dispatcher_thread = Thread.new { dispatch }
-            else
-              @buffer << datagram
-              flush
-              return self
+          if thread_healthcheck
+            @buffer << datagram
+
+            # To avoid sending too many signals when the thread is already flushing
+            # We only signal when the queue size is a multiple of `flush_threshold`
+            if @buffer.size % @flush_threshold == 0
+              wakeup_thread
             end
+          else
+            flush
           end
 
-          @buffer << datagram
           self
         end
 
@@ -91,6 +97,24 @@ module StatsD
 
         private
 
+        def wakeup_thread
+          begin
+            @monitor.synchronize do
+              @condition.signal
+            end
+          rescue ThreadError
+            # Can't synchronize from trap context
+            Thread.new { wakeup_thread }.join
+            return
+          end
+
+          begin
+            @dispatcher_thread&.run
+          rescue ThreadError # Somehow the thread just died
+            thread_healthcheck
+          end
+        end
+
         NEWLINE = "\n".b.freeze
         def flush
           return if @buffer.empty?
@@ -98,7 +122,7 @@ module StatsD
           datagrams = @buffer.shift(@buffer.size)
 
           until datagrams.empty?
-            packet = String.new(datagrams.pop, encoding: Encoding::BINARY, capacity: MAX_PACKET_SIZE)
+            packet = String.new(datagrams.shift, encoding: Encoding::BINARY, capacity: MAX_PACKET_SIZE)
 
             until datagrams.empty? || packet.bytesize + datagrams.first.bytesize + 1 > MAX_PACKET_SIZE
               packet << NEWLINE << datagrams.shift
@@ -108,6 +132,29 @@ module StatsD
           end
         end
 
+        def thread_healthcheck
+          # TODO: We have a race condition on JRuby / Truffle here. It could cause multiple
+          # dispatcher threads to be spawned, which would cause problems.
+          # However we can't simply lock here as we might be called from a trap context.
+          unless @dispatcher_thread&.alive?
+            # If the main the main thread is dead the VM is shutting down so we won't be able
+            # to spawn a new thread, so we fallback to sending our datagram directly.
+            return false unless Thread.main.alive?
+
+            # If the dispatcher thread is dead, it might be because the process was forked.
+            # So to avoid sending datagrams twice we clear the buffer.
+            if @pid != Process.pid
+              StatsD.logger.info { "[#{self.class.name}] Restarting the dispatcher thread after fork" }
+              @pid = Process.pid
+              @buffer.clear
+            else
+              StatsD.logger.info { "[#{self.class.name}] Restarting the dispatcher thread" }
+            end
+            @dispatcher_thread = Thread.new { dispatch }.tap { |t| t.priority = @thread_priority }
+          end
+          true
+        end
+
         def dispatch
           until @interrupted
             begin
@@ -115,7 +162,11 @@ module StatsD
               flush
               next_sleep_duration = @flush_interval - (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start)
 
-              sleep(next_sleep_duration) if next_sleep_duration > 0
+              if next_sleep_duration > 0
+                @monitor.synchronize do
+                  @condition.wait(next_sleep_duration)
+                end
+              end
             rescue => error
               report_error(error)
             end

--- a/lib/statsd/instrument/batched_udp_sink.rb
+++ b/lib/statsd/instrument/batched_udp_sink.rb
@@ -9,7 +9,8 @@ module StatsD
       DEFAULT_THREAD_PRIORITY = 100
       DEFAULT_FLUSH_THRESHOLD = 50
       DEFAULT_BUFFER_CAPACITY = 5_000
-      DEFAULT_MAX_PACKET_SIZE = 1432
+      # https://docs.datadoghq.com/developers/dogstatsd/high_throughput/?code-lang=ruby#ensure-proper-packet-sizes
+      DEFAULT_MAX_PACKET_SIZE = 1472
 
       def self.for_addr(addr, **kwargs)
         host, port_as_string = addr.split(":", 2)
@@ -233,7 +234,7 @@ module StatsD
             end
             invalidate_socket
             if retried
-              StatsD.logger.warning do
+              StatsD.logger.warn do
                 "[#{self.class.name}] Events were dropped because of #{error.class}: #{error.message}"
               end
             else

--- a/lib/statsd/instrument/environment.rb
+++ b/lib/statsd/instrument/environment.rb
@@ -86,6 +86,10 @@ module StatsD
         Float(env.fetch("STATSD_BUFFER_CAPACITY", StatsD::Instrument::BatchedUDPSink::DEFAULT_BUFFER_CAPACITY))
       end
 
+      def statsd_max_packet_size
+        Float(env.fetch("STATSD_MAX_PACKET_SIZE", StatsD::Instrument::BatchedUDPSink::DEFAULT_MAX_PACKET_SIZE))
+      end
+
       def client
         StatsD::Instrument::Client.from_env(self)
       end
@@ -98,6 +102,7 @@ module StatsD
               statsd_addr,
               flush_interval: statsd_flush_interval,
               buffer_capacity: statsd_buffer_capacity,
+              max_packet_size: statsd_max_packet_size,
             )
           else
             StatsD::Instrument::UDPSink.for_addr(statsd_addr)

--- a/lib/statsd/instrument/environment.rb
+++ b/lib/statsd/instrument/environment.rb
@@ -79,7 +79,11 @@ module StatsD
       end
 
       def statsd_flush_interval
-        Float(env.fetch("STATSD_FLUSH_INTERVAL", 1.0))
+        Float(env.fetch("STATSD_FLUSH_INTERVAL", StatsD::Instrument::BatchedUDPSink::DEFAULT_FLUSH_INTERVAL))
+      end
+
+      def statsd_buffer_capacity
+        Float(env.fetch("STATSD_BUFFER_CAPACITY", StatsD::Instrument::BatchedUDPSink::DEFAULT_BUFFER_CAPACITY))
       end
 
       def client
@@ -90,7 +94,11 @@ module StatsD
         case environment
         when "production", "staging"
           if statsd_flush_interval > 0.0
-            StatsD::Instrument::BatchedUDPSink.for_addr(statsd_addr, flush_interval: statsd_flush_interval)
+            StatsD::Instrument::BatchedUDPSink.for_addr(
+              statsd_addr,
+              flush_interval: statsd_flush_interval,
+              buffer_capacity: statsd_buffer_capacity,
+            )
           else
             StatsD::Instrument::UDPSink.for_addr(statsd_addr)
           end

--- a/test/udp_sink_test.rb
+++ b/test/udp_sink_test.rb
@@ -35,10 +35,11 @@ module UDPSinkTests
   def test_parallelism
     udp_sink = build_sink(@host, @port)
     50.times.map { |i| Thread.new { udp_sink << "foo:#{i}|c" << "bar:#{i}|c" } }
+    Thread.pass
     datagrams = []
 
     while @receiver.wait_readable(2)
-      datagram, _source = @receiver.recvfrom(4000)
+      datagram, _source = @receiver.recvfrom(4096)
       datagrams += datagram.split("\n")
     end
 
@@ -53,31 +54,39 @@ module UDPSinkTests
 
   def test_sends_datagram_in_signal_handler
     udp_sink = build_sink(@host, @port)
-    Signal.trap("USR1") { udp_sink << "exiting:1|c" }
-
-    pid = fork do
-      sleep(5)
+    Signal.trap("USR1") do
+      udp_sink << "exiting:1|c"
+      udp_sink << "exiting:1|d"
     end
 
+    Process.kill("USR1", Process.pid)
+    assert_equal(["exiting:1|c", "exiting:1|d"], read_datagrams(2))
+  ensure
     Signal.trap("USR1", "DEFAULT")
-
-    Process.kill("USR1", pid)
-    @receiver.wait_readable(1)
-    assert_equal("exiting:1|c", @receiver.recvfrom_nonblock(100).first)
-    Process.kill("KILL", pid)
-  rescue NotImplementedError
-    pass("Fork is not implemented on #{RUBY_PLATFORM}")
   end
 
   def test_sends_datagram_before_exit
     udp_sink = build_sink(@host, @port)
-    fork do
+    pid = fork do
       udp_sink << "exiting:1|c"
-      Process.exit(0)
+      udp_sink << "exiting:1|d"
     end
+    Process.wait(pid)
+    assert_equal(["exiting:1|c", "exiting:1|d"], read_datagrams(2))
+  rescue NotImplementedError
+    pass("Fork is not implemented on #{RUBY_PLATFORM}")
+  end
 
-    @receiver.wait_readable(1)
-    assert_equal("exiting:1|c", @receiver.recvfrom_nonblock(100).first)
+  def test_sends_datagram_in_at_exit_callback
+    udp_sink = build_sink(@host, @port)
+    pid = fork do
+      at_exit do
+        udp_sink << "exiting:1|c"
+        udp_sink << "exiting:1|d"
+      end
+    end
+    Process.wait(pid)
+    assert_equal(["exiting:1|c", "exiting:1|d"], read_datagrams(2))
   rescue NotImplementedError
     pass("Fork is not implemented on #{RUBY_PLATFORM}")
   end
@@ -86,11 +95,11 @@ module UDPSinkTests
     udp_sink = build_sink(@host, @port)
     fork do
       udp_sink << "exiting:1|c"
+      udp_sink << "exiting:1|d"
       Process.kill("TERM", Process.pid)
     end
 
-    @receiver.wait_readable(1)
-    assert_equal("exiting:1|c", @receiver.recvfrom_nonblock(100).first)
+    assert_equal(["exiting:1|c", "exiting:1|d"], read_datagrams(2))
   rescue NotImplementedError
     pass("Fork is not implemented on #{RUBY_PLATFORM}")
   end
@@ -99,6 +108,18 @@ module UDPSinkTests
 
   def build_sink(host = @host, port = @port)
     @sink_class.new(host, port)
+  end
+
+  def read_datagrams(count, timeout: 2)
+    datagrams = []
+    count.times do
+      if @receiver.wait_readable(timeout)
+        datagrams += @receiver.recvfrom_nonblock(1000).first.lines(chomp: true)
+      else
+        break
+      end
+    end
+    datagrams
   end
 
   class UDPSinkTest < Minitest::Test
@@ -145,7 +166,7 @@ module UDPSinkTests
     end
   end
 
-  class BatchedUDPSinkTest < Minitest::Test
+  module BatchedUDPSinkTests
     include UDPSinkTests
 
     def setup
@@ -154,28 +175,62 @@ module UDPSinkTests
       @host = @receiver.addr[2]
       @port = @receiver.addr[1]
       @sink_class = StatsD::Instrument::BatchedUDPSink
+      @sinks = []
     end
 
     def teardown
       @receiver.close
+      @sinks.each(&:shutdown)
     end
+
+    private
+
+    def build_sink(host = @host, port = @port)
+      sink = @sink_class.new(host, port, flush_threshold: default_flush_threshold)
+      @sinks << sink
+      sink
+    end
+
+    def default_flush_threshold
+      StatsD::Instrument::BatchedUDPSink::DEFAULT_FLUSH_THRESHOLD
+    end
+  end
+
+  class BatchedUDPSinkTest < Minitest::Test
+    include BatchedUDPSinkTests
 
     def test_parallelism_buffering
       udp_sink = build_sink(@host, @port)
-      50.times.map do |i|
+      threads = 50.times.map do |i|
         Thread.new do
           udp_sink << "foo:#{i}|c" << "bar:#{i}|c" << "baz:#{i}|c" << "plop:#{i}|c"
         end
       end
+      threads.each(&:join)
 
-      datagrams = []
+      assert_equal(200, read_datagrams(10, timeout: 2).size)
+    end
+  end
 
-      while @receiver.wait_readable(2)
-        datagram, _source = @receiver.recvfrom(1000)
-        datagrams += datagram.split("\n")
-      end
+  class LowThresholdBatchedUDPSinkTest < Minitest::Test
+    include BatchedUDPSinkTests
 
-      assert_equal(200, datagrams.size)
+    def test_sends_datagram_when_termed
+      # When the main thread exit, the dispatcher thread is aborted
+      # and there's no exceptions or anything like that to rescue.
+      # So if the dispatcher thread poped some events from the buffer
+      # but didn't sent them yet, then they may be lost.
+      skip("Unfortunately this can't be guaranteed")
+    end
+    alias_method :test_sends_datagram_in_at_exit_callback, :test_sends_datagram_when_termed
+    alias_method :test_sends_datagram_before_exit, :test_sends_datagram_when_termed
+
+    private
+
+    # We run the same tests again, but this time we wake up the dispatcher
+    # thread on every call to make sure trap context is properly handled
+    def default_flush_threshold
+      1
     end
   end
 end


### PR DESCRIPTION
Fix: https://github.com/Shopify/statsd-instrument/issues/297

The current sleep loop can lead to large memory usage if lots of events are queued rapidly. In such scenario the buffer can grow very large until the threads wake up and flush it.

To avoid this, after enqueueing a message, if the buffer reached a threshold we explicitly wake up the dispatch thread to trigger a flush.