### PR TITLE
Expose sink.flush

### DIFF
--- a/lib/statsd/instrument/batched_udp_sink.rb
+++ b/lib/statsd/instrument/batched_udp_sink.rb
@@ -55,6 +55,10 @@ module StatsD
         @dispatcher.shutdown(*args)
       end
 
+      def flush(blocking:)
+        @dispatcher.flush(blocking: blocking)
+      end
+
       class Buffer < SizedQueue
         def push_nonblock(item)
           push(item, true)
@@ -104,10 +108,6 @@ module StatsD
           flush(blocking: false)
         end
 
-        private
-
-        NEWLINE = "\n".b.freeze
-
         def flush(blocking:)
           packet = "".b
           next_datagram = nil
@@ -136,6 +136,10 @@ module StatsD
             packet.clear
           end
         end
+
+        private
+
+        NEWLINE = "\n".b.freeze
 
         def thread_healthcheck
           # TODO: We have a race condition on JRuby / Truffle here. It could cause multiple

--- a/lib/statsd/instrument/capture_sink.rb
+++ b/lib/statsd/instrument/capture_sink.rb
@@ -26,6 +26,10 @@ module StatsD
       def clear
         @datagrams.clear
       end
+
+      def flush(blocking:)
+        @parent.flush(blocking: blocking)
+      end
     end
   end
 end

--- a/lib/statsd/instrument/log_sink.rb
+++ b/lib/statsd/instrument/log_sink.rb
@@ -23,6 +23,10 @@ module StatsD
         logger.add(severity, "[StatsD] #{datagram.chomp}")
         self
       end
+
+      def flush(blocking:)
+        # noop
+      end
     end
   end
 end

--- a/lib/statsd/instrument/null_sink.rb
+++ b/lib/statsd/instrument/null_sink.rb
@@ -12,6 +12,10 @@ module StatsD
       def <<(_datagram)
         self # noop
       end
+
+      def flush(blocking:)
+        # noop
+      end
     end
   end
 end

--- a/lib/statsd/instrument/udp_sink.rb
+++ b/lib/statsd/instrument/udp_sink.rb
@@ -53,6 +53,10 @@ module StatsD
         self
       end
 
+      def flush(blocking:)
+        # noop
+      end
+
       private
 
       def invalidate_socket


### PR DESCRIPTION
Allow application code to flush any buffered stats. This is particularly useful for the `BatchedUDPSink`, and is a noop for other sinks.