### PR TITLE
Handle empty tags regression (bump version to 3.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ section below.
 
 ## Unreleased changes
 
+## Version 3.6.1
+
+- Fix `ArgumentError` when passing an empty Hash as tags.
+
 ## Version 3.6.0
 
 - Optimized datagram building.

--- a/lib/statsd/instrument/datagram_builder.rb
+++ b/lib/statsd/instrument/datagram_builder.rb
@@ -79,7 +79,7 @@ module StatsD
           datagram << @default_tags
         end
 
-        unless tags.nil?
+        unless tags.nil? || tags.empty?
           datagram << (@default_tags.nil? ? "|#" : ",")
           compile_tags(tags, datagram)
         end

--- a/lib/statsd/instrument/dogstatsd_datagram_builder.rb
+++ b/lib/statsd/instrument/dogstatsd_datagram_builder.rb
@@ -49,7 +49,7 @@ module StatsD
           datagram << @default_tags
         end
 
-        unless tags.nil?
+        unless tags.nil? || tags.empty?
           datagram << (@default_tags.nil? ? "|#" : ",")
           compile_tags(tags, datagram)
         end
@@ -80,7 +80,7 @@ module StatsD
           datagram << @default_tags
         end
 
-        unless tags.nil?
+        unless tags.nil? || tags.empty?
           datagram << (@default_tags.nil? ? "|#" : ",")
           compile_tags(tags, datagram)
         end

--- a/lib/statsd/instrument/version.rb
+++ b/lib/statsd/instrument/version.rb
@@ -2,6 +2,6 @@
 
 module StatsD
   module Instrument
-    VERSION = "3.6.0"
+    VERSION = "3.6.1"
   end
 end

--- a/test/datagram_builder_test.rb
+++ b/test/datagram_builder_test.rb
@@ -76,6 +76,12 @@ class DatagramBuilderTest < Minitest::Test
   end
 
   def test_tags
+    datagram = @datagram_builder.d("foo", 10, nil, {})
+    assert_equal("foo:10|d", datagram)
+
+    datagram = @datagram_builder.d("foo", 10, nil, [])
+    assert_equal("foo:10|d", datagram)
+
     datagram = @datagram_builder.d("foo", 10, nil, ["foo", "bar"])
     assert_equal("foo:10|d|#foo,bar", datagram)
 


### PR DESCRIPTION
Passing `tags: {}` would generate an invalid datagram.