### PR TITLE
Prevent misuse of compiled metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ section below.
 
 ## Unreleased changes
 
+- [#418](https://github.com/Shopify/statsd-instrument/pull/418) - Prevent misuse of `CompiledMetric` definitions by requiring a subclass when defining one.
 - [#417](https://github.com/Shopify/statsd-instrument/pull/417) - Add a `metric_name` method to `CompiledMetric`.
 
 ## Version 3.10.0

--- a/lib/statsd/instrument/compiled_metric.rb
+++ b/lib/statsd/instrument/compiled_metric.rb
@@ -33,6 +33,19 @@ module StatsD
         # @param max_cache_size [Integer] Maximum tag combinations this metric supports, and will be retained in-memory. Cardinality beyond this number will fall back to the slow path and should be avoided.
         # @return [Class] A new CompiledMetric subclass configured for this metric
         def define(name:, static_tags: {}, tags: {}, no_prefix: false, sample_rate: nil, max_cache_size: DEFAULT_MAX_TAG_COMBINATION_CACHE_SIZE)
+          if equal?(CompiledMetric) || superclass.equal?(CompiledMetric)
+            raise ArgumentError,
+              "`define` must be called on a subclass, not on #{self.name} directly. " \
+                "Use `Class.new(#{self.name}) { define(...) }` or " \
+                "`class MyMetric < #{self.name}; define(...); end` instead."
+          end
+
+          if defined?(@datagram_blueprint)
+            raise ArgumentError,
+              "`define` has already been called on #{self.name}. " \
+                "Each CompiledMetric subclass can only be defined once."
+          end
+
           client = StatsD.singleton_client
 
           # Build the datagram blueprint using the builder

--- a/lib/statsd/instrument/compiled_metric.rb
+++ b/lib/statsd/instrument/compiled_metric.rb
@@ -18,6 +18,12 @@ module StatsD
     #   # Later, emit with minimal allocations:
     #   CheckoutMetric.increment(shop_id: 123, user_id: 456, value: 1)
     class CompiledMetric
+      # Raised when a CompiledMetric subclass is defined incorrectly.
+      # This includes calling `define` on a base type class directly,
+      # calling `define` more than once, or using a metric before `define`
+      # has been called.
+      class DefinitionError < StandardError; end
+
       # Default maximum number of unique tag combinations to cache before clearing
       # the cache to prevent unbounded memory growth
       DEFAULT_MAX_TAG_COMBINATION_CACHE_SIZE = 5000
@@ -34,14 +40,14 @@ module StatsD
         # @return [Class] A new CompiledMetric subclass configured for this metric
         def define(name:, static_tags: {}, tags: {}, no_prefix: false, sample_rate: nil, max_cache_size: DEFAULT_MAX_TAG_COMBINATION_CACHE_SIZE)
           if equal?(CompiledMetric) || superclass.equal?(CompiledMetric)
-            raise ArgumentError,
+            raise DefinitionError,
               "`define` must be called on a subclass, not on #{self.name} directly. " \
                 "Use `Class.new(#{self.name}) { define(...) }` or " \
                 "`class MyMetric < #{self.name}; define(...); end` instead."
           end
 
           if defined?(@datagram_blueprint)
-            raise ArgumentError,
+            raise DefinitionError,
               "`define` has already been called on #{self.name}. " \
                 "Each CompiledMetric subclass can only be defined once."
           end
@@ -122,7 +128,7 @@ module StatsD
         # @return [Float] The defined sample rate for a metric class.
         # Will raise when `define` has not yet been called on the class.
         def sample_rate
-          raise ArgumentError, "Every CompiledMetric subclass needs to call `define` before accessing its sample_rate." unless defined?(@sample_rate)
+          raise DefinitionError, "Every CompiledMetric subclass needs to call `define` before accessing its sample_rate." unless defined?(@sample_rate)
 
           @sample_rate
         end
@@ -133,7 +139,7 @@ module StatsD
         # Once `define` was called during the class creation, it will override the
         # method implementation to emit the actual metric datagrams.
         def require_define_to_be_called
-          raise ArgumentError, "Every CompiledMetric subclass needs to call `define` before first invocation of #{method_name}."
+          raise DefinitionError, "Every CompiledMetric subclass needs to call `define` before first invocation of #{method_name}."
         end
 
         def generate_block_handler

--- a/test/compiled_metric/counter_test.rb
+++ b/test/compiled_metric/counter_test.rb
@@ -24,7 +24,7 @@ class CompiledMetricCounterTest < Minitest::Test
   def test_counter_without_define
     metric = Class.new(StatsD::Instrument::CompiledMetric::Counter)
 
-    error = assert_raises(ArgumentError) do
+    error = assert_raises(StatsD::Instrument::CompiledMetric::DefinitionError) do
       metric.increment(5)
     end
     assert_equal("Every CompiledMetric subclass needs to call `define` before first invocation of increment.", error.message)

--- a/test/compiled_metric/distribution_test.rb
+++ b/test/compiled_metric/distribution_test.rb
@@ -24,7 +24,7 @@ class CompiledMetricDistributionTest < Minitest::Test
   def test_distribution_without_define
     metric = Class.new(StatsD::Instrument::CompiledMetric::Distribution)
 
-    error = assert_raises(ArgumentError) do
+    error = assert_raises(StatsD::Instrument::CompiledMetric::DefinitionError) do
       metric.distribution(5)
     end
     assert_equal("Every CompiledMetric subclass needs to call `define` before first invocation of distribution.", error.message)

--- a/test/compiled_metric/gauge_test.rb
+++ b/test/compiled_metric/gauge_test.rb
@@ -24,7 +24,7 @@ class CompiledMetricGaugeTest < Minitest::Test
   def test_gauge_without_define
     metric = Class.new(StatsD::Instrument::CompiledMetric::Gauge)
 
-    error = assert_raises(ArgumentError) do
+    error = assert_raises(StatsD::Instrument::CompiledMetric::DefinitionError) do
       metric.gauge(5)
     end
     assert_equal("Every CompiledMetric subclass needs to call `define` before first invocation of gauge.", error.message)

--- a/test/compiled_metric_test.rb
+++ b/test/compiled_metric_test.rb
@@ -472,4 +472,45 @@ class CompiledMetricDefinitionTest < Minitest::Test
 
     assert_nil(metric.metric_name)
   end
+
+  def test_define_directly_on_counter_raises
+    error = assert_raises(ArgumentError) do
+      StatsD::Instrument::CompiledMetric::Counter.define(name: "bad_metric")
+    end
+    assert_includes(error.message, "`define` must be called on a subclass")
+    assert_includes(error.message, "Counter")
+  end
+
+  def test_define_directly_on_gauge_raises
+    error = assert_raises(ArgumentError) do
+      StatsD::Instrument::CompiledMetric::Gauge.define(name: "bad_metric")
+    end
+    assert_includes(error.message, "`define` must be called on a subclass")
+    assert_includes(error.message, "Gauge")
+  end
+
+  def test_define_directly_on_distribution_raises
+    error = assert_raises(ArgumentError) do
+      StatsD::Instrument::CompiledMetric::Distribution.define(name: "bad_metric")
+    end
+    assert_includes(error.message, "`define` must be called on a subclass")
+    assert_includes(error.message, "Distribution")
+  end
+
+  def test_define_directly_on_compiled_metric_raises
+    error = assert_raises(ArgumentError) do
+      StatsD::Instrument::CompiledMetric.define(name: "bad_metric")
+    end
+    assert_includes(error.message, "`define` must be called on a subclass")
+  end
+
+  def test_double_define_raises
+    error = assert_raises(ArgumentError) do
+      Class.new(StatsD::Instrument::CompiledMetric::Counter) do
+        define(name: "first_metric")
+        define(name: "second_metric")
+      end
+    end
+    assert_includes(error.message, "`define` has already been called")
+  end
 end

--- a/test/compiled_metric_test.rb
+++ b/test/compiled_metric_test.rb
@@ -439,7 +439,7 @@ class CompiledMetricDefinitionTest < Minitest::Test
   def test_sample_rate_without_define
     metric = Class.new(StatsD::Instrument::CompiledMetric::Counter)
 
-    error = assert_raises(ArgumentError) do
+    error = assert_raises(StatsD::Instrument::CompiledMetric::DefinitionError) do
       metric.sample_rate
     end
     assert_equal("Every CompiledMetric subclass needs to call `define` before accessing its sample_rate.", error.message)
@@ -474,7 +474,7 @@ class CompiledMetricDefinitionTest < Minitest::Test
   end
 
   def test_define_directly_on_counter_raises
-    error = assert_raises(ArgumentError) do
+    error = assert_raises(StatsD::Instrument::CompiledMetric::DefinitionError) do
       StatsD::Instrument::CompiledMetric::Counter.define(name: "bad_metric")
     end
     assert_includes(error.message, "`define` must be called on a subclass")
@@ -482,7 +482,7 @@ class CompiledMetricDefinitionTest < Minitest::Test
   end
 
   def test_define_directly_on_gauge_raises
-    error = assert_raises(ArgumentError) do
+    error = assert_raises(StatsD::Instrument::CompiledMetric::DefinitionError) do
       StatsD::Instrument::CompiledMetric::Gauge.define(name: "bad_metric")
     end
     assert_includes(error.message, "`define` must be called on a subclass")
@@ -490,7 +490,7 @@ class CompiledMetricDefinitionTest < Minitest::Test
   end
 
   def test_define_directly_on_distribution_raises
-    error = assert_raises(ArgumentError) do
+    error = assert_raises(StatsD::Instrument::CompiledMetric::DefinitionError) do
       StatsD::Instrument::CompiledMetric::Distribution.define(name: "bad_metric")
     end
     assert_includes(error.message, "`define` must be called on a subclass")
@@ -498,14 +498,14 @@ class CompiledMetricDefinitionTest < Minitest::Test
   end
 
   def test_define_directly_on_compiled_metric_raises
-    error = assert_raises(ArgumentError) do
+    error = assert_raises(StatsD::Instrument::CompiledMetric::DefinitionError) do
       StatsD::Instrument::CompiledMetric.define(name: "bad_metric")
     end
     assert_includes(error.message, "`define` must be called on a subclass")
   end
 
   def test_double_define_raises
-    error = assert_raises(ArgumentError) do
+    error = assert_raises(StatsD::Instrument::CompiledMetric::DefinitionError) do
       Class.new(StatsD::Instrument::CompiledMetric::Counter) do
         define(name: "first_metric")
         define(name: "second_metric")


### PR DESCRIPTION
## ✅ What

This change prevents accidental misuse of the `CompiledMetric` system by ensuring that you cannot `define` the base class, as that mutates shared, global state.

Additionally, the second commit introduces a "definition error" instead of using `ArgumentError` for definiton-time issues, as they aren't errors with passing invalid arguments, but with how you're setting up your definition. (Technically, this is a breaking change, but I doubt people are rescuing these `ArgumentError`s, so it should be safe. I opted for a second commit so we can just not ship that if we want to avoid this "breaking change".)

## 🤔 Why

I saw that the API was `CompiledMetric.define` and assumed it worked like [the `Data` structs](https://docs.ruby-lang.org/en/3.2/Data.html). It appeared to work until I went to define a _second_ metric, which caused things to break unexpectedly.

## 👩🔬 How to validate

I believe the test suite covers the behavior.

## Checklist

- [x] I documented the changes in the CHANGELOG file.
<!-- If this is a user-facing change, you must update the CHANGELOG file. OR -->
<!-- - [ ] This change is not user-facing and does not require a CHANGELOG update. -->
