### PR TITLE
Release v3.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ section below.
 
 ## Unreleased changes
 
+## Version 3.11.0
+
 - [#418](https://github.com/Shopify/statsd-instrument/pull/418) - Prevent misuse of `CompiledMetric` definitions by requiring a subclass when defining one.
 - [#417](https://github.com/Shopify/statsd-instrument/pull/417) - Add a `metric_name` method to `CompiledMetric`.
 

--- a/lib/statsd/instrument/version.rb
+++ b/lib/statsd/instrument/version.rb
@@ -2,6 +2,6 @@
 
 module StatsD
   module Instrument
-    VERSION = "3.10.0"
+    VERSION = "3.11.0"
   end
 end


### PR DESCRIPTION
## ✅ What

Release `CompiledMetric.metric_name` and the developer experience fix of disallowing `CompiledMetric.define` outside of a subclass.

## 🤔 Why

The `metric_name` method is a net-new feature so warrants a minor version.

> [!CAUTION]
> The disallowing of the `CompiledMetric.define` being called on the top-level class is technically a breaking change, but was a broken experience as soon as you called `define` on a second metric of the same type so it's unlikely anyone relied on it.
>
> Additionally, the change of error type for not calling `define` is a breaking change, but it's not one that anyone would rescue since the metric wouldn't work and would continually raise.
>
> Between these two things, I believe we do not need a major version bump.

## Checklist

- [x] I documented the changes in the CHANGELOG file.