### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following environment variables are supported:
 - `STATSD_ADDR`: (default `localhost:8125`) The address to send the StatsD UDP
   datagrams to.
 - `STATSD_IMPLEMENTATION`: (default: `datadog`). The StatsD implementation you
-  are using. `statsd`, `statsite` and `datadog` are supported. Some features
+  are using. `statsd` and `datadog` are supported. Some features
   are only available on certain implementations,
 - `STATSD_ENV`: The environment StatsD will run in. If this is not set
   explicitly, this will be determined based on other environment variables,


### PR DESCRIPTION
According to the changelog, support for `statsite` was dropped on version 3.0.0.