### PR TITLE
Benchmarks: adding benchmarks with more series and compare against other libs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,4 @@ gem "yard"
 gem "rubocop", ">= 1.0"
 gem "rubocop-shopify", require: false
 gem "benchmark-ips"
-
-group :development do
-  gem "dogstatsd-ruby", "~> 5.0", require: false
-end
+gem "dogstatsd-ruby", "~> 5.0", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,7 @@ gem "yard"
 gem "rubocop", ">= 1.0"
 gem "rubocop-shopify", require: false
 gem "benchmark-ips"
+
+group :development do
+  gem "dogstatsd-ruby", "~> 5.0", require: false
+end

--- a/benchmark/local-udp-throughput
+++ b/benchmark/local-udp-throughput
@@ -72,7 +72,7 @@ EVENTS_PER_ITERATION = 6
 ITERATIONS = Integer(ENV.fetch("ITERATIONS", 10_000))
 SERIES_COUNT = Integer(ENV.fetch("SERIES_COUNT", 0))
 
-def benchmark_implementation(name, env = {})
+def benchmark_implementation(name, env = {}, datadog_client = false)
   intermediate_results_filename = "#{Dir.tmpdir}/statsd-instrument-benchmarks/"
   log_filename = "#{Dir.tmpdir}/statsd-instrument-benchmarks/#{File.basename($PROGRAM_NAME)}-#{name}.log"
   FileUtils.mkdir_p(File.dirname(intermediate_results_filename))
@@ -91,7 +91,7 @@ def benchmark_implementation(name, env = {})
     "STATSD_ENV" => "production",
   ).merge(env)).client
 
-  if name.start_with?("Datadog Client")
+  if datadog_client
     statsd = Datadog::Statsd.new(receiver.addr[2], receiver.addr[1], **env)
     udp_client = DatadogShim.new(statsd)
   end
@@ -111,7 +111,7 @@ def benchmark_implementation(name, env = {})
   end
   start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
   threads.each(&:join)
-  if name.start_with?("Datadog Client")
+  if datadog_client
     udp_client.close
   end
   receiver.close
@@ -125,5 +125,5 @@ end
 
 benchmark_implementation("UDP sync", "STATSD_BUFFER_CAPACITY" => "0")
 benchmark_implementation("UDP batched")
-benchmark_implementation("Datadog Client - single thread", single_thread: true, delay_serialization: true)
-benchmark_implementation("Datadog Client - multi-thread", single_thread: false, delay_serialization: true)
+benchmark_implementation("Datadog Client - single thread", {single_thread: true, delay_serialization: true}, true)
+benchmark_implementation("Datadog Client - multi-thread", {single_thread: false, delay_serialization: true}, true)

--- a/benchmark/local-udp-throughput
+++ b/benchmark/local-udp-throughput
@@ -76,6 +76,7 @@ def benchmark_implementation(name, env = {})
   intermediate_results_filename = "#{Dir.tmpdir}/statsd-instrument-benchmarks/"
   log_filename = "#{Dir.tmpdir}/statsd-instrument-benchmarks/#{File.basename($PROGRAM_NAME)}-#{name}.log"
   FileUtils.mkdir_p(File.dirname(intermediate_results_filename))
+  FileUtils.mkdir_p(File.dirname(log_filename))
 
   # Set up an UDP listener to which we can send StatsD packets
   receiver = UDPSocket.new

--- a/benchmark/local-udp-throughput
+++ b/benchmark/local-udp-throughput
@@ -6,6 +6,45 @@ require "benchmark/ips"
 require "tmpdir"
 require "socket"
 require "statsd-instrument"
+require "datadog/statsd"
+require "forwardable"
+
+class DatadogShim
+  extend Forwardable
+
+  def_delegator :@client, :close
+  # This is a shim to make the Datadog client compatible with the StatsD client
+  # interface. It's not a complete implementation, but it's enough to run the
+  # benchmarks.
+  # @param [Datadog::Statsd] client
+  def initialize(client)
+    @client = client
+  end
+
+  def increment(stat, value = 1, tags: nil)
+    @client.increment(stat, value: value, tags: tags)
+  end
+
+  def measure(stat, value = nil, tags: nil, &block)
+    @client.time(stat, value: value, tags: tags, &block)
+  end
+
+  def gauge(stat, value, tags: nil)
+    @client.gauge(stat, value: value, tags: tags)
+  end
+
+  def set(stat, value, tags: nil)
+    @client.set(stat, value: value, tags: tags)
+  end
+
+  def event(title, text, tags: nil)
+    @client.event(title, text, tags: tags)
+  end
+
+  def service_check(name, status, tags: nil)
+    @client.service_check(name, status, tags: tags)
+  end
+end
 
 def send_metrics(client)
   client.increment("StatsD.increment", 10)
@@ -16,9 +55,23 @@ def send_metrics(client)
   client.service_check("StatsD.service_check", "ok")
 end
 
+def send_metrics_high_cardinality(client)
+  SERIES_COUNT.times do |i|
+    tags = ["series:#{i}", "foo:bar", "baz:quc"]
+    client.increment("StatsD.increment", 10, tags: tags)
+    client.measure("StatsD.measure", tags: tags) { 1 + 1 }
+    client.gauge("StatsD.gauge", 12.0, tags: tags)
+    client.set("StatsD.set", "value", tags: tags)
+    client.event("StasD.event", "12345", tags: tags)
+    client.service_check("StatsD.service_check", "ok", tags: tags)
+  end
+end
+
 THREAD_COUNT = Integer(ENV.fetch("THREAD_COUNT", 5))
 EVENTS_PER_ITERATION = 6
-ITERATIONS = 50_000
+ITERATIONS = Integer(ENV.fetch("ITERATIONS", 10_000))
+SERIES_COUNT = Integer(ENV.fetch("SERIES_COUNT", 0))
+
 def benchmark_implementation(name, env = {})
   intermediate_results_filename = "#{Dir.tmpdir}/statsd-instrument-benchmarks/"
   log_filename = "#{Dir.tmpdir}/statsd-instrument-benchmarks/#{File.basename($PROGRAM_NAME)}-#{name}.log"
@@ -37,23 +90,39 @@ def benchmark_implementation(name, env = {})
     "STATSD_ENV" => "production",
   ).merge(env)).client
 
-  puts "===== #{name} throughtput (#{THREAD_COUNT} threads) ====="
+  if name.start_with?("Datadog Client")
+    statsd = Datadog::Statsd.new(receiver.addr[2], receiver.addr[1], **env)
+    udp_client = DatadogShim.new(statsd)
+  end
+
+  puts "===== #{name} throughput (#{THREAD_COUNT} threads) ====="
   threads = THREAD_COUNT.times.map do
     Thread.new do
       count = ITERATIONS
       while (count -= 1) > 0
-        send_metrics(udp_client)
+        if SERIES_COUNT.zero?
+          send_metrics(udp_client)
+        else
+          send_metrics_high_cardinality(udp_client)
+        end
       end
     end
   end
   start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
   threads.each(&:join)
-  duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
-  events_sent = THREAD_COUNT * EVENTS_PER_ITERATION * ITERATIONS
-  puts "events: #{(events_sent / duration).round(1)}/s"
+  if name.start_with?("Datadog Client")
+    udp_client.close
+  end
   receiver.close
   udp_client.shutdown if udp_client.respond_to?(:shutdown)
+
+  duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+  series = SERIES_COUNT.zero? ? 1 : SERIES_COUNT
+  events_sent = THREAD_COUNT * EVENTS_PER_ITERATION * ITERATIONS * series
+  puts "events: #{(events_sent / duration).round(1).to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse}/s"
 end
 
 benchmark_implementation("UDP sync", "STATSD_BUFFER_CAPACITY" => "0")
 benchmark_implementation("UDP batched")
+benchmark_implementation("Datadog Client - single thread", single_thread: true, delay_serialization: true)
+benchmark_implementation("Datadog Client - multi-thread", single_thread: false, delay_serialization: true)

--- a/benchmark/local-udp-throughput
+++ b/benchmark/local-udp-throughput
@@ -125,5 +125,5 @@ end
 
 benchmark_implementation("UDP sync", "STATSD_BUFFER_CAPACITY" => "0")
 benchmark_implementation("UDP batched")
-benchmark_implementation("Datadog Client - single thread", {single_thread: true, delay_serialization: true}, true)
-benchmark_implementation("Datadog Client - multi-thread", {single_thread: false, delay_serialization: true}, true)
+benchmark_implementation("Datadog Client - single thread", { single_thread: true, delay_serialization: true }, true)
+benchmark_implementation("Datadog Client - multi-thread", { single_thread: false, delay_serialization: true }, true)


### PR DESCRIPTION
## Summary

Our benchmarks currently focus solely in serialization, we would benefit from having some tests focused also on scenarios where we have more cardinality. In this PR I am introducing a SERIES_COUNT parameter to inject different label combinations on the metrics we produce and also I am including the time to close/shutdown the client on the processing time, since we might clear buffers and finish actually pushing metrics.

Apart from that, I am also comparing our implementation against the official one from Datadog.


The new benchmark results on my machine (Apple M3 Pro (11) @ 4.06 GHz) are:

```
▶ time ITERATIONS=10 SERIES_COUNT=4000 THREAD_COUNT=10 ./benchmark/local-udp-throughput                                                                                                                                                                                                               🕙 10:12:44 
===== UDP sync throughput (10 threads) =====
events: 141,326.1/s
===== UDP batched throughput (10 threads) =====
events: 306,235.9/s
===== Datadog Client - single thread throughput (10 threads) =====
events: 299,073.5/s
===== Datadog Client - multi-thread throughput (10 threads) =====
events: 1,014,260.5/s
ITERATIONS=10 SERIES_COUNT=4000 THREAD_COUNT=10   21.93s user 24.03s system 129% cpu 35.593 total
```



