### PR TITLE
Fix compiled distribution sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ section below.
 
 ## Unreleased changes
 
+## Version 3.11.1
+
+- Fix `CompiledMetric::Distribution` applying `sample_rate` twice.
+
 ## Version 3.11.0
 
 - [#418](https://github.com/Shopify/statsd-instrument/pull/418) - Prevent misuse of `CompiledMetric` definitions by requiring a subclass when defining one.

--- a/lib/statsd/instrument/client.rb
+++ b/lib/statsd/instrument/client.rb
@@ -285,6 +285,25 @@ module StatsD
         StatsD::Instrument::VOID
       end
 
+      # Emits a pre-sampled compiled distribution metric.
+      # This method is used when the generated compiled metric method already made
+      # the sampling decision before measuring block latency.
+      #
+      # @param precompiled_datagram [StatsD::Instrument::CompiledMetric::PrecompiledDatagram]
+      #   The precompiled metric datagram
+      # @param value [Numeric] The metric value
+      # @return [void]
+      # @api private
+      def emit_presampled_precompiled_distribution_metric(precompiled_datagram, value)
+        if @enable_aggregation
+          @aggregator.aggregate_precompiled_timing_metric(precompiled_datagram, value)
+          return StatsD::Instrument::VOID
+        end
+
+        emit(precompiled_datagram.to_datagram(value))
+        StatsD::Instrument::VOID
+      end
+
       # Emits a precompiled metric for high-performance use cases.
       # This method is used by {StatsD::Instrument::CompiledMetric::Gauge} to emit metrics
       # with minimal allocations.

--- a/lib/statsd/instrument/compiled_metric.rb
+++ b/lib/statsd/instrument/compiled_metric.rb
@@ -177,6 +177,10 @@ module StatsD
           default_val = default_value
           default_val_assignment = default_val.nil? ? "" : " = #{default_val.inspect}"
           allow_block = allow_measuring_latency
+          # Block-enabled compiled metrics run through generate_block_handler first,
+          # which applies sample_rate before emitting. Use the presampled client helper
+          # here so distributions don't make a second sampling decision.
+          client_emit_method = allow_block ? "emit_presampled_precompiled_#{method}_metric" : "emit_precompiled_#{method}_metric"
 
           method_code = <<~RUBY
             def self.#{method}(__value__#{default_val_assignment}, #{tag_names.map { |name| "#{name}:" }.join(", ")})
@@ -218,7 +222,7 @@ module StatsD
 
               __datagram__ ||= PrecompiledDatagram.new([#{tag_names.join(", ")}], @datagram_blueprint, @sample_rate)
 
-              @singleton_client.emit_precompiled_#{method}_metric(__datagram__, __value__)
+              @singleton_client.#{client_emit_method}(__datagram__, __value__)
               __return_value__
             end
           RUBY
@@ -233,12 +237,16 @@ module StatsD
           method = method_name
           default_val = default_value
           allow_block = allow_measuring_latency
+          # Block-enabled compiled metrics run through generate_block_handler first,
+          # which applies sample_rate before emitting. Use the presampled client helper
+          # here so distributions don't make a second sampling decision.
+          client_emit_method = allow_block ? "emit_presampled_precompiled_#{method}_metric" : "emit_precompiled_#{method}_metric"
 
           instance_eval(<<~RUBY, __FILE__, __LINE__ + 1)
             def self.#{method}(__value__ = #{default_val.inspect})
               __return_value__ = StatsD::Instrument::VOID
               #{generate_block_handler if allow_block}
-              @singleton_client.emit_precompiled_#{method}_metric(@static_datagram, __value__)
+              @singleton_client.#{client_emit_method}(@static_datagram, __value__)
               __return_value__
             end
           RUBY

--- a/lib/statsd/instrument/version.rb
+++ b/lib/statsd/instrument/version.rb
@@ -2,6 +2,6 @@
 
 module StatsD
   module Instrument
-    VERSION = "3.11.0"
+    VERSION = "3.11.1"
   end
 end

--- a/test/compiled_metric/distribution_test.rb
+++ b/test/compiled_metric/distribution_test.rb
@@ -230,6 +230,43 @@ class CompiledMetricDistributionTest < Minitest::Test
     assert_equal(["env:production", "region:us-east", "service:web"], datagram.tags.sort)
   end
 
+  def test_sampled_distribution_value_uses_one_sampling_decision
+    sample_rate = 0.5
+    @sink.expects(:sample?).with(sample_rate).once.returns(true)
+
+    metric = Class.new(StatsD::Instrument::CompiledMetric::Distribution) do
+      define(
+        name: "foo.bar",
+        tags: { shop_id: Integer },
+        sample_rate: sample_rate,
+      )
+    end
+
+    metric.distribution(5, shop_id: 123)
+
+    assert_equal(1, @sink.datagrams.size)
+    assert_equal("test.foo.bar:5|d|@0.5|#shop_id:123", @sink.datagrams.first.source)
+  end
+
+  def test_sampled_distribution_block_uses_one_sampling_decision
+    sample_rate = 0.5
+    @sink.expects(:sample?).with(sample_rate).once.returns(true)
+    Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC, :float_millisecond).returns(100.0, 125.0)
+
+    metric = Class.new(StatsD::Instrument::CompiledMetric::Distribution) do
+      define(
+        name: "foo.bar",
+        sample_rate: sample_rate,
+      )
+    end
+
+    returned_value = metric.distribution { :result }
+
+    assert_equal(:result, returned_value)
+    assert_equal(1, @sink.datagrams.size)
+    assert_equal("test.foo.bar:25.0|d|@0.5", @sink.datagrams.first.source)
+  end
+
   def test_latency_as_value_when_block_provided
     metric = Class.new(StatsD::Instrument::CompiledMetric::Distribution) do
       define(
@@ -415,17 +452,16 @@ class CompiledMetricDistributionWithAggregationTest < Minitest::Test
   end
 
   def test_sample_rate_with_aggregation
-    # When aggregating with sample_rate, sampling happens before aggregation
-    # This test verifies that with a sample_rate >0, a subset of distributions are aggregated
+    sample_rate = 0.5
+    @sink.expects(:sample?).with(sample_rate).times(5).returns(false, true, false, false, true)
+
     metric = Class.new(StatsD::Instrument::CompiledMetric::Distribution) do
       define(
         name: "foo.bar",
         static_tags: { service: "web" },
-        sample_rate: 0.5,
+        sample_rate: sample_rate,
       )
     end
-
-    metric.stubs(:sample?).returns(false, true, false, false, true)
 
     metric.distribution(1)
     metric.distribution(2)


### PR DESCRIPTION
## ✅ What

Fixes `CompiledMetric::Distribution` so sampled metrics only make one sampling decision.

`CompiledMetric::Distribution` already samples in the generated latency/block handler. The precompiled distribution client emit path then sampled again, which made sampled compiled distributions emit with probability `sample_rate²` while still sending datagrams marked with only `|@sample_rate`.

This PR routes pre-sampled compiled distributions to a dedicated private emit helper so the generated method's sampling decision is reused for both direct emission and aggregation.

Also bumps the patch version to `3.11.1` for release.

Fixes #421.

## 🤔 Why

A compiled distribution with `sample_rate: 0.001` should emit about 1 in 1000 calls and let the backend scale by 1000. Instead it emitted about 1 in 1,000,000 calls and still told the backend to scale by only 1000, under-reporting by roughly the sample rate.

Counters and gauges were not affected because they do not use the generated latency/block handler.

## 👩🔬 How to validate

Tests added coverage that fails on `main` because `sample?` is called twice:

- sampled compiled distribution value path
- sampled compiled distribution block path
- sampled compiled distribution with aggregation enabled

Validation run locally:

```text
Full test suite:
390 runs, 1098 assertions, 0 failures, 0 errors

RuboCop changed files:
4 files inspected, no offenses detected
```

## Benchmark

Temporary benchmark script based on `benchmark/send-metrics-to-dev-null-log`, focused on compiled distributions. Higher `i/s` is better.

Environment: Ruby 3.4.9, arm64-darwin24.

`main` → this branch:

```text
compiled distribution value static rate=1
2.351M -> 2.579M i/s (+9.7%)

compiled distribution value dynamic tags rate=1
1.437M -> 1.509M i/s (+5.0%)

compiled distribution value static rate=0.5 sampled-in
2.055M -> 2.364M i/s (+15.0%)

compiled distribution block static rate=1
1.669M -> 1.746M i/s (+4.6%)
```

## Checklist

- [x] I documented the changes in the CHANGELOG file.
