### PR TITLE
Deprecate Ruby 2.6, improve CI setup

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
@@ -21,7 +21,7 @@ jobs:
     - name: Run throughput benchmark on branch
       run: benchmark/local-udp-throughput
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: 'main'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3', 'ruby-head', 'jruby-9.3.7.0', 'truffleruby-22.2.0']
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', 'ruby-head', 'jruby-9.3.7.0', 'truffleruby-22.2.0']
         # Windows on macOS builds started failing, so they are disabled for now
         # platform: [windows-2019, macOS-10.14, ubuntu-18.04]
         # exclude:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', 'ruby-head', 'jruby-9.3.7.0', 'truffleruby-22.2.0']
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', 'ruby-head', 'jruby-9.4.8.0', 'truffleruby-24.0.2']
         # Windows on macOS builds started failing, so they are disabled for now
         # platform: [windows-2019, macOS-10.14, ubuntu-18.04]
         # exclude:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
         # ...
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1

--- a/statsd-instrument.gemspec
+++ b/statsd-instrument.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.metadata['allowed_push_host'] = "https://rubygems.org"
 end


### PR DESCRIPTION
## Summary

Ruby 2.6 reached its EOL in March 2022, in newer versions of the library we could disable support for that deprecated ruby version.
Also, our CI for github was using actions that were running with deprecated versions of NodeJS, I am upgrading the actions versions so we can comply with the newer Node versions.
Lastly, I am updating the versions we run tests against for JRuby and TruffleRuby

- **abandon support for 2.6**
- **Using newer version of checkout action get rid of deprecation warnings;**
- **update jruby and truffleruby versions**
