### PR TITLE
Release 3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ section below.
 
 ## Unreleased changes
 
+## Version 3.5.0
+
 - Allow user to provide a lambda function to dynamically set metric tags
 
 ## Version 3.4.0

--- a/lib/statsd/instrument/version.rb
+++ b/lib/statsd/instrument/version.rb
@@ -2,6 +2,6 @@
 
 module StatsD
   module Instrument
-    VERSION = "3.4.0"
+    VERSION = "3.5.0"
   end
 end


### PR DESCRIPTION
I was not able to create a release, looks like I am missing write access.

## Version 3.5.0

- Allow user to provide a lambda function to dynamically set metric tags