### PR TITLE
Improve Shapes Friendliness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ section below.
 
 ## Unreleased changes
 
+- Improve shapes friendliness for Ruby 3.2+
+
 ## Version 3.5.2
 
 - Fix bug on assertions to allow the user passes `times: 0` as expectation.

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -360,6 +360,12 @@ module StatsD
 
     def_delegators :singleton_client, :increment, :gauge, :set, :measure,
       :histogram, :distribution, :event, :service_check
+
+    private
+
+    def extended(klass)
+      klass.statsd_instrumentations # eagerly define
+    end
   end
 end
 


### PR DESCRIPTION
For optimal performance in Ruby 3.2+ it's preferable to define instance variables in a consistent order.