### PR TITLE
Stop variable shadowing from breaking dynamic tags

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -79,8 +79,8 @@ module StatsD
         define_method(method) do |*args, &block|
           client ||= StatsD.singleton_client
           key = StatsD::Instrument.generate_metric_name(name, self, *args)
-          tags = StatsD::Instrument.generate_tags(tags, self, *args)
-          client.measure(key, sample_rate: sample_rate, tags: tags, no_prefix: no_prefix) do
+          generated_tags = StatsD::Instrument.generate_tags(tags, self, *args)
+          client.measure(key, sample_rate: sample_rate, tags: generated_tags, no_prefix: no_prefix) do
             super(*args, &block)
           end
         end
@@ -100,8 +100,8 @@ module StatsD
         define_method(method) do |*args, &block|
           client ||= StatsD.singleton_client
           key = StatsD::Instrument.generate_metric_name(name, self, *args)
-          tags = StatsD::Instrument.generate_tags(tags, self, *args)
-          client.distribution(key, sample_rate: sample_rate, tags: tags, no_prefix: no_prefix) do
+          generated_tags = StatsD::Instrument.generate_tags(tags, self, *args)
+          client.distribution(key, sample_rate: sample_rate, tags: generated_tags, no_prefix: no_prefix) do
             super(*args, &block)
           end
         end
@@ -145,10 +145,10 @@ module StatsD
           client ||= StatsD.singleton_client
           suffix = truthiness == false ? "failure" : "success"
           key = StatsD::Instrument.generate_metric_name(name, self, *args)
-          tags = StatsD::Instrument.generate_tags(tags, self, *args)
-          tags = Helpers.add_tag(tags, :error_class, error.class.name) if tag_error_class && error
+          generated_tags = StatsD::Instrument.generate_tags(tags, self, *args)
+          generated_tags = Helpers.add_tag(generated_tags, :error_class, error.class.name) if tag_error_class && error
 
-          client.increment("#{key}.#{suffix}", sample_rate: sample_rate, tags: tags, no_prefix: no_prefix)
+          client.increment("#{key}.#{suffix}", sample_rate: sample_rate, tags: generated_tags, no_prefix: no_prefix)
         end
       end
     end
@@ -185,8 +185,8 @@ module StatsD
           if truthiness
             client ||= StatsD.singleton_client
             key = StatsD::Instrument.generate_metric_name(name, self, *args)
-            tags = StatsD::Instrument.generate_tags(tags, self, *args)
-            client.increment(key, sample_rate: sample_rate, tags: tags, no_prefix: no_prefix)
+            generated_tags = StatsD::Instrument.generate_tags(tags, self, *args)
+            client.increment(key, sample_rate: sample_rate, tags: generated_tags, no_prefix: no_prefix)
           end
         end
       end
@@ -206,8 +206,8 @@ module StatsD
         define_method(method) do |*args, &block|
           client ||= StatsD.singleton_client
           key = StatsD::Instrument.generate_metric_name(name, self, *args)
-          tags = StatsD::Instrument.generate_tags(tags, self, *args)
-          client.increment(key, sample_rate: sample_rate, tags: tags, no_prefix: no_prefix)
+          generated_tags = StatsD::Instrument.generate_tags(tags, self, *args)
+          client.increment(key, sample_rate: sample_rate, tags: generated_tags, no_prefix: no_prefix)
           super(*args, &block)
         end
       end

--- a/test/statsd_instrumentation_test.rb
+++ b/test/statsd_instrumentation_test.rb
@@ -231,6 +231,9 @@ class StatsDInstrumentationTest < Minitest::Test
     assert_statsd_increment("subgateway.foo", tags: { "key": "foo" }) do
       GatewaySubClass.new.purchase("foo")
     end
+    assert_statsd_increment("subgateway.bar", tags: { "key": "bar" }) do
+      GatewaySubClass.new.purchase("bar")
+    end
   ensure
     ActiveMerchant::Gateway.statsd_remove_count(:ssl_post, metric_namer)
   end
@@ -242,6 +245,9 @@ class StatsDInstrumentationTest < Minitest::Test
 
     assert_statsd_increment("subgateway.foo", tags: { "key": "foo" }) do
       GatewaySubClass.new.purchase("foo")
+    end
+    assert_statsd_increment("subgateway.bar", tags: { "key": "bar" }) do
+      GatewaySubClass.new.purchase("bar")
     end
   ensure
     ActiveMerchant::Gateway.statsd_remove_count(:ssl_post, metric_namer)


### PR DESCRIPTION
## Summary

Fix dynamic tags being evaluated only once.

## Description

Re-assigning the `tags` variable defined outside a block inside the block overrides that value for subsequent calls. That caused dynamic tags to be evaluated once and then be fixed to that first value — rather than being dynamically evaluated on every invocation. By using a unique variable name, this is prevented from happening.

## Example

See the added tests; they fail without the change in this PR.