### PR TITLE
Allow user to provide expectation with times zero

### DIFF
--- a/lib/statsd/instrument/assertions.rb
+++ b/lib/statsd/instrument/assertions.rb
@@ -165,6 +165,8 @@ module StatsD
           filtered_datagrams = datagrams.select { |m| m.type == expectation.type && m.name == expectation.name }
 
           if filtered_datagrams.empty?
+            next if expectation_times == 0
+
             flunk("No StatsD calls for metric #{expectation.name} of type #{expectation.type} were made.")
           end
 
@@ -193,7 +195,7 @@ module StatsD
         end
         expectations -= matched_expectations
 
-        unless expectations.empty?
+        if expectations.any? { |m| m.times != 0 }
           flunk("Unexpected StatsD calls; the following metric expectations " \
             "were not satisfied: #{expectations.inspect}")
         end

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -303,6 +303,23 @@ class AssertionsTest < Minitest::Test
       StatsD.increment("counter", tags: { foo: 1 })
       StatsD.increment("counter", tags: { foo: 2 })
     end
+
+    foo_1_metric = StatsD::Instrument::Expectation.increment("counter", times: 2, tags: ["foo:1"])
+    foo_2_metric = StatsD::Instrument::Expectation.increment("counter", times: 0, tags: ["foo:2"])
+    @test_case.assert_statsd_expectations([foo_1_metric, foo_2_metric]) do
+      StatsD.increment("counter", tags: { foo: 1 })
+      StatsD.increment("counter", tags: { foo: 1 })
+    end
+
+    assert_raises(Minitest::Assertion) do
+      foo_1_metric = StatsD::Instrument::Expectation.increment("counter", times: 2, tags: ["foo:1"])
+      foo_2_metric = StatsD::Instrument::Expectation.increment("counter", times: 0, tags: ["foo:2"])
+      @test_case.assert_statsd_expectations([foo_1_metric, foo_2_metric]) do
+        StatsD.increment("counter", tags: { foo: 1 })
+        StatsD.increment("counter", tags: { foo: 1 })
+        StatsD.increment("counter", tags: { foo: 2 })
+      end
+    end
   end
 
   def test_assert_statsd_increment_with_tags


### PR DESCRIPTION
This allows to mix positive and negative expectations, meaning user is able to assert that a given metric is not present while checking for the presence of others.

```
foo_1_metric = StatsD::Instrument::Expectation.increment("counter", times: 2, tags: ["foo:1"])
foo_2_metric = StatsD::Instrument::Expectation.increment("counter", times: 0, tags: ["foo:2"])
assert_statsd_expectations([foo_1_metric, foo_2_metric]) do
  ...
end
```

Without this change, if user passes `times: 0` as expectation the test does not fail and the metric is not checked to make sure it was not called, given an impression to the user that the feature is available.