### PR TITLE
Adding new PR template for the repo'

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## ✅ What
+<!-- A brief description of the changes in this PR. -->
+
+## 🤔 Why
+<!-- A brief description of the reason for these changes. -->
+
+## 👩🔬 How to validate
+<!-- Step-by-step instructions for how reviewers can verify these changes work as expected. -->
+
+## Checklist
+
+- [ ] I documented the changes in the CHANGELOG file.
+<!-- If this is a user-facing change, you must update the CHANGELOG file. OR -->
+<!-- - [ ] This change is not user-facing and does not require a CHANGELOG update. -->


### PR DESCRIPTION
## Summary

Adding a new PR template to the repository, mostly to avoid forgetting to add CHANGELOG messages.