### PR TITLE
Expose tag_error_class option in strict mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ section below.
 
 ## Unreleased changes
 
+- Allow the `tag_error_class` option for `statsd_count_success` in strict mode.
+
 ## Version 3.5.7
 
 - Improve time measurement to avoid seconds to milliseconds conversions.

--- a/lib/statsd/instrument/strict.rb
+++ b/lib/statsd/instrument/strict.rb
@@ -114,7 +114,8 @@ module StatsD
         super
       end
 
-      def statsd_count_success(method, name, sample_rate: nil, tags: nil, no_prefix: false, client: nil)
+      def statsd_count_success(method, name, sample_rate: nil, tags: nil, no_prefix: false, client: nil,
+        tag_error_class: false)
         check_method_and_metric_name(method, name)
         super
       end


### PR DESCRIPTION
This exposes the `tag_error_class` on `statsd_count_success` in strict mode. Seems like it should be accessible in strict mode since it is not deprecated and has been released for some time (https://github.com/Shopify/statsd-instrument/pull/304).

I did not find any existing tests for strict mode, so I avoided testing this change.

For reviewers:
- Once this delivers, should I open a release commit?