### PR TITLE
Aggregation: reduce log level of flush thread restart

### DIFF
--- a/lib/statsd/instrument/aggregator.rb
+++ b/lib/statsd/instrument/aggregator.rb
@@ -246,11 +246,11 @@ module StatsD
             return false unless Thread.main.alive?
 
             if @pid != Process.pid
-              StatsD.logger.info { "[#{self.class.name}] Restarting the flush thread after fork" }
+              StatsD.logger.debug { "[#{self.class.name}] Restarting the flush thread after fork" }
               @pid = Process.pid
               @aggregation_state.clear
             else
-              StatsD.logger.info { "[#{self.class.name}] Restarting the flush thread" }
+              StatsD.logger.debug { "[#{self.class.name}] Restarting the flush thread" }
             end
             @flush_thread = Thread.new do
               Thread.current.abort_on_exception = true


### PR DESCRIPTION
## ✅ What

Reducing the log level in some messages related to the health check thread on the aggregator.

## 🤔 Why

In some high throughput scenarios the log message can not only be verbose, but also cause locks (think trying to write to a physical file) inside a synchronized block.

## Checklist

- [ ] I documented the changes in the CHANGELOG file.
<!-- If this is a user-facing change, you must update the CHANGELOG file. OR -->
<!-- - [ ] This change is not user-facing and does not require a CHANGELOG update. -->
