### PR TITLE
Add a warning about where one can use dynamic tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ metric_tagger = lambda { |object, args| { "key": args.first } }
 GoogleBase.statsd_count(:insert, 'GoogleBase.insert', tags: metric_tagger)
 ```
 
+> You can only use the dynamic tag while using the instrumentation through metaprogramming methods
+
 ## Testing
 
 This library comes with a module called `StatsD::Instrument::Assertions` and `StatsD::Instrument::Matchers` to help you write tests


### PR DESCRIPTION
I was trying to use the `dynamic tags` outside of the metaprogramming methods, and I noticed that it won't work because the feature was added only to the [Instrument](https://github.com/Shopify/statsd-instrument/blob/master/lib/statsd/instrument.rb#L40).

I thought it's good to leave a note while we don't implement the same behavior for the basic methods.


