### PR TITLE
Allow compound matcher without specifying tags

### DIFF
--- a/lib/statsd/instrument/matchers.rb
+++ b/lib/statsd/instrument/matchers.rb
@@ -44,9 +44,10 @@ module StatsD
         def expect_statsd_call(metric_type, metric_name, options, &block)
           metrics = capture_statsd_calls(&block)
           metrics = metrics.select do |m|
-            options_tags = options[:tags] || []
             metric_tags = m.tags || []
-            m.type == metric_type && m.name == metric_name && metric_tags.all? { |t| options_tags.include?(t) }
+            options_tags = options[:tags] || []
+            tag_matches = options_tags.empty? || metric_tags.all? { |t| options_tags.include?(t) }
+            m.type == metric_type && m.name == metric_name && tag_matches
           end
 
           if metrics.empty?

--- a/test/matchers_test.rb
+++ b/test/matchers_test.rb
@@ -54,6 +54,17 @@ class MatchersTest < Minitest::Test
     }))
   end
 
+  def test_statsd_increment_compound_without_explicit_tags_using_and_matched
+    matcher_1 = StatsD::Instrument::Matchers::Increment.new(:c, "first_counter", times: 2)
+    matcher_2 = StatsD::Instrument::Matchers::Increment.new(:c, "second_counter", times: 1)
+
+    assert(matcher_1.and(matcher_2).matches?(lambda {
+      StatsD.increment("first_counter", tags: ["a"])
+      StatsD.increment("first_counter", tags: ["b"])
+      StatsD.increment("second_counter", tags: ["c"])
+    }))
+  end
+
   def test_statsd_increment_with_times_matched
     assert(StatsD::Instrument::Matchers::Increment.new(:c, "counter", times: 1)
       .matches?(lambda { StatsD.increment("counter") }))


### PR DESCRIPTION
This allows the user to specify a compound matcher to verify that a metric was emitted, without having to specify the tags.

It fixes issue pointed by @ChanChar https://github.com/Shopify/statsd-instrument/pull/331#issuecomment-1450880018