### PR TITLE
Allow user to assert different tags using RSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,13 @@ RSpec.describe 'Matchers' do
     it 'will pass if there is no matching StatsD call on negative expectation' do
       expect { StatsD.increment('other_counter') }.not_to trigger_statsd_increment('counter')
     end
+
+    it 'will pass if every statsD call matches its call tag variations' do
+      expect do
+        StatsD.increment('counter', tags: ['variation:a'])
+        StatsD.increment('counter', tags: ['variation:b'])
+      end.to trigger_statsd_increment('counter', times: 1, tags: ["variation:a"]).and trigger_statsd_increment('counter', times: 1, tags: ["variation:b"])
+    end
   end
 end
 ```

--- a/lib/statsd/instrument/matchers.rb
+++ b/lib/statsd/instrument/matchers.rb
@@ -43,7 +43,11 @@ module StatsD
 
         def expect_statsd_call(metric_type, metric_name, options, &block)
           metrics = capture_statsd_calls(&block)
-          metrics = metrics.select { |m| m.type == metric_type && m.name == metric_name }
+          metrics = metrics.select do |m|
+            options_tags = options[:tags] || []
+            metric_tags = m.tags || []
+            m.type == metric_type && m.name == metric_name && metric_tags.all? { |t| options_tags.include?(t) }
+          end
 
           if metrics.empty?
             raise RSpec::Expectations::ExpectationNotMetError, "No StatsD calls for metric #{metric_name} were made."

--- a/test/matchers_test.rb
+++ b/test/matchers_test.rb
@@ -34,6 +34,26 @@ class MatchersTest < Minitest::Test
     }))
   end
 
+  def test_statsd_increment_compound_using_and_matched
+    matcher_1 = StatsD::Instrument::Matchers::Increment.new(:c, "counter", times: 1, tags: ["a"])
+    matcher_2 = StatsD::Instrument::Matchers::Increment.new(:c, "counter", times: 1, tags: ["b"])
+
+    assert(matcher_1.and(matcher_2).matches?(lambda {
+      StatsD.increment("counter", tags: ["a"])
+      StatsD.increment("counter", tags: ["b"])
+    }))
+  end
+
+  def test_statsd_increment_compound_using_and_not_matched
+    matcher_1 = StatsD::Instrument::Matchers::Increment.new(:c, "counter", times: 1, tags: ["a"])
+    matcher_2 = StatsD::Instrument::Matchers::Increment.new(:c, "counter", times: 1, tags: ["b"])
+
+    refute(matcher_1.and(matcher_2).matches?(lambda {
+      StatsD.increment("counter", tags: ["a"])
+      StatsD.increment("counter", tags: ["c"])
+    }))
+  end
+
   def test_statsd_increment_with_times_matched
     assert(StatsD::Instrument::Matchers::Increment.new(:c, "counter", times: 1)
       .matches?(lambda { StatsD.increment("counter") }))


### PR DESCRIPTION
Previously the matcher filtered out metrics based on type and name to test against expectation. So, when the user tried to assert different different tags, the matcher would fail.
With this change, the matcher will filter out metrics also based on tags too, allowing the user to use RSpec `and` expectation.

For instance this test would fail before:

```
RSpec.describe 'Matchers' do
  context 'trigger_statsd_increment' do
    it 'will pass if every statsD call matches its calls' do
      expect do
        StatsD.increment('counter', tags: ['variation:a'])
        StatsD.increment('counter', tags: ['variation:b'])
      end.to trigger_statsd_increment('counter', times: 1, tags: ["variation:a"]).and trigger_statsd_increment('counter', times: 1, tags: ["variation:b"])
    end
  end
end
```

fixes: https://github.com/Shopify/statsd-instrument/issues/300