### PR TITLE
Allow user to pass a lambda function to dynamic set the tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ section below.
 
 ## Unreleased changes
 
+- Allow user to provide a lambda function to dynamically set metric tags
+
 ## Version 3.4.0
 
 - UDP Batching has been largely refactored again. The `STATSD_FLUSH_INTERVAL` environment variable

--- a/README.md
+++ b/README.md
@@ -255,6 +255,16 @@ GoogleBase.statsd_count :insert, 'GoogleBase.insert', tags: ['env:production']
 If implementation is not set to `:datadog`, tags will not be included in the UDP packets, and a
 warning is logged to `StatsD.logger`.
 
+You can use lambda function that instead of a list of tags to set the metric tags.
+Like the dynamic metric name, the lambda function must accept two arguments:
+the object the function is being called on and the array of arguments
+passed.
+
+``` ruby
+metric_tagger = lambda { |object, args| { "key": args.first } }
+GoogleBase.statsd_count(:insert, 'GoogleBase.insert', tags: metric_tagger)
+```
+
 ## Testing
 
 This library comes with a module called `StatsD::Instrument::Assertions` and `StatsD::Instrument::Matchers` to help you write tests


### PR DESCRIPTION
Adds the same functionality that allows dynamic metric names to tags. Now you can use lambda function that instead of a list of tags to set the metric tags.
The lambda function must accept two arguments:
  - the object the function is being called on
  - the array of arguments passed

This is useful when defining metaprogramming methods.


```
Comparison:
UDP batched (branch: dynamic_tags, sha: d650250):   264181.0 i/s
UDP batched (branch: master, sha: e69ab35):   256938.6 i/s - same-ish: difference falls within error
```