### PR TITLE
Add Proc as a valid type for tag

### DIFF
--- a/lib/statsd/instrument/strict.rb
+++ b/lib/statsd/instrument/strict.rb
@@ -97,8 +97,8 @@ module StatsD
         unless sample_rate.nil? || sample_rate.is_a?(Numeric)
           raise ArgumentError, "The sample_rate argument should be a number, got #{sample_rate}"
         end
-        unless tags.nil? || tags.is_a?(Hash) || tags.is_a?(Array)
-          raise ArgumentError, "The tags argument should be a hash or an array, got #{tags.inspect}"
+        unless tags.nil? || tags.is_a?(Hash) || tags.is_a?(Array) || tags.is_a?(Proc)
+          raise ArgumentError, "The tags argument should be a hash, a proc or an array, got #{tags.inspect}"
         end
       end
     end


### PR DESCRIPTION
[statsd-instrument](https://github.com/Shopify/statsd-instrument/commit/c29fbdaccb78a3f309f7328a8d3c67e940905fd2) is enabling the users to pass a lambda function to dynamically set the tags. The `strict mode` is allowing only `nil`, `hash`, or an `array`. This PR adds `Proc` as a valid class type for the strict mode. 

I couldn't find tests for the strict class. I thought about duplicating the existing test [test_statsd_count_with_tags_as_lambda](https://github.com/Shopify/statsd-instrument/blob/master/test/statsd_instrumentation_test.rb#L226) forcing it to run under the [strict mode](https://github.com/Shopify/statsd-instrument/blob/70a61459122a9929b5abb44a25035c9e36968bcd/lib/statsd/instrument.rb#L384), but it doesn't seem like a future-proof method of testing the strictness.

Adding the error log just to help seo/searchability. 
```
FAIL                                                                                                                                             
XXXXX_duration_via_StatsD
    An exception occurred in the block provided to the StatsD assertion.
    
    ArgumentError: The tags argument should be a hash or an array, got #<Proc:0x00007f01e0dd3770 /xxxxxxxx:43 (lambda)>
        /xxxxxxxxx:101:in `check_tags_and_sample_rate'
        /xxxxxxxxx:in `distribution'
```