### PR TITLE
Expose the metric name for CompiledMetric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ section below.
 
 ## Unreleased changes
 
+- [#417](https://github.com/Shopify/statsd-instrument/pull/417) - Add a `metric_name` method to `CompiledMetric`.
+
 ## Version 3.10.0
 
 - [#416](https://github.com/Shopify/statsd-instrument/pull/416) - Fix missing `metric_prefix` in Aggregator finalizer, causing metrics to lose their prefix when flushed during GC.

--- a/lib/statsd/instrument/compiled_metric.rb
+++ b/lib/statsd/instrument/compiled_metric.rb
@@ -51,7 +51,7 @@ module StatsD
           # Create a new class for this specific metric
           # Using classes instead of instances for better YJIT optimization
           metric_class = tap do
-            @name = DatagramBlueprintBuilder.normalize_name(name)
+            @name = DatagramBlueprintBuilder.normalize_name(name).freeze
             @datagram_blueprint = datagram_blueprint
             @tag_combination_cache = {}
             @max_cache_size = max_cache_size

--- a/lib/statsd/instrument/compiled_metric.rb
+++ b/lib/statsd/instrument/compiled_metric.rb
@@ -101,6 +101,11 @@ module StatsD
           @singleton_client.sink.sample?(sample_rate)
         end
 
+        # @return [String, nil] The normalized metric name for this compiled metric class (`nil` if not yet defined).
+        def metric_name
+          @name
+        end
+
         # @return [Float] The defined sample rate for a metric class.
         # Will raise when `define` has not yet been called on the class.
         def sample_rate

--- a/test/compiled_metric_test.rb
+++ b/test/compiled_metric_test.rb
@@ -453,6 +453,7 @@ class CompiledMetricDefinitionTest < Minitest::Test
     end
 
     assert_equal("foo.bar", metric.metric_name)
+    assert_predicate(metric.metric_name, :frozen?)
   end
 
   def test_metric_name_is_normalized
@@ -463,6 +464,7 @@ class CompiledMetricDefinitionTest < Minitest::Test
     end
 
     assert_equal("foo_bar_baz_qux", metric.metric_name)
+    assert_predicate(metric.metric_name, :frozen?)
   end
 
   def test_metric_name_without_define

--- a/test/compiled_metric_test.rb
+++ b/test/compiled_metric_test.rb
@@ -444,4 +444,30 @@ class CompiledMetricDefinitionTest < Minitest::Test
     end
     assert_equal("Every CompiledMetric subclass needs to call `define` before accessing its sample_rate.", error.message)
   end
+
+  def test_metric_name
+    metric = Class.new(StatsD::Instrument::CompiledMetric::Counter) do
+      define(
+        name: "foo.bar",
+      )
+    end
+
+    assert_equal("foo.bar", metric.metric_name)
+  end
+
+  def test_metric_name_is_normalized
+    metric = Class.new(StatsD::Instrument::CompiledMetric::Counter) do
+      define(
+        name: "foo:bar|baz@qux",
+      )
+    end
+
+    assert_equal("foo_bar_baz_qux", metric.metric_name)
+  end
+
+  def test_metric_name_without_define
+    metric = Class.new(StatsD::Instrument::CompiledMetric::Counter)
+
+    assert_nil(metric.metric_name)
+  end
 end


### PR DESCRIPTION
## ✅ What

This change makes the metric name accessible via a top-level `.metric_name` method on the compiled metric.

## 🤔 Why

This has the benefit of making it easy to use the metric name in tests in lieu of defining constants to share the name.

## 👩🔬 How to validate

The test suite makes the usage quite clear; it's a single method on the subclass of `CompiledMetric`.

## Checklist

- [x] I documented the changes in the CHANGELOG file.
