### PR TITLE
Renaming references to old master branch

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,13 +24,13 @@ jobs:
 
     - uses: actions/checkout@v1
       with:
-        ref: 'master'
+        ref: 'main'
 
     - name: Install dependencies if needed
       run: bundle check || bundle install --jobs 4 --retry 3
 
-    - name: Run benchmark on master
+    - name: Run benchmark on main
       run: benchmark/send-metrics-to-local-udp-receiver
 
-    - name: Run throughput benchmark on master
+    - name: Run throughput benchmark on main
       run: benchmark/local-udp-throughput

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -23,7 +23,7 @@ To benchmark your changes:
      be available if you check out another branch.
 2. Run these scripts on your pull request branch. The results will be stored in
    a temporary file.
-3. Checkout the latest version of `master`.
+3. Checkout the latest version of `main`.
 4. Run the benchmark again. The benchmark script will now print a comparison
-   between your branch and master.
+   between your branch and main.
 5. Include the output in your pull request description.

--- a/benchmark/send-metrics-to-dev-null-log
+++ b/benchmark/send-metrics-to-dev-null-log
@@ -6,9 +6,9 @@ require "tmpdir"
 require "benchmark/ips"
 
 revision = %x(git rev-parse HEAD).rstrip
-base_revision = %x(git rev-parse origin/master).rstrip
+base_revision = %x(git rev-parse origin/main).rstrip
 branch = if revision == base_revision
-  "master"
+  "main"
 else
   %x(git rev-parse --abbrev-ref HEAD).rstrip
 end
@@ -39,7 +39,7 @@ end
 
 if report.entries.length == 1
   puts
-  puts "To compare the performance of this revision against another revision (e.g. master),"
+  puts "To compare the performance of this revision against another revision (e.g. main),"
   puts "check out a different branch and run this benchmark script again."
 elsif ENV["KEEP_RESULTS"]
   puts

--- a/benchmark/send-metrics-to-local-udp-receiver
+++ b/benchmark/send-metrics-to-local-udp-receiver
@@ -20,9 +20,9 @@ end
 
 def benchmark_implementation(name, env = {})
   revision = %x(git rev-parse HEAD).rstrip
-  base_revision = %x(git rev-parse origin/master).rstrip
+  base_revision = %x(git rev-parse origin/main).rstrip
   branch = if revision == base_revision
-    "master"
+    "main"
   else
     %x(git rev-parse --abbrev-ref HEAD).rstrip
   end
@@ -60,7 +60,7 @@ def benchmark_implementation(name, env = {})
 
   if report.entries.length == 1
     puts
-    puts "To compare the performance of this revision against another revision (e.g. master),"
+    puts "To compare the performance of this revision against another revision (e.g. main),"
     puts "check out a different branch and run this benchmark script again."
   elsif ENV["KEEP_RESULTS"]
     puts


### PR DESCRIPTION
## Summary

We are cleaning up the repo to resolve references to the `master` branch and to use `main` now, in a commitment to inclusion, an effort done throughout Shopify repos.
