### PR TITLE
get time in ms directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ section below.
 
 ## Unreleased changes
 
+- Improve time measurement to avoid seconds to milliseconds conversions.
+
 ## Version 3.5.6
 
 - Fix issue from 3.5.5 where tests using RSpec matcher for tag assertion would fail, because the matcher as being

--- a/lib/statsd/instrument/client.rb
+++ b/lib/statsd/instrument/client.rb
@@ -310,16 +310,16 @@ module StatsD
       # @yield The latency (execution time) of the block
       # @return The return value of the provided block will be passed through.
       def latency(name, sample_rate: nil, tags: nil, metric_type: nil, no_prefix: false)
-        start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
         begin
           yield
         ensure
-          stop = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          stop = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
 
           sample_rate ||= @default_sample_rate
           if sample?(sample_rate)
             metric_type ||= datagram_builder(no_prefix: no_prefix).latency_metric_type
-            latency_in_ms = 1000.0 * (stop - start)
+            latency_in_ms = stop - start
             emit(datagram_builder(no_prefix: no_prefix).send(metric_type, name, latency_in_ms, sample_rate, tags))
           end
         end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -95,7 +95,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_measure_with_block
-    Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(0.1, 0.2)
+    Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC, :float_millisecond).returns(100.0, 200.0)
     datagrams = @client.capture do
       @client.measure("foo") {}
     end
@@ -128,7 +128,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_distribution_with_block
-    Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(0.1, 0.2)
+    Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC, :float_millisecond).returns(100.0, 200.0)
     datagrams = @dogstatsd_client.capture do
       @dogstatsd_client.distribution("foo") {}
     end
@@ -137,7 +137,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_latency_emits_ms_metric
-    Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(0.1, 0.2)
+    Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC, :float_millisecond).returns(100.0, 200.0)
     datagrams = @client.capture do
       @client.latency("foo") {}
     end
@@ -146,7 +146,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_latency_on_dogstatsd_prefers_distribution_metric_type
-    Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(0.1, 0.2)
+    Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC, :float_millisecond).returns(100.0, 200.0)
     datagrams = @dogstatsd_client.capture do
       @dogstatsd_client.latency("foo") {}
     end

--- a/test/statsd_test.rb
+++ b/test/statsd_test.rb
@@ -18,7 +18,7 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_measure_with_benchmarked_block_duration
-    Process.stubs(:clock_gettime).returns(5.0, 5.0 + 1.12)
+    Process.stubs(:clock_gettime).returns(5000.0, 5000.0 + 1120.0)
     metric = capture_statsd_call do
       StatsD.measure("values.foobar") { "foo" }
     end
@@ -31,7 +31,7 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_measure_with_return_in_block_still_captures
-    Process.stubs(:clock_gettime).returns(5.0, 6.12)
+    Process.stubs(:clock_gettime).returns(5000.0, 6120.0)
     result = nil
     metric = capture_statsd_call do
       lambda = -> do
@@ -46,7 +46,7 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_measure_with_exception_in_block_still_captures
-    Process.stubs(:clock_gettime).returns(5.0, 6.12)
+    Process.stubs(:clock_gettime).returns(5000.0, 6120.0)
     result = nil
     metric = capture_statsd_call do
       lambda = -> do
@@ -111,7 +111,7 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_distribution_with_benchmarked_block_duration
-    Process.stubs(:clock_gettime).returns(5.0, 5.0 + 1.12)
+    Process.stubs(:clock_gettime).returns(5000.0, 5000.0 + 1120.0)
     metric = capture_statsd_call do
       result = StatsD.distribution("values.foobar") { "foo" }
       assert_equal("foo", result)
@@ -121,7 +121,7 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_distribution_with_return_in_block_still_captures
-    Process.stubs(:clock_gettime).returns(5.0, 5.0 + 1.12)
+    Process.stubs(:clock_gettime).returns(5000.0, 5000.0 + 1120.0)
     result = nil
     metric = capture_statsd_call do
       lambda = -> do
@@ -138,7 +138,7 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_distribution_with_exception_in_block_still_captures
-    Process.stubs(:clock_gettime).returns(5.0, 5.0 + 1.12)
+    Process.stubs(:clock_gettime).returns(5000.0, 5000.0 + 1120.0)
     result = nil
     metric = capture_statsd_call do
       lambda = -> do
@@ -158,7 +158,7 @@ class StatsDTest < Minitest::Test
   end
 
   def test_statsd_distribution_with_block_and_options
-    Process.stubs(:clock_gettime).returns(5.0, 5.0 + 1.12)
+    Process.stubs(:clock_gettime).returns(5000.0, 5000.0 + 1120.0)
     metric = capture_statsd_call do
       StatsD.distribution("values.foobar", tags: ["test"], sample_rate: 0.9) { "foo" }
     end


### PR DESCRIPTION
* 1000.0 is slow and decrease precision.