### PR TITLE
Clean up some test noise

### DIFF
--- a/test/environment_test.rb
+++ b/test/environment_test.rb
@@ -57,6 +57,9 @@ class EnvironmentTest < Minitest::Test
   end
 
   def test_client_from_env_uses_regular_udp_sink_when_flush_interval_is_0
+    StatsD::Instrument::Environment.any_instance.expects(:warn).with(
+      "STATSD_FLUSH_INTERVAL=0.0 is deprecated, please set STATSD_BUFFER_CAPACITY=0 instead.",
+    ).once
     env = StatsD::Instrument::Environment.new(
       "STATSD_USE_NEW_CLIENT" => "1",
       "STATSD_ENV" => "staging",

--- a/test/udp_sink_test.rb
+++ b/test/udp_sink_test.rb
@@ -152,6 +152,7 @@ module UDPSinkTests
         socket.expects(:close).in_sequence(seq)
         socket.expects(:connect).with("localhost", 8125).in_sequence(seq)
         socket.expects(:send).twice.returns(1).in_sequence(seq)
+        socket.expects(:close).in_sequence(seq)
 
         udp_sink = build_sink("localhost", 8125)
         udp_sink << "foo:1|c"
@@ -164,6 +165,8 @@ module UDPSinkTests
         )
       ensure
         StatsD.logger = previous_logger
+        # Make sure our fake socket is closed so that it doesn't interfere with other tests
+        udp_sink&.send(:invalidate_socket)
       end
     end
   end


### PR DESCRIPTION
I was having problems with sporadic output from the tests, e.g.

```
rake TESTOPTS="--seed=46384" test                                                       
Run options: --seed=46384                                                                                                                                      
                                                                                                                                                               
# Running:                                                                                                                                                     
                                                                                                                                                               
............................................/opt/rubies/ruby-3.1.4-pshopify1/lib/ruby/3.1.0/psych/nodes/scalar.rb:65: warning: Exception in finalizer #<Proc:0x
00007f76b40897d8 /home/spin/src/github.com/Shopify/statsd-instrument/lib/statsd/instrument/udp_sink.rb:17 (lambda)>                                            
/home/spin/src/github.com/Shopify/statsd-instrument/lib/statsd/instrument/udp_sink.rb:20:in `block (2 levels) in <class:UDPSink>': #<Mock:socket> was instantia
ted in one test but it is receiving invocations within another test. This can lead to unintended interactions between tests and hence unexpected test failures.
 Ensure that every test correctly cleans up any state that it introduces. (Mocha::StubbingError)                                                               
        from /home/spin/src/github.com/Shopify/statsd-instrument/lib/statsd/instrument/udp_sink.rb:18:in `each'                                                
        from /home/spin/src/github.com/Shopify/statsd-instrument/lib/statsd/instrument/udp_sink.rb:18:in `block in <class:UDPSink>'                            
        from /opt/rubies/ruby-3.1.4-pshopify1/lib/ruby/3.1.0/psych/nodes/scalar.rb:65:in `initialize'                                                          
        from /opt/rubies/ruby-3.1.4-pshopify1/lib/ruby/3.1.0/psych/tree_builder.rb:97:in `new'                                                                 
        from /opt/rubies/ruby-3.1.4-pshopify1/lib/ruby/3.1.0/psych/tree_builder.rb:97:in `scalar'                              
...
```

I think this could be because the mock socket doesn't necessarily get cleaned up right away after the UDP sink tests execute.

I also added an expectation for the environment test mainly to avoid that warning from spamming the console every time tests are run.