### PR TITLE
Tests that relied on tags being matcher are broken

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gemspec
 gem "rake"
 gem "minitest"
 gem "rspec"
-gem "rspec-mocks"
 gem "mocha"
 gem "yard"
 gem "rubocop", [">= 1.0", "< 1.30"] # TODO: Our cops are broken by rubocop 1.30, we need to figure out why

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 gem "rake"
 gem "minitest"
 gem "rspec"
+gem "rspec-mocks"
 gem "mocha"
 gem "yard"
 gem "rubocop", [">= 1.0", "< 1.30"] # TODO: Our cops are broken by rubocop 1.30, we need to figure out why

--- a/lib/statsd/instrument/matchers.rb
+++ b/lib/statsd/instrument/matchers.rb
@@ -45,8 +45,8 @@ module StatsD
           metrics = capture_statsd_calls(&block)
           metrics = metrics.select do |m|
             metric_tags = m.tags || []
-            options_tags = options[:tags] || []
-            tag_matches = options_tags.empty? || metric_tags.all? { |t| options_tags.include?(t) }
+            options_tags = options[:tags] || nil
+            tag_matches = options_tags.nil? || RSpec::Matchers::BuiltIn::Match.new(options_tags).matches?(metric_tags)
             m.type == metric_type && m.name == metric_name && tag_matches
           end
 

--- a/lib/statsd/instrument/matchers.rb
+++ b/lib/statsd/instrument/matchers.rb
@@ -45,7 +45,7 @@ module StatsD
           metrics = capture_statsd_calls(&block)
           metrics = metrics.select do |m|
             metric_tags = m.tags || []
-            options_tags = options[:tags] || nil
+            options_tags = options[:tags]
             tag_matches = options_tags.nil? || RSpec::Matchers::BuiltIn::Match.new(options_tags).matches?(metric_tags)
             m.type == metric_type && m.name == metric_name && tag_matches
           end

--- a/test/matchers_test.rb
+++ b/test/matchers_test.rb
@@ -2,8 +2,10 @@
 
 require "test_helper"
 require "statsd/instrument/matchers"
+require "rspec/mocks/argument_matchers"
 
 class MatchersTest < Minitest::Test
+
   def test_statsd_increment_matched
     assert(StatsD::Instrument::Matchers::Increment.new(:c, "counter", {})
       .matches?(lambda { StatsD.increment("counter") }))
@@ -112,6 +114,13 @@ class MatchersTest < Minitest::Test
   def test_statsd_increment_with_tags_matched
     assert(StatsD::Instrument::Matchers::Increment.new(:c, "counter", tags: ["a", "b"])
       .matches?(lambda { StatsD.increment("counter", tags: ["a", "b"]) }))
+  end
+
+  def test_statsd_increment_with_subset_matcher
+    include_matcher = RSpec::Matchers::BuiltIn::Include.new("foo:bar")
+    final = RSpec::Matchers::AliasedMatcher.new(include_matcher, :include)
+    assert(StatsD::Instrument::Matchers::Increment.new(:c, "counter", tags: final)
+      .matches?(lambda { StatsD.increment("counter", tags: ["foo:bar", "bar:baz"]) }))
   end
 
   def test_statsd_increment_with_tags_not_matched

--- a/test/matchers_test.rb
+++ b/test/matchers_test.rb
@@ -5,7 +5,6 @@ require "statsd/instrument/matchers"
 require "rspec/mocks/argument_matchers"
 
 class MatchersTest < Minitest::Test
-
   def test_statsd_increment_matched
     assert(StatsD::Instrument::Matchers::Increment.new(:c, "counter", {})
       .matches?(lambda { StatsD.increment("counter") }))


### PR DESCRIPTION
## Summary

In #331 we introduced some changes that fail tests that rely on using the `tags` option for the Statsd assertion as a RSpec matcher.
If the test would use a matcher like this:

```ruby
expect do
      my_tested_function()
    end.to(trigger_statsd_distribution("time_took_ms", tags: include(
      "foo:true",
      "bar:invalid",
    )))
```

The test would fail because `include` matcher does not answer to `empty?`.


