### PR TITLE
Adds support for prefixes to `assert_no_statsd_calls`

### DIFF
--- a/lib/statsd/instrument/assertions.rb
+++ b/lib/statsd/instrument/assertions.rb
@@ -73,7 +73,14 @@ module StatsD
         formatted_metrics = if no_prefix
           metric_names
         else
-          metric_names.map { |metric| StatsD::Instrument::Expectation.prefix_metric(metric, client: client) }
+          metric_names.map do |metric|
+            if StatsD::Instrument::Helpers.prefixed_metric?(metric, client: client)
+              warn("`#{__method__}` will prefix metrics by default. `#{metric}` skipped due to existing prefix.")
+              metric
+            else
+              StatsD::Instrument::Helpers.prefix_metric(metric, client: client)
+            end
+          end
         end
 
         datagrams.select! { |metric| formatted_metrics.include?(metric.name) } unless formatted_metrics.empty?

--- a/lib/statsd/instrument/assertions.rb
+++ b/lib/statsd/instrument/assertions.rb
@@ -49,6 +49,13 @@ module StatsD
       # @param [Array<String>] metric_names (default: []) The metric names that are not
       #   allowed to happen inside the block. If this is set to `[]`, the assertion
       #   will fail if any metric occurs.
+      # @param [Array<StatsD::Instrument::Datagram>] datagrams (default: nil) The datagrams
+      #   to be inspected for metric emission.
+      # @param [StatsD::Instrument::Client] client (default: nil) The client to be used
+      #   for fetching datagrams (if not provided) and metric prefix. If not provided, the
+      #   singleton client will attempt to be used.
+      # @param [Boolean] no_prefix (default: false) A directive to indicate if the client's
+      #   prefix should be prepended to the metric names.
       # @yield A block in which the specified metric should not occur. This block
       #   should not raise any exceptions.
       # @return [void]

--- a/lib/statsd/instrument/expectation.rb
+++ b/lib/statsd/instrument/expectation.rb
@@ -43,7 +43,7 @@ module StatsD
         sample_rate: nil, tags: nil, no_prefix: false, times: 1)
 
         @type = type
-        @name = no_prefix ? name : self.class.prefix_metric(name, client: client)
+        @name = no_prefix ? name : StatsD::Instrument::Helpers.prefix_metric(name, client: client)
         @value = normalized_value_for_type(type, value) if value
         @sample_rate = sample_rate
         @tags = normalize_tags(tags)

--- a/lib/statsd/instrument/expectation.rb
+++ b/lib/statsd/instrument/expectation.rb
@@ -30,11 +30,6 @@ module StatsD
         def histogram(name, value = nil, **options)
           new(type: :h, name: name, value: value, **options)
         end
-
-        def prefix_metric(metric_name, client: nil)
-          client ||= StatsD.singleton_client
-          client&.prefix ? "#{client.prefix}.#{metric_name}" : metric_name
-        end
       end
 
       attr_accessor :times, :type, :name, :value, :sample_rate, :tags

--- a/lib/statsd/instrument/helpers.rb
+++ b/lib/statsd/instrument/helpers.rb
@@ -26,6 +26,18 @@ module StatsD
 
         tags
       end
+
+      def self.prefix_metric(metric_name, client: nil)
+        client ||= StatsD.singleton_client
+        client&.prefix ? "#{client.prefix}.#{metric_name}" : metric_name
+      end
+
+      def self.prefixed_metric?(metric_name, client: nil)
+        client ||= StatsD.singleton_client
+        return false unless client&.prefix
+
+        metric_name =~ /\A#{Regexp.escape(client.prefix)}\./
+      end
     end
   end
 end

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -116,7 +116,7 @@ class AssertionsTest < Minitest::Test
     StatsD.singleton_client = client
 
     @test_case.assert_no_statsd_calls("counter") do
-      client.increment("other")
+      StatsD.increment("other")
     end
 
     assertion = assert_raises(Minitest::Assertion) do

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -74,6 +74,48 @@ class AssertionsTest < Minitest::Test
     assert_equal(assertion.message, "No StatsD calls for metric other, another expected.")
   end
 
+  def test_assert_no_statsd_calls_with_prefix
+    client = StatsD::Instrument::Client.new(prefix: "prefix")
+
+    @test_case.assert_no_statsd_calls("counter", client: client) do
+      client.increment("other")
+    end
+
+    assertion = assert_raises(Minitest::Assertion) do
+      @test_case.assert_no_statsd_calls("counter", client: client) do
+        client.increment("counter")
+      end
+    end
+    assert_equal(assertion.message, "No StatsD calls for metric prefix.counter expected.")
+
+    assertion = assert_raises(Minitest::Assertion) do
+      @test_case.assert_no_statsd_calls("counter", client: client, no_prefix: true) do
+        client.increment("counter", no_prefix: true)
+      end
+    end
+    assert_equal(assertion.message, "No StatsD calls for metric counter expected.")
+
+    StatsD.singleton_client = client
+
+    @test_case.assert_no_statsd_calls("counter") do
+      client.increment("other")
+    end
+
+    assertion = assert_raises(Minitest::Assertion) do
+      @test_case.assert_no_statsd_calls("counter") do
+        StatsD.increment("counter")
+      end
+    end
+    assert_equal(assertion.message, "No StatsD calls for metric prefix.counter expected.")
+
+    assertion = assert_raises(Minitest::Assertion) do
+      @test_case.assert_no_statsd_calls("counter", no_prefix: true) do
+        StatsD.increment("counter", no_prefix: true)
+      end
+    end
+    assert_equal(assertion.message, "No StatsD calls for metric counter expected.")
+  end
+
   def test_assert_statsd
     @test_case.assert_statsd_increment("counter") do
       StatsD.increment("counter")

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -88,6 +88,24 @@ class AssertionsTest < Minitest::Test
     end
     assert_equal(assertion.message, "No StatsD calls for metric prefix.counter expected.")
 
+    @test_case.expects(:warn).with(
+      "`assert_no_statsd_calls` will prefix metrics by default. `prefix.counter` skipped due to existing prefix."
+    )
+    assertion = assert_raises(Minitest::Assertion) do
+      @test_case.assert_no_statsd_calls("prefix.counter", client: client) do
+        client.increment("counter")
+      end
+    end
+    assert_equal(assertion.message, "No StatsD calls for metric prefix.counter expected.")
+
+    @test_case.expects(:warn).never
+    assertion = assert_raises(Minitest::Assertion) do
+      @test_case.assert_no_statsd_calls("prefix.counter", client: client, no_prefix: true) do
+        client.increment("counter")
+      end
+    end
+    assert_equal(assertion.message, "No StatsD calls for metric prefix.counter expected.")
+
     assertion = assert_raises(Minitest::Assertion) do
       @test_case.assert_no_statsd_calls("counter", client: client, no_prefix: true) do
         client.increment("counter", no_prefix: true)

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -7,6 +7,11 @@ class HelpersTest < Minitest::Test
     test_class = Class.new(Minitest::Test)
     test_class.send(:include, StatsD::Instrument::Helpers)
     @test_case = test_class.new("fake")
+    @old_client = StatsD.singleton_client
+  end
+
+  def teardown
+    StatsD.singleton_client = @old_client
   end
 
   def test_capture_metrics_inside_block_only
@@ -77,5 +82,59 @@ class HelpersTest < Minitest::Test
     assert_raises(ArgumentError, "add_tag only supports string, array or hash, Integer provided") do
       StatsD::Instrument::Helpers.add_tag(1, :key, 123)
     end
+  end
+
+  def test_prefix_metric_returns_metric_if_no_prefix
+    metric = "metric"
+    client = StatsD::Instrument::Client.new(prefix: nil)
+    assert_equal(metric, StatsD::Instrument::Helpers.prefix_metric(metric, client: client))
+  end
+
+  def test_prefix_metric_returns_prefixed_metric
+    prefix = "prefix"
+    metric = "metric"
+    client = StatsD::Instrument::Client.new(prefix: prefix)
+    assert_equal("#{prefix}.#{metric}", StatsD::Instrument::Helpers.prefix_metric(metric, client: client))
+  end
+
+  def test_prefix_metric_can_use_singleton_client
+    prefix = "prefix"
+    metric = "metric"
+    StatsD.singleton_client = StatsD::Instrument::Client.new(prefix: prefix)
+    assert_equal("#{prefix}.#{metric}", StatsD::Instrument::Helpers.prefix_metric(metric))
+  end
+
+  def test_prefixed_metric_return_true_if_prefix_present
+    prefix = "prefix"
+    metric = "prefix.metric"
+    client = StatsD::Instrument::Client.new(prefix: prefix)
+    assert(StatsD::Instrument::Helpers.prefixed_metric?(metric, client: client))
+  end
+
+  def test_prefixed_meric_returns_false_if_prefix_missing
+    prefix = "prefix"
+    metric = "metric"
+    client = StatsD::Instrument::Client.new(prefix: prefix)
+    refute(StatsD::Instrument::Helpers.prefixed_metric?(metric, client: client))
+  end
+
+  def test_prefixed_metric_returns_false_if_prefix_not_at_beginning
+    prefix = "prefix"
+    metric = "metric.prefix"
+    client = StatsD::Instrument::Client.new(prefix: prefix)
+    refute(StatsD::Instrument::Helpers.prefixed_metric?(metric, client: client))
+  end
+
+  def test_prefixed_metrics_returns_false_if_no_prefix_defined
+    metric = "prefix.metric"
+    client = StatsD::Instrument::Client.new(prefix: nil)
+    refute(StatsD::Instrument::Helpers.prefixed_metric?(metric, client: client))
+  end
+
+  def test_prefixed_metric_can_use_singleton_client
+    prefix = "prefix"
+    metric = "prefix.metric"
+    StatsD.singleton_client = StatsD::Instrument::Client.new(prefix: prefix)
+    assert(StatsD::Instrument::Helpers.prefixed_metric?(metric))
   end
 end


### PR DESCRIPTION
While using `assert_no_statsd_calls`, I found it doesn't currently support prefixes which can lead to false successes -- so this PR adds that support.

The current assertions generally expect an un-prefixed metric similar to how you'd emit the metric originally:
```
client = StatsD::Instrument::Client.new(prefix: "prefix")
assert_statsd_increment("counter", client: client) do
  client.increment("counter")
end
# Success because `prefix.counter` is emitted!
```

With `assert_no_statsd_calls`, this is actually succeeding currently:
```
client = StatsD::Instrument::Client.new(prefix: "prefix")
assert_no_statsd_calls("counter", client: client) do
  client.increment("counter")
end
# Success even though `prefix.counter` was emitted?!
```

This is because the metric names passed into `assert_no_statsd_calls` are never processed to append prefixes to them if a prefix was available, but are just used raw:
https://github.com/Shopify/statsd-instrument/blob/d5bfc145a06beaba2467170f66782a77057e8bc3/lib/statsd/instrument/assertions.rb#L64

For the positive assertions, they have the prefix appended in the `Expectation` class:
https://github.com/Shopify/statsd-instrument/blob/d5bfc145a06beaba2467170f66782a77057e8bc3/lib/statsd/instrument/expectation.rb#L42

This is especially insidious in an `assert_no_...` method when you're looking for the absence of something. Since the names aren't processed identically and the comparison finds no matches, it will always falsely succeed if a prefix is defined.