### PR TITLE
Prevent ENOBUFS errors by skipping UDP send buffer size configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ section below.
 
 ## Unreleased changes
 
+## Version 3.9.9
+
+- [#392](https://github.com/Shopify/statsd-instrument/pull/392) - Prevent ENOBUFS errors when using UDP, by skipping setting socket buffer size.
+
 ## Version 3.9.8
 
 - [#390](https://github.com/Shopify/statsd-instrument/pull/391) - Fixing bug in Environment when using UDS. The max packet size option was not being passed to the 

--- a/Gemfile
+++ b/Gemfile
@@ -19,4 +19,9 @@ platform :mri do
   if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.2")
     gem "vernier", require: false
   end
+
+  # From Ruby >= 3.5, logger is not part of the stdlib anymore
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.5")
+    gem "logger"
+  end
 end

--- a/lib/statsd/instrument/connection_behavior.rb
+++ b/lib/statsd/instrument/connection_behavior.rb
@@ -42,7 +42,7 @@ module StatsD
         original_socket
       rescue IOError => e
         StatsD.logger.debug do
-          "[#{self.class.name}] Failed to create socket: #{e.class}: #{e.message}"
+          "[#{self.class.name}] Failed to setup socket: #{e.class}: #{e.message}"
         end
         nil
       end

--- a/lib/statsd/instrument/udp_connection.rb
+++ b/lib/statsd/instrument/udp_connection.rb
@@ -25,11 +25,16 @@ module StatsD
 
       private
 
+      def setup_socket(original_socket)
+        original_socket
+      end
+
       def socket
         @socket ||= begin
-          udp_socket = UDPSocket.new
+          family = Addrinfo.udp(host, port).afamily
+          udp_socket = UDPSocket.new(family)
           setup_socket(udp_socket)&.tap do |s|
-            s.connect(@host, @port)
+            s.connect(host, port)
           end
         end
       end

--- a/lib/statsd/instrument/version.rb
+++ b/lib/statsd/instrument/version.rb
@@ -2,6 +2,6 @@
 
 module StatsD
   module Instrument
-    VERSION = "3.9.8"
+    VERSION = "3.9.9"
   end
 end

--- a/test/udp_sink_test.rb
+++ b/test/udp_sink_test.rb
@@ -151,25 +151,11 @@ class UDPSinkTest < Minitest::Test
       seq = sequence("connect_fail_connect_succeed")
 
       # First attempt
-      socket.expects(:setsockopt)
-        .with(Socket::SOL_SOCKET, Socket::SO_SNDBUF, StatsD::Instrument::UdpConnection::DEFAULT_MAX_PACKET_SIZE)
-        .in_sequence(seq)
-      socket.expects(:getsockopt)
-        .with(Socket::SOL_SOCKET, Socket::SO_SNDBUF)
-        .returns(mock(int: StatsD::Instrument::UdpConnection::DEFAULT_MAX_PACKET_SIZE))
-        .in_sequence(seq)
       socket.expects(:connect).with("localhost", 8125).in_sequence(seq)
       socket.expects(:send).raises(Errno::EDESTADDRREQ).in_sequence(seq)
       socket.expects(:close).in_sequence(seq)
 
       # Second attempt after error
-      socket.expects(:setsockopt)
-        .with(Socket::SOL_SOCKET, Socket::SO_SNDBUF, StatsD::Instrument::UdpConnection::DEFAULT_MAX_PACKET_SIZE)
-        .in_sequence(seq)
-      socket.expects(:getsockopt)
-        .with(Socket::SOL_SOCKET, Socket::SO_SNDBUF)
-        .returns(mock(int: StatsD::Instrument::UdpConnection::DEFAULT_MAX_PACKET_SIZE))
-        .in_sequence(seq)
       socket.expects(:connect).with("localhost", 8125).in_sequence(seq)
       socket.expects(:send).twice.returns(1).in_sequence(seq)
       socket.expects(:close).in_sequence(seq)


### PR DESCRIPTION
## ✅ What
- Prevents ENOBUFS errors by making UDP connections skip send buffer size configuration
- Improves UDP socket creation by using the correct address family
- Updates error message to be more accurate

## 🤔 Why
When using UDP connections, the previous implementation attempted to set the socket's send buffer size. This could lead to `Errno::ENOBUFS` errors in certain environments, particularly when the system is under high load or has strict buffer size limitations. By skipping the buffer size configuration for UDP connections specifically, we prevent these errors while maintaining the original functionality for other connection types.

## Validation

Made sure that we dont see any ENOBUFS in benchmarks (even though this might be related to network layer).


## Checklist

- [x] I documented the changes in the CHANGELOG file.
