### PR TITLE
Fix Rubocop warnings

### DIFF
--- a/lib/statsd/instrument/rubocop/measure_as_dist_argument.rb
+++ b/lib/statsd/instrument/rubocop/measure_as_dist_argument.rb
@@ -15,7 +15,7 @@ module RuboCop
       #       --only StatsD/MeasureAsDistArgument
       #
       # This cop will not autocorrect offenses.
-      class MeasureAsDistArgument < Cop
+      class MeasureAsDistArgument < Base
         include RuboCop::Cop::StatsD
 
         MSG = <<~MSG

--- a/lib/statsd/instrument/rubocop/metaprogramming_positional_arguments.rb
+++ b/lib/statsd/instrument/rubocop/metaprogramming_positional_arguments.rb
@@ -16,7 +16,7 @@ module RuboCop
       #
       #
       # This cop will not autocorrect the offenses it finds, but generally the fixes are easy to fix
-      class MetaprogrammingPositionalArguments < Cop
+      class MetaprogrammingPositionalArguments < Base
         include RuboCop::Cop::StatsD
 
         MSG = "Use keyword arguments for StatsD metaprogramming macros"

--- a/lib/statsd/instrument/rubocop/metric_prefix_argument.rb
+++ b/lib/statsd/instrument/rubocop/metric_prefix_argument.rb
@@ -12,7 +12,7 @@ module RuboCop
       #       --only StatsD/MetricPrefixArgument
       #
       # This cop will not autocorrect offenses.
-      class MetricPrefixArgument < Cop
+      class MetricPrefixArgument < Base
         include RuboCop::Cop::StatsD
 
         MSG = <<~MSG

--- a/lib/statsd/instrument/rubocop/metric_return_value.rb
+++ b/lib/statsd/instrument/rubocop/metric_return_value.rb
@@ -14,7 +14,7 @@ module RuboCop
       # This cop cannot autocorrect offenses. In production code, StatsD should be used in a fire-and-forget
       # fashion. This means that you shouldn't rely on the return value. If you really need to access the
       # emitted metrics, you can look into `capture_statsd_calls`
-      class MetricReturnValue < Cop
+      class MetricReturnValue < Base
         include RuboCop::Cop::StatsD
 
         MSG = "Do not use the return value of StatsD metric methods"

--- a/lib/statsd/instrument/rubocop/metric_value_keyword_argument.rb
+++ b/lib/statsd/instrument/rubocop/metric_value_keyword_argument.rb
@@ -16,7 +16,7 @@ module RuboCop
       # value as the second argument, rather than a keyword argument.
       #
       # `StatsD.increment('foo', value: 3)` => `StatsD.increment('foo', 3)`
-      class MetricValueKeywordArgument < Cop
+      class MetricValueKeywordArgument < Base
         include RuboCop::Cop::StatsD
 
         MSG = <<~MSG

--- a/lib/statsd/instrument/rubocop/singleton_configuration.rb
+++ b/lib/statsd/instrument/rubocop/singleton_configuration.rb
@@ -25,7 +25,7 @@ module RuboCop
       #   same options.
       # - If you have to, you can call the old methods on `StatsD.legacy_singleton_client`. Note
       #   that this option will go away in the next major version.
-      class SingletonConfiguration < Cop
+      class SingletonConfiguration < Base
         include RuboCop::Cop::StatsD
 
         MSG = <<~MESSAGE

--- a/lib/statsd/instrument/rubocop/splat_arguments.rb
+++ b/lib/statsd/instrument/rubocop/splat_arguments.rb
@@ -13,7 +13,7 @@ module RuboCop
       #      --only StatsD/SplatArguments
       #
       # This cop will not autocorrect offenses.
-      class SplatArguments < Cop
+      class SplatArguments < Base
         include RuboCop::Cop::StatsD
 
         MSG = "Do not use splat arguments in StatsD metric calls"


### PR DESCRIPTION

## ✅ What
Fix

```
warning: Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead.
For more information, see https://docs.rubocop.org/rubocop/v1_upgrade_notes.html.
```


