### PR TITLE
Aggregation: actually passing down sample_rate to aggregator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ section below.
 
 ## Unreleased changes
 
+## Version 3.9.6
+
+- [#388](https://github.com/Shopify/statsd-instrument/pull/388) - Properly fixing the bug when using aggregation and sending sampled
+histograms, now the client will respect the sampling rate when sending the metrics and pass it down to the aggregator.
+
 ## Version 3.9.5
 
 - [#387](https://github.com/Shopify/statsd-instrument/pull/387) - Fixing bug when using aggregation and sending sampled

--- a/lib/statsd/instrument/aggregator.rb
+++ b/lib/statsd/instrument/aggregator.rb
@@ -138,7 +138,7 @@ module StatsD
       def aggregate_timing(name, value, tags: [], no_prefix: false, type: DISTRIBUTION, sample_rate: CONST_SAMPLE_RATE)
         unless thread_healthcheck
           @sink << datagram_builder(no_prefix: no_prefix).timing_value_packed(
-            name, type.to_s, [value], CONST_SAMPLE_RATE, tags
+            name, type.to_s, [value], sample_rate, tags
           )
           return
         end

--- a/lib/statsd/instrument/version.rb
+++ b/lib/statsd/instrument/version.rb
@@ -2,6 +2,6 @@
 
 module StatsD
   module Instrument
-    VERSION = "3.9.5"
+    VERSION = "3.9.6"
   end
 end


### PR DESCRIPTION
## ✅ What

Fixing sampling logic in the client when using aggregation, passing the sample_rate parameter down to the aggregator.

Added some new integration tests to make sure we are doing what we are supposed to do.

![image](https://github.com/user-attachments/assets/23f80300-1319-43d0-854f-7f91d16e2050)


## 🤔 Why

When aggregation is enabled, if you create a sampled distribution metric, the sample rate was not being passed down to the aggregator. Which caused scaling of rate of histogram and even values later on.

## 👩🔬 How to validate

Installed the new version of the library in an app, the app is now sending sampled distributions with the sampling rate, even when aggregating.

## Checklist

- [X] I documented the changes in the CHANGELOG file.
<!-- If this is a user-facing change, you must update the CHANGELOG file. OR -->
<!-- - [ ] This change is not user-facing and does not require a CHANGELOG update. -->
