### PR TITLE
UDS: fixing batched sink constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ section below.
 
 ## Unreleased changes
 
+## Version 3.9.7
+
+- [#389](https://github.com/Shopify/statsd-instrument/pull/389) - Fixing bug with BatchedSink constructor when using UDS, the constructor was not properly passing the Sink to the BatchedSink.
+
 ## Version 3.9.6
 
 - [#388](https://github.com/Shopify/statsd-instrument/pull/388) - Properly fixing the bug when using aggregation and sending sampled

--- a/lib/statsd/instrument/batched_sink.rb
+++ b/lib/statsd/instrument/batched_sink.rb
@@ -18,13 +18,8 @@ module StatsD
 
       class << self
         def for_addr(addr, **kwargs)
-          if addr.include?(":")
-            sink = StatsD::Instrument::Sink.for_addr(addr)
-            new(sink, **kwargs)
-          else
-            connection = UdsConnection.new(addr)
-            new(connection, **kwargs)
-          end
+          sink = StatsD::Instrument::Sink.for_addr(addr)
+          new(sink, **kwargs)
         end
 
         def finalize(dispatcher)

--- a/lib/statsd/instrument/version.rb
+++ b/lib/statsd/instrument/version.rb
@@ -2,6 +2,6 @@
 
 module StatsD
   module Instrument
-    VERSION = "3.9.6"
+    VERSION = "3.9.7"
   end
 end

--- a/test/uds_sink_test.rb
+++ b/test/uds_sink_test.rb
@@ -121,6 +121,12 @@ class BatchedUdsSinkTest < Minitest::Test
     @sinks.each(&:shutdown)
   end
 
+  def test_construct_from_addr
+    batched_sink = StatsD::Instrument::BatchedSink.for_addr(@socket_path)
+    assert_instance_of(StatsD::Instrument::BatchedSink, batched_sink)
+    assert_instance_of(StatsD::Instrument::UdsConnection, batched_sink.connection)
+  end
+
   def test_send_metric_with_tags
     metric = "test.metric"
     value = 42


### PR DESCRIPTION
## ✅ What

Fixing a bug when using UDS and the batched sink, where we were passing a connection and not a sink to the BatchedSink.

## 🤔 Why

Well, it was broken :) 

## Checklist

- [X] I documented the changes in the CHANGELOG file.
<!-- If this is a user-facing change, you must update the CHANGELOG file. OR -->
<!-- - [ ] This change is not user-facing and does not require a CHANGELOG update. -->
