### PR TITLE
UDS Sink + async UDS sink batched

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,10 @@ gem "rubocop", ">= 1.0"
 gem "rubocop-shopify", require: false
 gem "benchmark-ips"
 gem "dogstatsd-ruby", "~> 5.0", require: false
+
+platform :mri do
+  # only if Ruby is MRI && >= 3.2
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.2")
+    gem "vernier", require: false
+  end
+end

--- a/benchmark/local-udp-throughput
+++ b/benchmark/local-udp-throughput
@@ -8,6 +8,7 @@ require "socket"
 require "statsd-instrument"
 require "datadog/statsd"
 require "forwardable"
+require "vernier"
 
 class DatadogShim
   extend Forwardable
@@ -21,12 +22,25 @@ class DatadogShim
     @client = client
   end
 
+  class NullSink
+    def flush(blocking: false)
+    end
+  end
+
+  def sink
+    @sink ||= NullSink.new
+  end
+
   def increment(stat, value = 1, tags: nil)
     @client.increment(stat, value: value, tags: tags)
   end
 
   def measure(stat, value = nil, tags: nil, &block)
     @client.time(stat, value: value, tags: tags, &block)
+  end
+
+  def histogram(stat, value = nil, tags: nil, &block)
+    @client.histogram(stat, value: value, tags: tags, &block)
   end
 
   def gauge(stat, value, tags: nil)
@@ -50,9 +64,6 @@ def send_metrics(client)
   client.increment("StatsD.increment", 10)
   client.measure("StatsD.measure") { 1 + 1 }
   client.gauge("StatsD.gauge", 12.0, tags: ["foo:bar", "quc"])
-  client.set("StatsD.set", "value", tags: { foo: "bar", baz: "quc" })
-  client.event("StasD.event", "12345")
-  client.service_check("StatsD.service_check", "ok")
 end
 
 def send_metrics_high_cardinality(client)
@@ -61,26 +72,45 @@ def send_metrics_high_cardinality(client)
     client.increment("StatsD.increment", 10, tags: tags)
     client.measure("StatsD.measure", tags: tags) { 1 + 1 }
     client.gauge("StatsD.gauge", 12.0, tags: tags)
-    client.set("StatsD.set", "value", tags: tags)
-    client.event("StasD.event", "12345", tags: tags)
-    client.service_check("StatsD.service_check", "ok", tags: tags)
   end
 end
 
+SOCKET_PATH = File.join(Dir.pwd, "tmp/metric.sock")
 THREAD_COUNT = Integer(ENV.fetch("THREAD_COUNT", 5))
-EVENTS_PER_ITERATION = 6
+EVENTS_PER_ITERATION = 3
 ITERATIONS = Integer(ENV.fetch("ITERATIONS", 10_000))
 SERIES_COUNT = Integer(ENV.fetch("SERIES_COUNT", 0))
+ENABLE_PROFILING = ENV.key?("ENABLE_PROFILING")
+
+LOG_DIR = File.join(Dir.tmpdir, "statsd-instrument-benchmarks")
+FileUtils.mkdir_p(LOG_DIR)
+puts "Logs are stored in #{LOG_DIR}"
 
 def benchmark_implementation(name, env = {}, datadog_client = false)
   intermediate_results_filename = "#{Dir.tmpdir}/statsd-instrument-benchmarks/"
-  log_filename = "#{Dir.tmpdir}/statsd-instrument-benchmarks/#{File.basename($PROGRAM_NAME)}-#{name}.log"
+  log_filename = File.join(LOG_DIR, "#{File.basename($PROGRAM_NAME)}-#{name}.log".tr(" ", "_"))
   FileUtils.mkdir_p(File.dirname(intermediate_results_filename))
   FileUtils.mkdir_p(File.dirname(log_filename))
 
   # Set up an UDP listener to which we can send StatsD packets
   receiver = UDPSocket.new
   receiver.bind("localhost", 0)
+
+  FileUtils.mkdir_p(File.dirname(SOCKET_PATH))
+  FileUtils.rm_f(SOCKET_PATH)
+  receiver_uds = Socket.new(Socket::AF_UNIX, Socket::SOCK_DGRAM)
+  receiver_uds.setsockopt(Socket::SOL_SOCKET, Socket::SO_REUSEADDR, true)
+  receiver_uds.setsockopt(Socket::SOL_SOCKET, Socket::SO_RCVBUF, 32768 * THREAD_COUNT)
+  receiver_uds.bind(Socket.pack_sockaddr_un(SOCKET_PATH))
+  # with UDS we have to take data out of the socket, otherwise it will fill up
+  # and we will block writing to it (which is what we are testing)
+  consume = Thread.new do
+    loop do
+      receiver_uds.recv(32768)
+    rescue
+      # Ignored
+    end
+  end
 
   log_file = File.open(log_filename, "w+", level: Logger::WARN)
   StatsD.logger = Logger.new(log_file)
@@ -96,7 +126,10 @@ def benchmark_implementation(name, env = {}, datadog_client = false)
     udp_client = DatadogShim.new(statsd)
   end
 
-  puts "===== #{name} throughput (#{THREAD_COUNT} threads) ====="
+  series = SERIES_COUNT.zero? ? 1 : SERIES_COUNT
+  events_sent = THREAD_COUNT * EVENTS_PER_ITERATION * ITERATIONS * series
+  puts "===== #{name} throughput (#{THREAD_COUNT} threads) - total events: #{events_sent} ====="
+  start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
   threads = THREAD_COUNT.times.map do
     Thread.new do
       count = ITERATIONS
@@ -109,21 +142,60 @@ def benchmark_implementation(name, env = {}, datadog_client = false)
       end
     end
   end
-  start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
   threads.each(&:join)
+  udp_client.shutdown if udp_client.respond_to?(:shutdown)
   if datadog_client
     udp_client.close
   end
-  receiver.close
-  udp_client.shutdown if udp_client.respond_to?(:shutdown)
 
   duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+
+  consume.kill
+  receiver.close
+  receiver_uds.close
+
   series = SERIES_COUNT.zero? ? 1 : SERIES_COUNT
   events_sent = THREAD_COUNT * EVENTS_PER_ITERATION * ITERATIONS * series
   puts "events: #{(events_sent / duration).round(1).to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse}/s"
 end
 
+if ENABLE_PROFILING
+  Vernier.start_profile(out: "tmp/benchmark_profile_udp_sync.json")
+end
 benchmark_implementation("UDP sync", "STATSD_BUFFER_CAPACITY" => "0")
+if ENABLE_PROFILING
+  Vernier.stop_profile
+end
+
+if ENABLE_PROFILING
+  Vernier.start_profile(out: "tmp/benchmark_profile_udp_async.json")
+end
 benchmark_implementation("UDP batched")
-benchmark_implementation("Datadog Client - single thread", { single_thread: true, delay_serialization: true }, true)
-benchmark_implementation("Datadog Client - multi-thread", { single_thread: false, delay_serialization: true }, true)
+if ENABLE_PROFILING
+  Vernier.stop_profile
+end
+
+if ENABLE_PROFILING
+  Vernier.start_profile(out: "tmp/benchmark_profile_uds_small_packet.json")
+end
+
+benchmark_implementation("UDS batched with small packet", "STATSD_SOCKET_PATH" => SOCKET_PATH)
+
+if ENABLE_PROFILING
+  Vernier.stop_profile
+end
+
+if ENABLE_PROFILING
+  Vernier.start_profile(out: "tmp/benchmark_profile_uds_batched_async.json")
+end
+
+benchmark_implementation(
+  "UDS batched with jumbo packet",
+  "STATSD_SOCKET_PATH" => SOCKET_PATH,
+  "STATSD_MAX_PACKET_SIZE" => "32768",
+)
+
+if ENABLE_PROFILING
+  Vernier.stop_profile
+end

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -201,7 +201,10 @@ module StatsD
     #
     # @param method (see #statsd_measure)
     # @param name (see #statsd_measure)
-    # @param metric_options (see #statsd_measure)
+    # @param sample_rate
+    # @param tags
+    # @param no_prefix
+    # @param client
     # @return [void]
     def statsd_count(method, name, sample_rate: nil, tags: nil, no_prefix: false, client: nil)
       add_to_method(method, name, :count) do
@@ -391,14 +394,16 @@ require "statsd/instrument/datagram_builder"
 require "statsd/instrument/statsd_datagram_builder"
 require "statsd/instrument/dogstatsd_datagram_builder"
 require "statsd/instrument/null_sink"
-require "statsd/instrument/udp_sink"
-require "statsd/instrument/batched_udp_sink"
 require "statsd/instrument/capture_sink"
 require "statsd/instrument/log_sink"
 require "statsd/instrument/environment"
 require "statsd/instrument/helpers"
 require "statsd/instrument/assertions"
 require "statsd/instrument/expectation"
+require "statsd/instrument/uds_connection"
+require "statsd/instrument/udp_connection"
+require "statsd/instrument/sink"
+require "statsd/instrument/batched_sink"
 require "statsd/instrument/matchers" if defined?(RSpec)
 require "statsd/instrument/railtie" if defined?(Rails::Railtie)
 require "statsd/instrument/strict" if ENV["STATSD_STRICT_MODE"]

--- a/lib/statsd/instrument/client.rb
+++ b/lib/statsd/instrument/client.rb
@@ -82,7 +82,7 @@ module StatsD
       # Generally, you should use an instance of one of the following classes that
       # ship with this library:
       #
-      # - {StatsD::Instrument::UDPSink} A sink that will actually emit the provided
+      # - {StatsD::Instrument::Sink} A sink that will actually emit the provided
       #   datagrams over UDP.
       # - {StatsD::Instrument::NullSink} A sink that will simply swallow every
       #   datagram. This sink is for use when testing your application.

--- a/lib/statsd/instrument/sink.rb
+++ b/lib/statsd/instrument/sink.rb
@@ -2,17 +2,20 @@
 
 module StatsD
   module Instrument
-    # @note This class is part of the new Client implementation that is intended
-    #   to become the new default in the next major release of this library.
-    class UDPSink
+    class Sink
       class << self
         def for_addr(addr)
-          host, port_as_string = addr.split(":", 2)
-          new(host, Integer(port_as_string))
+          # if addr is host:port
+          if addr.include?(":")
+            host, port_as_string = addr.split(":", 2)
+            connection = UdpConnection.new(host, Integer(port_as_string))
+            new(connection)
+          else
+            connection = UdsConnection.new(addr)
+            new(connection)
+          end
         end
       end
-
-      attr_reader :host, :port
 
       FINALIZER = ->(object_id) do
         Thread.list.each do |thread|
@@ -22,10 +25,9 @@ module StatsD
         end
       end
 
-      def initialize(host, port)
+      def initialize(connection = nil)
         ObjectSpace.define_finalizer(self, FINALIZER)
-        @host = host
-        @port = port
+        @connection = connection
       end
 
       def sample?(sample_rate)
@@ -35,12 +37,12 @@ module StatsD
       def <<(datagram)
         retried = false
         begin
-          socket.send(datagram, 0)
+          connection.send_datagram(datagram)
         rescue SocketError, IOError, SystemCallError => error
           StatsD.logger.debug do
-            "[StatsD::Instrument::UDPSink] Resetting connection because of #{error.class}: #{error.message}"
+            "[#{self.class.name}] Resetting connection because of #{error.class}: #{error.message}"
           end
-          invalidate_socket
+          invalidate_connection
           if retried
             StatsD.logger.warn do
               "[#{self.class.name}] Events were dropped because of #{error.class}: #{error.message}"
@@ -53,27 +55,34 @@ module StatsD
         self
       end
 
-      def flush(blocking:)
+      def flush(blocking: false)
         # noop
+      end
+
+      def connection_type
+        connection.class.name
+      end
+
+      def connection
+        thread_store[object_id] ||= @connection
+      end
+
+      def host
+        connection.host
+      end
+
+      def port
+        connection.port
       end
 
       private
 
-      def invalidate_socket
-        socket = thread_store.delete(object_id)
-        socket&.close
-      end
-
-      def socket
-        thread_store[object_id] ||= begin
-          socket = UDPSocket.new
-          socket.connect(@host, @port)
-          socket
-        end
+      def invalidate_connection
+        connection&.close
       end
 
       def thread_store
-        Thread.current["StatsD::UDPSink"] ||= {}
+        Thread.current["StatsD::Sink"] ||= {}
       end
     end
   end

--- a/lib/statsd/instrument/udp_connection.rb
+++ b/lib/statsd/instrument/udp_connection.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module StatsD
+  module Instrument
+    class UdpConnection
+      DEFAULT_MAX_PACKET_SIZE = 1_472
+
+      attr_reader :host, :port
+
+      def initialize(host, port)
+        @host = host
+        @port = port
+      end
+
+      def send_datagram(message)
+        socket.send(message, 0)
+      end
+
+      def close
+        @socket&.close
+        @socket = nil
+      end
+
+      def type
+        :udp
+      end
+
+      private
+
+      def socket
+        @socket ||= begin
+          socket = UDPSocket.new
+          socket.connect(@host, @port)
+          socket
+        end
+      end
+    end
+  end
+end

--- a/lib/statsd/instrument/uds_connection.rb
+++ b/lib/statsd/instrument/uds_connection.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module StatsD
+  module Instrument
+    class UdsConnection
+      DEFAULT_MAX_PACKET_SIZE = 8_192
+
+      def initialize(socket_path, max_packet_size: DEFAULT_MAX_PACKET_SIZE)
+        if max_packet_size <= 0
+          StatsD.logger.warn do
+            "[StatsD::Instrument::UdsConnection] max_packet_size must be greater than 0, " \
+              "using default: #{DEFAULT_MAX_PACKET_SIZE}"
+          end
+        end
+        @socket_path = socket_path
+        @max_packet_size = max_packet_size
+      end
+
+      def send_datagram(message)
+        socket.sendmsg(message, 0)
+      end
+
+      def close
+        @socket&.close
+        @socket = nil
+      end
+
+      def host
+        nil
+      end
+
+      def port
+        nil
+      end
+
+      def type
+        :uds
+      end
+
+      private
+
+      def socket
+        @socket ||= begin
+          socket = Socket.new(Socket::AF_UNIX, Socket::SOCK_DGRAM)
+          socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, @max_packet_size.to_i)
+          socket.connect(Socket.pack_sockaddr_un(@socket_path))
+          socket
+        end
+      end
+    end
+  end
+end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -24,7 +24,7 @@ class ClientTest < Minitest::Test
     assert_equal(["shard:1", "env:production"], client.default_tags)
     assert_equal(StatsD::Instrument::StatsDDatagramBuilder, client.datagram_builder_class)
 
-    assert_kind_of(StatsD::Instrument::BatchedUDPSink, client.sink)
+    assert_kind_of(StatsD::Instrument::BatchedSink, client.sink)
     assert_equal("1.2.3.4", client.sink.host)
     assert_equal(8125, client.sink.port)
   end

--- a/test/dispatcher_stats_test.rb
+++ b/test/dispatcher_stats_test.rb
@@ -6,7 +6,7 @@ class DispatcherStatsTest < Minitest::Test
   include StatsD::Instrument::Assertions
 
   def test_maybe_flush
-    stats = StatsD::Instrument::BatchedUDPSink::DispatcherStats.new(0)
+    stats = StatsD::Instrument::BatchedSink::DispatcherStats.new(0, "udp")
 
     stats.increment_synchronous_sends
     stats.increment_batched_sends(1, 1, 1)
@@ -25,13 +25,13 @@ class DispatcherStatsTest < Minitest::Test
     assert_equal(0, stats.instance_variable_get(:@avg_batched_packet_size))
     assert_equal(0, stats.instance_variable_get(:@avg_batch_length))
 
-    stats = StatsD::Instrument::BatchedUDPSink::DispatcherStats.new(1)
+    stats = StatsD::Instrument::BatchedSink::DispatcherStats.new(1, :udp)
     stats.increment_batched_sends(1, 1, 1)
     assert_no_statsd_calls { stats.maybe_flush! }
   end
 
   def test_calculations_are_correct
-    stats = StatsD::Instrument::BatchedUDPSink::DispatcherStats.new(0)
+    stats = StatsD::Instrument::BatchedSink::DispatcherStats.new(0, :udp)
 
     5.times { stats.increment_synchronous_sends }
     assert_equal(5, stats.instance_variable_get(:@synchronous_sends))

--- a/test/environment_test.rb
+++ b/test/environment_test.rb
@@ -48,12 +48,12 @@ class EnvironmentTest < Minitest::Test
 
   def test_client_from_env_uses_batched_udp_sink_in_staging_environment
     env = StatsD::Instrument::Environment.new("STATSD_USE_NEW_CLIENT" => "1", "STATSD_ENV" => "staging")
-    assert_kind_of(StatsD::Instrument::BatchedUDPSink, env.client.sink)
+    assert_kind_of(StatsD::Instrument::BatchedSink, env.client.sink)
   end
 
   def test_client_from_env_uses_batched_udp_sink_in_production_environment
     env = StatsD::Instrument::Environment.new("STATSD_USE_NEW_CLIENT" => "1", "STATSD_ENV" => "production")
-    assert_kind_of(StatsD::Instrument::BatchedUDPSink, env.client.sink)
+    assert_kind_of(StatsD::Instrument::BatchedSink, env.client.sink)
   end
 
   def test_client_from_env_uses_regular_udp_sink_when_flush_interval_is_0
@@ -65,7 +65,7 @@ class EnvironmentTest < Minitest::Test
       "STATSD_ENV" => "staging",
       "STATSD_FLUSH_INTERVAL" => "0.0",
     )
-    assert_kind_of(StatsD::Instrument::UDPSink, env.client.sink)
+    assert_kind_of(StatsD::Instrument::Sink, env.client.sink)
   end
 
   def test_client_from_env_uses_regular_udp_sink_when_buffer_capacity_is_0
@@ -74,6 +74,6 @@ class EnvironmentTest < Minitest::Test
       "STATSD_ENV" => "staging",
       "STATSD_BUFFER_CAPACITY" => "0",
     )
-    assert_kind_of(StatsD::Instrument::UDPSink, env.client.sink)
+    assert_kind_of(StatsD::Instrument::Sink, env.client.sink)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,9 @@ end
 ENV["ENV"] = "test"
 
 require "minitest/autorun"
-require "minitest/pride"
+unless ENV.key?("CI")
+  require "minitest/pride"
+end
 require "mocha/minitest"
 require "statsd-instrument"
 

--- a/test/uds_sink_test.rb
+++ b/test/uds_sink_test.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module UdsTestHelper
+  MAX_READ_BYTES = 64 * 1024
+  private_constant :MAX_READ_BYTES
+
+  private
+
+  def create_socket_file
+    tmpdir = Dir.mktmpdir
+    socket_path = File.join(tmpdir, "sockets", "statsd.sock")
+    FileUtils.mkdir_p(File.dirname(socket_path))
+
+    socket_path
+  end
+
+  def create_receiver(socket_path)
+    FileUtils.rm_f(socket_path)
+    receiver = Socket.new(Socket::AF_UNIX, Socket::SOCK_DGRAM)
+    receiver.setsockopt(Socket::SOL_SOCKET, Socket::SO_REUSEADDR, true)
+    receiver.setsockopt(Socket::SOL_SOCKET, Socket::SO_RCVBUF, (2 * MAX_READ_BYTES).to_i)
+    receiver.bind(Socket.pack_sockaddr_un(socket_path))
+
+    receiver
+  end
+
+  def build_sink(socket_path)
+    connection = StatsD::Instrument::UdsConnection.new(socket_path)
+    @sink_class.new(connection)
+  end
+
+  def sink
+    @sink ||= build_sink(@socket_path)
+  end
+
+  def skip_on_jruby(message = "JRuby does not support UNIX domain sockets")
+    skip(message) if RUBY_PLATFORM == "java"
+  end
+
+  def read_datagrams(count, timeout: ENV["CI"] ? 5 : 1)
+    datagrams = []
+    count.times do
+      if @receiver.wait_readable(timeout)
+
+        datagrams += @receiver.recvfrom(MAX_READ_BYTES).first.lines(chomp: true)
+        break if datagrams.size >= count
+      else
+        break
+      end
+    end
+
+    datagrams
+  end
+end
+
+class UdsSinkTest < Minitest::Test
+  include UdsTestHelper
+
+  def setup
+    @sink_class = StatsD::Instrument::Sink
+    @socket_path = create_socket_file
+    skip_on_jruby
+
+    @receiver = create_receiver(@socket_path)
+  end
+
+  def teardown
+    return if RUBY_PLATFORM == "java"
+
+    @receiver.close
+    FileUtils.rm_f(@socket_path)
+  end
+
+  def test_send_metric_with_tags
+    metric = "test.metric"
+    value = 42
+    tags = { region: "us-west", environment: "production" }
+    sink << "#{metric}:#{value}|c|##{"region:#{tags[:region]},environment:#{tags[:environment]}"}"
+    # Assert that the metric with tags was sent successfully
+
+    datagrams = read_datagrams(1)
+    assert_equal("test.metric:42|c|#region:us-west,environment:production".b, datagrams.first)
+  end
+
+  def test_send_metric_with_sample_rate
+    metric = "test.metric"
+    value = 42
+    sample_rate = 0.5
+    sink << "#{metric}:#{value}|c|@#{sample_rate}"
+    datagrams = read_datagrams(1)
+    assert_equal("test.metric:42|c|@0.5".b, datagrams.first)
+  end
+
+  def test_flush_with_empty_batch
+    sink.flush
+    datagrams = read_datagrams(1, timeout: 0.1)
+    assert_empty(datagrams)
+  end
+end
+
+class BatchedUdsSinkTest < Minitest::Test
+  include UdsTestHelper
+
+  def setup
+    @socket_path = create_socket_file
+    @sink_class = StatsD::Instrument::BatchedSink
+    @sinks = []
+
+    skip_on_jruby
+
+    @receiver = create_receiver(@socket_path)
+  end
+
+  def teardown
+    return if RUBY_PLATFORM == "java"
+
+    @receiver.close
+    FileUtils.remove_entry(@socket_path)
+    @sinks.each(&:shutdown)
+  end
+
+  def test_send_metric_with_tags
+    metric = "test.metric"
+    value = 42
+    tags = { region: "us-west", environment: "production" }
+    sink << "#{metric}:#{value}|c|##{"region:#{tags[:region]},environment:#{tags[:environment]}"}"
+    datagrams = read_datagrams(1)
+    assert_equal("test.metric:42|c|#region:us-west,environment:production".b, datagrams.first)
+  end
+
+  def test_send_metric_with_sample_rate
+    metric = "test.metric"
+    value = 42
+    sample_rate = 0.5
+    sink << "#{metric}:#{value}|c|@#{sample_rate}"
+    datagrams = read_datagrams(1)
+    assert_equal("test.metric:42|c|@0.5".b, datagrams.first)
+  end
+
+  def test_flush_with_empty_batch
+    sink.flush(blocking: false)
+    datagrams = read_datagrams(1, timeout: 0.1)
+    assert_empty(datagrams)
+  end
+
+  def test_flush
+    buffer_size = 50
+    sink = build_sink(@socket_path, buffer_capacity: buffer_size)
+    dispatcher = sink.instance_variable_get(:@dispatcher)
+    buffer = dispatcher.instance_variable_get(:@buffer)
+    (buffer_size * 2).times { |i| sink << "foo:#{i}|c" }
+    assert(!buffer.empty?)
+    sink.flush(blocking: false)
+    assert(buffer.empty?)
+  end
+
+  def test_statistics
+    datagrams = StatsD.singleton_client.capture do
+      buffer_size = 2
+      sink = build_sink(@socket_path, buffer_capacity: buffer_size, statistics_interval: 0.1)
+      2.times { |i| sink << "foo:#{i}|c" }
+      sink.flush(blocking: false)
+      sink.instance_variable_get(:@dispatcher).instance_variable_get(:@statistics).maybe_flush!(force: true)
+    end
+
+    assert(datagrams.any? { |d| d.name.start_with?("statsd_instrument.batched_uds_sink.avg_batch_length") })
+    assert(datagrams.any? { |d| d.name.start_with?("statsd_instrument.batched_uds_sink.avg_batched_packet_size") })
+    assert(datagrams.any? { |d| d.name.start_with?("statsd_instrument.batched_uds_sink.avg_buffer_length") })
+    assert(datagrams.any? { |d| d.name.start_with?("statsd_instrument.batched_uds_sink.batched_sends") })
+    assert(datagrams.any? { |d| d.name.start_with?("statsd_instrument.batched_uds_sink.synchronous_sends") })
+  end
+
+  private
+
+  def build_sink(socket_path, buffer_capacity: 50, statistics_interval: 0)
+    sink = StatsD::Instrument::Sink.for_addr(socket_path)
+    sink = @sink_class.new(
+      sink,
+      buffer_capacity: buffer_capacity,
+      statistics_interval: statistics_interval,
+    )
+    @sinks << sink
+    sink
+  end
+end


### PR DESCRIPTION
## Summary

Using UDS (Unix Domain Sockets) is one of the main recommendation from Datadog to achieve higher throughput for StatsD traffic. So far, this client did not provide such a sink. 

In this PR I am introducing a UDS sink that uses same batching logic from UDP sink.


### Follow up improvements

* https://github.com/Shopify/statsd-instrument/pull/374 - Here I am removing the specific types of sinks and making them generic, then I introduce the concept of `Connection` which will then interact with the sockets. This solves the duplication problem I introduced in this PR.

Ended up merging this PR above and squashing the other commits, when reviewing, one can review the commits separately. 


### Benchmarks
We can see from benchmarks that using larger batches improves client throughput with a considerable margin:

```
▶ RUBY_YJIT_ENABLE=true ./benchmark/local-udp-throughput                                                                                                                                                                                                                                             
Logs are stored in /var/folders/9v/vqq8s1cd2n53w68813dwjz4c0000gn/T/statsd-instrument-benchmarks
===== UDP sync throughput (5 threads) - total events: 150000 =====
events: 138,061.4/s
===== UDP batched throughput (5 threads) - total events: 150000 =====
events: 734,325.8/s
===== UDS batched with small packet throughput (5 threads) - total events: 150000 =====
events: 1,386,411.3/s
===== UDS batched with jumbo packet throughput (5 threads) - total events: 150000 =====
events: 1,248,824.0/s

```