### PR TITLE
Release 3.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ section below.
 
 ## Unreleased changes
 
+## Version 3.8.0
+
+- UDP batching will now track statistics about its own batching performance, and
+  emit those statistics to the default sink when `STATSD_BATCH_STATISTICS_INTERVAL`
+  is set to any non-zero value. The default value is zero; additional information
+  on statistics tracked is available in the README.
+
 ## Version 3.7.0
 
 - Add public `.flush` method to sink classes.

--- a/lib/statsd/instrument/version.rb
+++ b/lib/statsd/instrument/version.rb
@@ -2,6 +2,6 @@
 
 module StatsD
   module Instrument
-    VERSION = "3.7.0"
+    VERSION = "3.8.0"
   end
 end


### PR DESCRIPTION
Release 3.8.0 contains the batched udp statistics tracking, disabled by default.
