### PR TITLE
Allow `nil` in `clone_with_options`

### DIFF
--- a/lib/statsd/instrument/client.rb
+++ b/lib/statsd/instrument/client.rb
@@ -417,7 +417,8 @@ module StatsD
           prefix: prefix == NO_CHANGE ? @prefix : prefix,
           default_sample_rate: default_sample_rate == NO_CHANGE ? @default_sample_rate : default_sample_rate,
           default_tags: default_tags == NO_CHANGE ? @default_tags : default_tags,
-          datagram_builder_class: datagram_builder_class == NO_CHANGE ? @datagram_builder_class : datagram_builder_class,
+          datagram_builder_class:
+            datagram_builder_class == NO_CHANGE ? @datagram_builder_class : datagram_builder_class,
         )
       end
 

--- a/lib/statsd/instrument/client.rb
+++ b/lib/statsd/instrument/client.rb
@@ -378,6 +378,8 @@ module StatsD
         ))
       end
 
+      NO_CHANGE = Object.new
+
       # Instantiates a new StatsD client that uses the settings of the current client,
       # except for the provided overrides.
       #
@@ -386,11 +388,11 @@ module StatsD
       #   will be disposed after the block returns
       # @return The return value of the block will be passed on as return value.
       def with_options(
-        sink: nil,
-        prefix: nil,
-        default_sample_rate: nil,
-        default_tags: nil,
-        datagram_builder_class: nil
+        sink: NO_CHANGE,
+        prefix: NO_CHANGE,
+        default_sample_rate: NO_CHANGE,
+        default_tags: NO_CHANGE,
+        datagram_builder_class: NO_CHANGE
       )
         client = clone_with_options(
           sink: sink,
@@ -404,18 +406,18 @@ module StatsD
       end
 
       def clone_with_options(
-        sink: nil,
-        prefix: nil,
-        default_sample_rate: nil,
-        default_tags: nil,
-        datagram_builder_class: nil
+        sink: NO_CHANGE,
+        prefix: NO_CHANGE,
+        default_sample_rate: NO_CHANGE,
+        default_tags: NO_CHANGE,
+        datagram_builder_class: NO_CHANGE
       )
         self.class.new(
-          sink: sink || @sink,
-          prefix: prefix || @prefix,
-          default_sample_rate: default_sample_rate || @default_sample_rate,
-          default_tags: default_tags || @default_tags,
-          datagram_builder_class: datagram_builder_class || @datagram_builder_class,
+          sink: sink == NO_CHANGE ? @sink : sink,
+          prefix: prefix == NO_CHANGE ? @prefix : prefix,
+          default_sample_rate: default_sample_rate == NO_CHANGE ? @default_sample_rate : default_sample_rate,
+          default_tags: default_tags == NO_CHANGE ? @default_tags : default_tags,
+          datagram_builder_class: datagram_builder_class == NO_CHANGE ? @datagram_builder_class : datagram_builder_class,
         )
       end
 

--- a/lib/statsd/instrument/rubocop.rb
+++ b/lib/statsd/instrument/rubocop.rb
@@ -51,7 +51,7 @@ module RuboCop
       end
 
       def keyword_arguments(node)
-        return nil if node.arguments.empty?
+        return if node.arguments.empty?
 
         last_argument = if node.arguments.last&.type == :block_pass
           node.arguments[node.arguments.length - 2]

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -223,4 +223,18 @@ class ClientTest < Minitest::Test
     original_client.increment("metric")
     client_with_other_options.increment("metric")
   end
+
+  def test_clone_can_remove_prefix
+    # Both clients will use the same sink.
+    mock_sink = mock("sink")
+    mock_sink.stubs(:sample?).returns(true)
+    mock_sink.expects(:<<).with("foo.metric:1|c").returns(mock_sink)
+    mock_sink.expects(:<<).with("metric:1|c").returns(mock_sink)
+
+    original_client = StatsD::Instrument::Client.new(sink: mock_sink, prefix: "foo")
+    client_with_other_options = original_client.clone_with_options(prefix: nil)
+
+    original_client.increment("metric")
+    client_with_other_options.increment("metric")
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/Shopify/statsd-instrument/issues/350

This is a first stab at allowing `nil` to override existing values in `clone_with_options`. My biggest concern is that this is technically a breaking change, although the documentation seems to imply that this behaviour is how it's supposed to work.