### PR TITLE
Add statistics to the BatchedUDPSink

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ The following environment variables are supported:
   If your network is properly configured to handle larger packets you may try
   to increase this value for better performance, but most network can't handle
   larger packets.
+- `STATSD_BATCH_STATISTICS_INTERVAL`: (default: "0") If non-zero, the `BatchedUDPSink`
+  will track and emit statistics on this interval to the default sink for your environment.
+  The current tracked statistics are:
+
+  - `statsd_instrument.batched_udp_sink.batched_sends`: The number of batches sent, of any size.
+  - `statsd_instrument.batched_udp_sink.synchronous_sends`: The number of times the batched udp sender needed to send a statsd line synchronously, due to the buffer being full.
+  - `statsd_instrument.batched_udp_sink.avg_buffer_length`: The average buffer length, measured at the beginning of each batch.
+  - `statsd_instrument.batched_udp_sink.avg_batched_packet_size`: The average per-batch byte size of the packet sent to the underlying UDPSink.
+  - `statsd_instrument.batched_udp_sink.avg_batch_length`: The average number of statsd lines per batch.
+
 
 ## StatsD keys
 

--- a/lib/statsd/instrument/environment.rb
+++ b/lib/statsd/instrument/environment.rb
@@ -98,6 +98,13 @@ module StatsD
         Float(env.fetch("STATSD_MAX_PACKET_SIZE", StatsD::Instrument::BatchedUDPSink::DEFAULT_MAX_PACKET_SIZE))
       end
 
+      def statsd_batch_statistics_interval
+        Integer(env.fetch(
+          "STATSD_BATCH_STATISTICS_INTERVAL",
+          StatsD::Instrument::BatchedUDPSink::DEFAULT_STATISTICS_INTERVAL,
+        ))
+      end
+
       def client
         StatsD::Instrument::Client.from_env(self)
       end
@@ -110,6 +117,7 @@ module StatsD
               statsd_addr,
               buffer_capacity: statsd_buffer_capacity,
               max_packet_size: statsd_max_packet_size,
+              statistics_interval: statsd_batch_statistics_interval,
             )
           else
             StatsD::Instrument::UDPSink.for_addr(statsd_addr)

--- a/test/dispatcher_stats_test.rb
+++ b/test/dispatcher_stats_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DispatcherStatsTest < Minitest::Test
+  include StatsD::Instrument::Assertions
+
+  def test_maybe_flush
+    stats = StatsD::Instrument::BatchedUDPSink::DispatcherStats.new(0)
+
+    stats.increment_synchronous_sends
+    stats.increment_batched_sends(1, 1, 1)
+
+    expectations = [
+      StatsD::Instrument::Expectation.increment("statsd_instrument.batched_udp_sink.synchronous_sends", 1),
+      StatsD::Instrument::Expectation.increment("statsd_instrument.batched_udp_sink.batched_sends", 1),
+      StatsD::Instrument::Expectation.gauge("statsd_instrument.batched_udp_sink.avg_buffer_length", 1),
+      StatsD::Instrument::Expectation.gauge("statsd_instrument.batched_udp_sink.avg_batched_packet_size", 1),
+      StatsD::Instrument::Expectation.gauge("statsd_instrument.batched_udp_sink.avg_batch_length", 1),
+    ]
+    assert_statsd_expectations(expectations) { stats.maybe_flush! }
+    assert_equal(0, stats.instance_variable_get(:@synchronous_sends))
+    assert_equal(0, stats.instance_variable_get(:@batched_sends))
+    assert_equal(0, stats.instance_variable_get(:@avg_buffer_length))
+    assert_equal(0, stats.instance_variable_get(:@avg_batched_packet_size))
+    assert_equal(0, stats.instance_variable_get(:@avg_batch_length))
+
+    stats = StatsD::Instrument::BatchedUDPSink::DispatcherStats.new(1)
+    stats.increment_batched_sends(1, 1, 1)
+    assert_no_statsd_calls { stats.maybe_flush! }
+  end
+
+  def test_calculations_are_correct
+    stats = StatsD::Instrument::BatchedUDPSink::DispatcherStats.new(0)
+
+    5.times { stats.increment_synchronous_sends }
+    assert_equal(5, stats.instance_variable_get(:@synchronous_sends))
+
+    batches = [
+      { buffer_len: 100, packet_size: 1472, batch_len: 10 },
+      { buffer_len: 90,  packet_size: 1300, batch_len: 20 },
+      { buffer_len: 110, packet_size: 1470, batch_len: 8  },
+      { buffer_len: 500, packet_size: 1000, batch_len: 1  },
+      { buffer_len: 100, packet_size: 30,   batch_len: 99 },
+    ]
+    batches.each do |batch|
+      stats.increment_batched_sends(batch[:buffer_len], batch[:packet_size], batch[:batch_len])
+    end
+    assert_equal(batches.length, stats.instance_variable_get(:@batched_sends))
+    assert_equal(
+      batches.map { |b|
+        b[:buffer_len]
+      }.sum / batches.length,
+      stats.instance_variable_get(:@avg_buffer_length),
+    )
+    assert_equal(
+      batches.map { |b|
+        b[:packet_size]
+      }.sum / batches.length,
+      stats.instance_variable_get(:@avg_batched_packet_size),
+    )
+    assert_equal(
+      batches.map { |b|
+        b[:batch_len]
+      }.sum / batches.length,
+      stats.instance_variable_get(:@avg_batch_length),
+    )
+  end
+end


### PR DESCRIPTION
This commit tracks a few simple statistics around the performance of the
BatchedUDPSink:
- number of batches sent
- number of synchronous sends, due to the buffer being full
- average length of batched packets
- average number of statsd lines in batched packets
- average number of statsd lines in the buffer (measured at the
  beginning of a batch)

We add a new option `STATSD_BATCH_STATISTICS_INTERVAL` (default: 0),
which when set to any non-zero value, will track and flush statistics at
that same interval.

To do this, we need to use a mutex for synchronization. Local benchmarks
indicate that the performance impact is minimal, if not non-existent:

```
zsh ❯ ./send-metrics-to-dev-null-log
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
Warming up --------------------------------------
StatsD metrics to /dev/null log (branch: main, sha: https://github.com/Shopify/statsd-instrument/commit/3c944c95d103e84cd04671c27dc57e965ad21166)
                        11.805k i/100ms
Calculating -------------------------------------
StatsD metrics to /dev/null log (branch: main, sha: https://github.com/Shopify/statsd-instrument/commit/3c944c95d103e84cd04671c27dc57e965ad21166)
                        129.435k (± 1.9%) i/s -    649.275k in   5.018026s

Comparison:
StatsD metrics to /dev/null log (branch: ahayworth/batched-udp-stats-wow-such-meta, sha: cb6297d):   130488.2 i/s
StatsD metrics to /dev/null log (branch: main, sha: https://github.com/Shopify/statsd-instrument/commit/3c944c95d103e84cd04671c27dc57e965ad21166):   129434.7 i/s - same-ish: difference falls within error
```

```
zsh ❯ ./send-metrics-to-local-udp-receiver
===== UDP sync =====
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
Warming up --------------------------------------
UDP sync (branch: main, sha: https://github.com/Shopify/statsd-instrument/commit/3c944c95d103e84cd04671c27dc57e965ad21166)
                         2.173k i/100ms
Calculating -------------------------------------
UDP sync (branch: main, sha: https://github.com/Shopify/statsd-instrument/commit/3c944c95d103e84cd04671c27dc57e965ad21166)
                         20.776k (± 7.6%) i/s -    104.304k in   5.058975s

Comparison:
UDP sync (branch: ahayworth/batched-udp-stats-wow-such-meta, sha: cb6297d):    21049.0 i/s
UDP sync (branch: main, sha: https://github.com/Shopify/statsd-instrument/commit/3c944c95d103e84cd04671c27dc57e965ad21166):    20776.0 i/s - same-ish: difference falls within error

================
===== UDP batched =====
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
Warming up --------------------------------------
UDP batched (branch: main, sha: https://github.com/Shopify/statsd-instrument/commit/3c944c95d103e84cd04671c27dc57e965ad21166)
                         8.699k i/100ms
Calculating -------------------------------------
UDP batched (branch: main, sha: https://github.com/Shopify/statsd-instrument/commit/3c944c95d103e84cd04671c27dc57e965ad21166)
                         86.768k (± 1.6%) i/s -    434.950k in   5.014276s

Comparison:
UDP batched (branch: ahayworth/batched-udp-stats-wow-such-meta, sha: cb6297d):    87104.6 i/s
UDP batched (branch: main, sha: https://github.com/Shopify/statsd-instrument/commit/3c944c95d103e84cd04671c27dc57e965ad21166):    86767.6 i/s - same-ish: difference falls within error
```

Of course, we are doing more work when the option is enabled, so
technically there must be *some* impact to it. However, at least in
local micro-benchmarks, it certainly seems acceptable.