### PR TITLE
Add positional aggregator interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ section below.
 
 ## Unreleased changes
 
-- Add an injectable positional aggregator interface with fixed-arity `increment`, `gauge`, and `aggregate_timing` entrypoints for native aggregation backends. Existing public client methods retain their keyword arguments.
+- Make the internal aggregator interface positional-only and injectable through `Client`, with fixed-arity `increment`, `gauge`, and `aggregate_timing` entrypoints for native aggregation backends. Public Client metric methods retain their keyword API.
 
 ## Version 3.11.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ section below.
 
 ## Unreleased changes
 
+## Version 3.12.0
+
 - Make the internal aggregator interface positional-only and injectable through `Client`, with fixed-arity `increment`, `gauge`, and `aggregate_timing` entrypoints for native aggregation backends. Public Client metric methods retain their keyword API.
 
 ## Version 3.11.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ section below.
 
 ## Unreleased changes
 
-## Version 3.12.0
+## Version 4.0.0
 
 - Make the internal aggregator interface positional-only and injectable through `Client`, with fixed-arity `increment`, `gauge`, and `aggregate_timing` entrypoints for native aggregation backends. Public Client metric methods retain their keyword API.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ section below.
 
 ## Unreleased changes
 
+- Add an injectable positional aggregator interface with fixed-arity `increment`, `gauge`, and `aggregate_timing` entrypoints for native aggregation backends. Existing public client methods retain their keyword arguments.
+
 ## Version 3.11.2
 
 - Widen the `CompiledMetric` tag-combination cache key from 32 to 57 bits, eliminating

--- a/README.md
+++ b/README.md
@@ -111,6 +111,32 @@ Please note that since aggregation is an experimental feature, it should be used
 > [!WARNING]
 > This feature is only compatible with Datadog Agent's version >=6.25.0 && <7.0.0 or Agent's versions >=7.25.0.
 
+#### External positional aggregators
+
+A client can use an external aggregation backend by passing `aggregator:`. This
+implicitly enables aggregation and uses fixed-arity positional calls, which
+avoids converting keyword arguments at a native extension boundary:
+
+```ruby
+client = StatsD::Instrument::Client.new(aggregator: MyNativeAggregator.new)
+```
+
+The aggregator implements:
+
+```ruby
+def record_counter(name, value, tags, no_prefix, sample_rate)
+def record_gauge(name, value, tags, no_prefix)
+def record_timing(name, value, tags, no_prefix, type, sample_rate)
+def flush
+```
+
+Calls without tags receive a shared frozen empty array. Other tag values are
+forwarded as-is; native aggregators can require callers to use arrays. The
+backend is responsible for applying the client's prefix/default-tag policy and
+for implementing the existing precompiled aggregation methods if it will be
+used with `CompiledMetric`. Cloned clients reuse the injected aggregator unless
+`aggregator:` is overridden.
+
 ## StatsD keys
 
 StatsD keys look like 'admin.logins.api.success'. Dots are used as namespace separators.

--- a/README.md
+++ b/README.md
@@ -111,11 +111,12 @@ Please note that since aggregation is an experimental feature, it should be used
 > [!WARNING]
 > This feature is only compatible with Datadog Agent's version >=6.25.0 && <7.0.0 or Agent's versions >=7.25.0.
 
-#### External positional aggregators
+#### Positional aggregator interface
 
-A client can use an external aggregation backend by passing `aggregator:`. This
-implicitly enables aggregation and uses fixed-arity positional calls, which
-avoids converting keyword arguments at a native extension boundary:
+The aggregator is an internal fixed-arity positional interface. Public Client
+methods keep their keyword options, but no keyword arguments are forwarded to
+the built-in or an injected aggregator. A client can inject a backend by passing
+`aggregator:`, which also implicitly enables aggregation:
 
 ```ruby
 client = StatsD::Instrument::Client.new(aggregator: MyNativeAggregator.new)
@@ -124,14 +125,14 @@ client = StatsD::Instrument::Client.new(aggregator: MyNativeAggregator.new)
 The aggregator implements:
 
 ```ruby
-def record_counter(name, value, tags, no_prefix, sample_rate)
-def record_gauge(name, value, tags, no_prefix)
-def record_timing(name, value, tags, no_prefix, type, sample_rate)
+def increment(name, value, tags, no_prefix, sample_rate)
+def gauge(name, value, tags, no_prefix)
+def aggregate_timing(name, value, tags, no_prefix, type, sample_rate)
 def flush
 ```
 
 Calls without tags receive a shared frozen empty array. Other tag values are
-forwarded as-is; native aggregators can require callers to use arrays. The
+forwarded as-is; custom aggregators can require callers to use arrays. The
 backend is responsible for applying the client's prefix/default-tag policy and
 for implementing the existing precompiled aggregation methods if it will be
 used with `CompiledMetric`. Cloned clients reuse the injected aggregator unless

--- a/README.md
+++ b/README.md
@@ -111,33 +111,6 @@ Please note that since aggregation is an experimental feature, it should be used
 > [!WARNING]
 > This feature is only compatible with Datadog Agent's version >=6.25.0 && <7.0.0 or Agent's versions >=7.25.0.
 
-#### Positional aggregator interface
-
-The aggregator is an internal fixed-arity positional interface. Public Client
-methods keep their keyword options, but no keyword arguments are forwarded to
-the built-in or an injected aggregator. A client can inject a backend by passing
-`aggregator:`, which also implicitly enables aggregation:
-
-```ruby
-client = StatsD::Instrument::Client.new(aggregator: MyNativeAggregator.new)
-```
-
-The aggregator implements:
-
-```ruby
-def increment(name, value, tags, no_prefix, sample_rate)
-def gauge(name, value, tags, no_prefix)
-def aggregate_timing(name, value, tags, no_prefix, type, sample_rate)
-def flush
-```
-
-Calls without tags receive a shared frozen empty array. Other tag values are
-forwarded as-is; custom aggregators can require callers to use arrays. The
-backend is responsible for applying the client's prefix/default-tag policy and
-for implementing the existing precompiled aggregation methods if it will be
-used with `CompiledMetric`. Cloned clients reuse the injected aggregator unless
-`aggregator:` is overridden.
-
 ## StatsD keys
 
 StatsD keys look like 'admin.logins.api.success'. Dots are used as namespace separators.

--- a/lib/statsd/instrument/aggregator.rb
+++ b/lib/statsd/instrument/aggregator.rb
@@ -148,7 +148,7 @@ module StatsD
       # @param tags [Hash{String, Symbol => String},Array<String>] The tags to attach to the counter.
       # @param no_prefix [Boolean] If true, the metric will not be prefixed.
       # @return [void]
-      def increment(name, value = 1, tags: [], no_prefix: false, sample_rate: CONST_SAMPLE_RATE)
+      def increment(name, value, tags, no_prefix, sample_rate)
         unless thread_healthcheck
           @sink << datagram_builder(no_prefix: no_prefix).c(name, value, sample_rate, tags)
           return
@@ -161,12 +161,6 @@ module StatsD
           @aggregation_state[key] ||= 0
           @aggregation_state[key] += value
         end
-      end
-
-      # Positional-only counter entrypoint used by external aggregation backends.
-      # @api private
-      def record_counter(name, value, tags, no_prefix, sample_rate)
-        increment(name, value, tags: tags, no_prefix: no_prefix, sample_rate: sample_rate)
       end
 
       # Aggregates a precompiled metric that can be combined into a single scalar for later flushing.
@@ -230,7 +224,7 @@ module StatsD
         end
       end
 
-      def aggregate_timing(name, value, tags: [], no_prefix: false, type: DISTRIBUTION, sample_rate: CONST_SAMPLE_RATE)
+      def aggregate_timing(name, value, tags, no_prefix, type, sample_rate)
         unless thread_healthcheck
           @sink << datagram_builder(no_prefix: no_prefix).timing_value_packed(
             name, type.to_s, [value], sample_rate, tags
@@ -255,13 +249,7 @@ module StatsD
         do_flush(aggregation_state) if aggregation_state
       end
 
-      # Positional-only timing entrypoint used by external aggregation backends.
-      # @api private
-      def record_timing(name, value, tags, no_prefix, type, sample_rate)
-        aggregate_timing(name, value, tags: tags, no_prefix: no_prefix, type: type, sample_rate: sample_rate)
-      end
-
-      def gauge(name, value, tags: [], no_prefix: false)
+      def gauge(name, value, tags, no_prefix)
         unless thread_healthcheck
           @sink << datagram_builder(no_prefix: no_prefix).g(name, value, CONST_SAMPLE_RATE, tags)
           return
@@ -273,12 +261,6 @@ module StatsD
         @aggregation_state_mutex.synchronize do
           @aggregation_state[key] = value
         end
-      end
-
-      # Positional-only gauge entrypoint used by external aggregation backends.
-      # @api private
-      def record_gauge(name, value, tags, no_prefix)
-        gauge(name, value, tags: tags, no_prefix: no_prefix)
       end
 
       def flush

--- a/lib/statsd/instrument/aggregator.rb
+++ b/lib/statsd/instrument/aggregator.rb
@@ -163,6 +163,12 @@ module StatsD
         end
       end
 
+      # Positional-only counter entrypoint used by external aggregation backends.
+      # @api private
+      def record_counter(name, value, tags, no_prefix, sample_rate)
+        increment(name, value, tags: tags, no_prefix: no_prefix, sample_rate: sample_rate)
+      end
+
       # Aggregates a precompiled metric that can be combined into a single scalar for later flushing.
       # @param precompiled_datagram [StatsD::Instrument::CompiledMetric::PrecompiledDatagram]
       #   The precompiled metric datagram, with the tag values already "filled-in".
@@ -249,6 +255,12 @@ module StatsD
         do_flush(aggregation_state) if aggregation_state
       end
 
+      # Positional-only timing entrypoint used by external aggregation backends.
+      # @api private
+      def record_timing(name, value, tags, no_prefix, type, sample_rate)
+        aggregate_timing(name, value, tags: tags, no_prefix: no_prefix, type: type, sample_rate: sample_rate)
+      end
+
       def gauge(name, value, tags: [], no_prefix: false)
         unless thread_healthcheck
           @sink << datagram_builder(no_prefix: no_prefix).g(name, value, CONST_SAMPLE_RATE, tags)
@@ -261,6 +273,12 @@ module StatsD
         @aggregation_state_mutex.synchronize do
           @aggregation_state[key] = value
         end
+      end
+
+      # Positional-only gauge entrypoint used by external aggregation backends.
+      # @api private
+      def record_gauge(name, value, tags, no_prefix)
+        gauge(name, value, tags: tags, no_prefix: no_prefix)
       end
 
       def flush

--- a/lib/statsd/instrument/client.rb
+++ b/lib/statsd/instrument/client.rb
@@ -19,6 +19,9 @@ module StatsD
     # @see StatsD.singleton_client
     # @see #clone_with_options
     class Client
+      EMPTY_TAGS = [].freeze
+      private_constant :EMPTY_TAGS
+
       class << self
         # Instantiates a StatsD::Instrument::Client using configuration values provided in
         # environment variables.
@@ -31,7 +34,8 @@ module StatsD
           default_tags: env.statsd_default_tags,
           implementation: env.statsd_implementation,
           sink: env.default_sink_for_environment,
-          datagram_builder_class: datagram_builder_class_for_implementation(implementation)
+          datagram_builder_class: datagram_builder_class_for_implementation(implementation),
+          aggregator: nil
         )
           new(
             prefix: prefix,
@@ -42,6 +46,7 @@ module StatsD
             datagram_builder_class: datagram_builder_class,
             enable_aggregation: env.experimental_aggregation_enabled?,
             aggregation_flush_interval: env.aggregation_interval,
+            aggregator: aggregator,
           )
         end
 
@@ -147,6 +152,17 @@ module StatsD
       end
 
       # Instantiates a new client.
+      #
+      # When +aggregator+ is provided, it enables aggregation and dispatches through
+      # the fixed-arity positional +record_counter+, +record_gauge+, and
+      # +record_timing+ interface. This avoids keyword argument conversion at a
+      # native extension boundary. The injected aggregator is also expected to
+      # implement the existing precompiled aggregation methods and +flush+.
+      # Calls without tags receive a shared frozen empty array. Other tag values
+      # are forwarded as-is; native backends may require callers to pass arrays.
+      #
+      # @param aggregator [#record_counter, #record_gauge, #record_timing, nil]
+      #   Optional external aggregation backend.
       # @see .from_env to instantiate a client using environment variables.
       def initialize(
         prefix: nil,
@@ -157,7 +173,8 @@ module StatsD
         datagram_builder_class: self.class.datagram_builder_class_for_implementation(implementation),
         enable_aggregation: false,
         aggregation_flush_interval: 2.0,
-        aggregation_max_context_size: StatsD::Instrument::Aggregator::DEFAULT_MAX_CONTEXT_SIZE
+        aggregation_max_context_size: StatsD::Instrument::Aggregator::DEFAULT_MAX_CONTEXT_SIZE,
+        aggregator: nil
       )
         @sink = sink
         @datagram_builder_class = datagram_builder_class
@@ -167,10 +184,11 @@ module StatsD
         @default_sample_rate = default_sample_rate
 
         @datagram_builder = { false => nil, true => nil }
-        @enable_aggregation = enable_aggregation
+        @positional_aggregator = !aggregator.nil?
+        @enable_aggregation = enable_aggregation || @positional_aggregator
         @aggregation_flush_interval = aggregation_flush_interval
         if @enable_aggregation
-          @aggregator =
+          @aggregator = aggregator ||
             Aggregator.new(
               @sink,
               datagram_builder_class,
@@ -223,7 +241,11 @@ module StatsD
         return StatsD::Instrument::VOID if sample_rate && !sample?(sample_rate)
 
         if @enable_aggregation
-          @aggregator.increment(name, value, tags: tags, no_prefix: no_prefix, sample_rate: sample_rate)
+          if @positional_aggregator
+            @aggregator.record_counter(name, value, tags || EMPTY_TAGS, no_prefix, sample_rate)
+          else
+            @aggregator.increment(name, value, tags: tags, no_prefix: no_prefix, sample_rate: sample_rate)
+          end
         else
           emit(datagram_builder(no_prefix: no_prefix).c(name, value, sample_rate, tags))
         end
@@ -357,7 +379,11 @@ module StatsD
         end
 
         if @enable_aggregation
-          @aggregator.aggregate_timing(name, value, tags: tags, no_prefix: no_prefix, type: :ms, sample_rate: sample_rate)
+          if @positional_aggregator
+            @aggregator.record_timing(name, value, tags || EMPTY_TAGS, no_prefix, :ms, sample_rate)
+          else
+            @aggregator.aggregate_timing(name, value, tags: tags, no_prefix: no_prefix, type: :ms, sample_rate: sample_rate)
+          end
           return StatsD::Instrument::VOID
         end
         emit(datagram_builder(no_prefix: no_prefix).ms(name, value, sample_rate, tags))
@@ -379,7 +405,11 @@ module StatsD
       # @return [void]
       def gauge(name, value, sample_rate: nil, tags: nil, no_prefix: false)
         if @enable_aggregation
-          @aggregator.gauge(name, value, tags: tags, no_prefix: no_prefix)
+          if @positional_aggregator
+            @aggregator.record_gauge(name, value, tags || EMPTY_TAGS, no_prefix)
+          else
+            @aggregator.gauge(name, value, tags: tags, no_prefix: no_prefix)
+          end
           return StatsD::Instrument::VOID
         end
 
@@ -431,14 +461,18 @@ module StatsD
         end
 
         if @enable_aggregation
-          @aggregator.aggregate_timing(
-            name,
-            value,
-            tags: tags,
-            no_prefix: no_prefix,
-            type: :d,
-            sample_rate: sample_rate,
-          )
+          if @positional_aggregator
+            @aggregator.record_timing(name, value, tags || EMPTY_TAGS, no_prefix, :d, sample_rate)
+          else
+            @aggregator.aggregate_timing(
+              name,
+              value,
+              tags: tags,
+              no_prefix: no_prefix,
+              type: :d,
+              sample_rate: sample_rate,
+            )
+          end
           return StatsD::Instrument::VOID
         end
 
@@ -467,7 +501,11 @@ module StatsD
         end
 
         if @enable_aggregation
-          @aggregator.aggregate_timing(name, value, tags: tags, no_prefix: no_prefix, type: :h, sample_rate: sample_rate)
+          if @positional_aggregator
+            @aggregator.record_timing(name, value, tags || EMPTY_TAGS, no_prefix, :h, sample_rate)
+          else
+            @aggregator.aggregate_timing(name, value, tags: tags, no_prefix: no_prefix, type: :h, sample_rate: sample_rate)
+          end
           return StatsD::Instrument::VOID
         end
 
@@ -505,14 +543,18 @@ module StatsD
             latency_in_ms = stop - start
 
             if @enable_aggregation
-              @aggregator.aggregate_timing(
-                name,
-                latency_in_ms,
-                tags: tags,
-                no_prefix: no_prefix,
-                type: metric_type,
-                sample_rate: sample_rate,
-              )
+              if @positional_aggregator
+                @aggregator.record_timing(name, latency_in_ms, tags || EMPTY_TAGS, no_prefix, metric_type, sample_rate)
+              else
+                @aggregator.aggregate_timing(
+                  name,
+                  latency_in_ms,
+                  tags: tags,
+                  no_prefix: no_prefix,
+                  type: metric_type,
+                  sample_rate: sample_rate,
+                )
+              end
             else
               emit(datagram_builder(no_prefix: no_prefix).send(metric_type, name, latency_in_ms, sample_rate, tags))
             end
@@ -598,7 +640,8 @@ module StatsD
         prefix: NO_CHANGE,
         default_sample_rate: NO_CHANGE,
         default_tags: NO_CHANGE,
-        datagram_builder_class: NO_CHANGE
+        datagram_builder_class: NO_CHANGE,
+        aggregator: NO_CHANGE
       )
         client = clone_with_options(
           sink: sink,
@@ -606,6 +649,7 @@ module StatsD
           default_sample_rate: default_sample_rate,
           default_tags: default_tags,
           datagram_builder_class: datagram_builder_class,
+          aggregator: aggregator,
         )
 
         yield(client)
@@ -616,7 +660,8 @@ module StatsD
         prefix: NO_CHANGE,
         default_sample_rate: NO_CHANGE,
         default_tags: NO_CHANGE,
-        datagram_builder_class: NO_CHANGE
+        datagram_builder_class: NO_CHANGE,
+        aggregator: NO_CHANGE
       )
         self.class.new(
           sink: sink == NO_CHANGE ? @sink : sink,
@@ -627,6 +672,7 @@ module StatsD
             datagram_builder_class == NO_CHANGE ? @datagram_builder_class : datagram_builder_class,
           enable_aggregation: @enable_aggregation,
           aggregation_flush_interval: @aggregation_flush_interval,
+          aggregator: aggregator == NO_CHANGE ? (@aggregator if @positional_aggregator) : aggregator,
         )
       end
 

--- a/lib/statsd/instrument/client.rb
+++ b/lib/statsd/instrument/client.rb
@@ -153,15 +153,14 @@ module StatsD
 
       # Instantiates a new client.
       #
-      # When +aggregator+ is provided, it enables aggregation and dispatches through
-      # the fixed-arity positional +record_counter+, +record_gauge+, and
-      # +record_timing+ interface. This avoids keyword argument conversion at a
-      # native extension boundary. The injected aggregator is also expected to
-      # implement the existing precompiled aggregation methods and +flush+.
-      # Calls without tags receive a shared frozen empty array. Other tag values
-      # are forwarded as-is; native backends may require callers to pass arrays.
+      # Aggregators use fixed-arity positional +increment+, +gauge+, and
+      # +aggregate_timing+ methods. This keeps the aggregation hot path simple
+      # and avoids keyword argument forwarding. An injected aggregator is also
+      # expected to implement the existing precompiled aggregation methods and
+      # +flush+. Calls without tags receive a shared frozen empty array. Other tag
+      # values are forwarded as-is; custom backends may require arrays.
       #
-      # @param aggregator [#record_counter, #record_gauge, #record_timing, nil]
+      # @param aggregator [#increment, #gauge, #aggregate_timing, nil]
       #   Optional external aggregation backend.
       # @see .from_env to instantiate a client using environment variables.
       def initialize(
@@ -184,8 +183,8 @@ module StatsD
         @default_sample_rate = default_sample_rate
 
         @datagram_builder = { false => nil, true => nil }
-        @positional_aggregator = !aggregator.nil?
-        @enable_aggregation = enable_aggregation || @positional_aggregator
+        @injected_aggregator = aggregator
+        @enable_aggregation = enable_aggregation || !aggregator.nil?
         @aggregation_flush_interval = aggregation_flush_interval
         if @enable_aggregation
           @aggregator = aggregator ||
@@ -241,11 +240,7 @@ module StatsD
         return StatsD::Instrument::VOID if sample_rate && !sample?(sample_rate)
 
         if @enable_aggregation
-          if @positional_aggregator
-            @aggregator.record_counter(name, value, tags || EMPTY_TAGS, no_prefix, sample_rate)
-          else
-            @aggregator.increment(name, value, tags: tags, no_prefix: no_prefix, sample_rate: sample_rate)
-          end
+          @aggregator.increment(name, value, tags || EMPTY_TAGS, no_prefix, sample_rate)
         else
           emit(datagram_builder(no_prefix: no_prefix).c(name, value, sample_rate, tags))
         end
@@ -379,11 +374,7 @@ module StatsD
         end
 
         if @enable_aggregation
-          if @positional_aggregator
-            @aggregator.record_timing(name, value, tags || EMPTY_TAGS, no_prefix, :ms, sample_rate)
-          else
-            @aggregator.aggregate_timing(name, value, tags: tags, no_prefix: no_prefix, type: :ms, sample_rate: sample_rate)
-          end
+          @aggregator.aggregate_timing(name, value, tags || EMPTY_TAGS, no_prefix, :ms, sample_rate)
           return StatsD::Instrument::VOID
         end
         emit(datagram_builder(no_prefix: no_prefix).ms(name, value, sample_rate, tags))
@@ -405,11 +396,7 @@ module StatsD
       # @return [void]
       def gauge(name, value, sample_rate: nil, tags: nil, no_prefix: false)
         if @enable_aggregation
-          if @positional_aggregator
-            @aggregator.record_gauge(name, value, tags || EMPTY_TAGS, no_prefix)
-          else
-            @aggregator.gauge(name, value, tags: tags, no_prefix: no_prefix)
-          end
+          @aggregator.gauge(name, value, tags || EMPTY_TAGS, no_prefix)
           return StatsD::Instrument::VOID
         end
 
@@ -461,18 +448,7 @@ module StatsD
         end
 
         if @enable_aggregation
-          if @positional_aggregator
-            @aggregator.record_timing(name, value, tags || EMPTY_TAGS, no_prefix, :d, sample_rate)
-          else
-            @aggregator.aggregate_timing(
-              name,
-              value,
-              tags: tags,
-              no_prefix: no_prefix,
-              type: :d,
-              sample_rate: sample_rate,
-            )
-          end
+          @aggregator.aggregate_timing(name, value, tags || EMPTY_TAGS, no_prefix, :d, sample_rate)
           return StatsD::Instrument::VOID
         end
 
@@ -501,11 +477,7 @@ module StatsD
         end
 
         if @enable_aggregation
-          if @positional_aggregator
-            @aggregator.record_timing(name, value, tags || EMPTY_TAGS, no_prefix, :h, sample_rate)
-          else
-            @aggregator.aggregate_timing(name, value, tags: tags, no_prefix: no_prefix, type: :h, sample_rate: sample_rate)
-          end
+          @aggregator.aggregate_timing(name, value, tags || EMPTY_TAGS, no_prefix, :h, sample_rate)
           return StatsD::Instrument::VOID
         end
 
@@ -543,18 +515,14 @@ module StatsD
             latency_in_ms = stop - start
 
             if @enable_aggregation
-              if @positional_aggregator
-                @aggregator.record_timing(name, latency_in_ms, tags || EMPTY_TAGS, no_prefix, metric_type, sample_rate)
-              else
-                @aggregator.aggregate_timing(
-                  name,
-                  latency_in_ms,
-                  tags: tags,
-                  no_prefix: no_prefix,
-                  type: metric_type,
-                  sample_rate: sample_rate,
-                )
-              end
+              @aggregator.aggregate_timing(
+                name,
+                latency_in_ms,
+                tags || EMPTY_TAGS,
+                no_prefix,
+                metric_type,
+                sample_rate,
+              )
             else
               emit(datagram_builder(no_prefix: no_prefix).send(metric_type, name, latency_in_ms, sample_rate, tags))
             end
@@ -672,7 +640,7 @@ module StatsD
             datagram_builder_class == NO_CHANGE ? @datagram_builder_class : datagram_builder_class,
           enable_aggregation: @enable_aggregation,
           aggregation_flush_interval: @aggregation_flush_interval,
-          aggregator: aggregator == NO_CHANGE ? (@aggregator if @positional_aggregator) : aggregator,
+          aggregator: aggregator == NO_CHANGE ? @injected_aggregator : aggregator,
         )
       end
 

--- a/lib/statsd/instrument/version.rb
+++ b/lib/statsd/instrument/version.rb
@@ -2,6 +2,6 @@
 
 module StatsD
   module Instrument
-    VERSION = "3.11.2"
+    VERSION = "3.12.0"
   end
 end

--- a/lib/statsd/instrument/version.rb
+++ b/lib/statsd/instrument/version.rb
@@ -2,6 +2,6 @@
 
 module StatsD
   module Instrument
-    VERSION = "3.12.0"
+    VERSION = "4.0.0"
   end
 end

--- a/test/aggregator_test.rb
+++ b/test/aggregator_test.rb
@@ -3,22 +3,6 @@
 require "test_helper"
 
 class AggregatorTest < Minitest::Test
-  # Keeps the behavior-focused tests readable while the production Aggregator
-  # exposes only its strict positional interface.
-  class KeywordTestAggregator < StatsD::Instrument::Aggregator
-    def increment(name, value = 1, tags: [], no_prefix: false, sample_rate: 1.0)
-      super(name, value, tags, no_prefix, sample_rate)
-    end
-
-    def gauge(name, value, tags: [], no_prefix: false)
-      super(name, value, tags, no_prefix)
-    end
-
-    def aggregate_timing(name, value, tags: [], no_prefix: false, type: :d, sample_rate: 1.0)
-      super(name, value, tags, no_prefix, type, sample_rate)
-    end
-  end
-
   class CaptureLogger
     attr_reader :messages
 
@@ -40,7 +24,7 @@ class AggregatorTest < Minitest::Test
     StatsD.logger = @logger
 
     @sink = StatsD::Instrument::CaptureSink.new(parent: StatsD::Instrument::NullSink.new)
-    @subject = KeywordTestAggregator.new(
+    @subject = StatsD::Instrument::Aggregator.new(
       @sink, StatsD::Instrument::DatagramBuilder, nil, [], flush_interval: 0.1
     )
   end
@@ -52,8 +36,8 @@ class AggregatorTest < Minitest::Test
   end
 
   def test_increment_simple
-    @subject.increment("foo", 1, tags: { foo: "bar" })
-    @subject.increment("foo", 1, tags: { foo: "bar" })
+    @subject.increment("foo", 1, ["foo:bar"], false, 1.0)
+    @subject.increment("foo", 1, ["foo:bar"], false, 1.0)
     @subject.flush
 
     datagram = @sink.datagrams.first
@@ -64,10 +48,9 @@ class AggregatorTest < Minitest::Test
   end
 
   def test_increment_with_sample_rate
-    # Test that increment properly passes through sample_rate
-    @subject.increment("counter.sampled", 1, tags: { foo: "bar" }, sample_rate: 0.5)
-    @subject.increment("counter.sampled", 2, tags: { foo: "bar" }, sample_rate: 0.5)
-    @subject.increment("counter.unsampled", 1, tags: { foo: "bar" })
+    @subject.increment("counter.sampled", 1, ["foo:bar"], false, 0.5)
+    @subject.increment("counter.sampled", 2, ["foo:bar"], false, 0.5)
+    @subject.increment("counter.unsampled", 1, ["foo:bar"], false, 1.0)
     @subject.flush
 
     assert_equal(2, @sink.datagrams.size)
@@ -84,11 +67,10 @@ class AggregatorTest < Minitest::Test
   end
 
   def test_increment_different_sample_rates_create_different_aggregation_keys
-    # Counters with different sample rates should be aggregated separately
-    @subject.increment("counter", 1, sample_rate: 0.5)
-    @subject.increment("counter", 2, sample_rate: 0.5)
-    @subject.increment("counter", 10, sample_rate: 0.1)
-    @subject.increment("counter", 20, sample_rate: 0.1)
+    @subject.increment("counter", 1, [], false, 0.5)
+    @subject.increment("counter", 2, [], false, 0.5)
+    @subject.increment("counter", 10, [], false, 0.1)
+    @subject.increment("counter", 20, [], false, 0.1)
     @subject.flush
 
     assert_equal(2, @sink.datagrams.size)
@@ -101,8 +83,8 @@ class AggregatorTest < Minitest::Test
   end
 
   def test_distribution_simple
-    @subject.aggregate_timing("foo", 1, tags: { foo: "bar" })
-    @subject.aggregate_timing("foo", 100, tags: { foo: "bar" })
+    @subject.aggregate_timing("foo", 1, ["foo:bar"], false, :d, 1.0)
+    @subject.aggregate_timing("foo", 100, ["foo:bar"], false, :d, 1.0)
     @subject.flush
 
     datagram = @sink.datagrams.first
@@ -112,9 +94,9 @@ class AggregatorTest < Minitest::Test
   end
 
   def test_timing_sampling_scaling
-    @subject.aggregate_timing("timing.sampled", 60.0, sample_rate: 0.01)
-    @subject.aggregate_timing("timing.sampled", 80.0, sample_rate: 0.01)
-    @subject.aggregate_timing("timing.unsampled", 60.0, sample_rate: 1.0)
+    @subject.aggregate_timing("timing.sampled", 60.0, [], false, :d, 0.01)
+    @subject.aggregate_timing("timing.sampled", 80.0, [], false, :d, 0.01)
+    @subject.aggregate_timing("timing.unsampled", 60.0, [], false, :d, 1.0)
 
     @subject.flush
 
@@ -130,11 +112,11 @@ class AggregatorTest < Minitest::Test
   end
 
   def test_mixed_type_timings
-    @subject.aggregate_timing("foo_ms", 1, tags: { foo: "bar" }, type: :ms)
-    @subject.aggregate_timing("foo_ms", 100, tags: { foo: "bar" }, type: :ms)
+    @subject.aggregate_timing("foo_ms", 1, ["foo:bar"], false, :ms, 1.0)
+    @subject.aggregate_timing("foo_ms", 100, ["foo:bar"], false, :ms, 1.0)
 
-    @subject.aggregate_timing("foo_d", 100, tags: { foo: "bar" }, type: :d)
-    @subject.aggregate_timing("foo_d", 120, tags: { foo: "bar" }, type: :d)
+    @subject.aggregate_timing("foo_d", 100, ["foo:bar"], false, :d, 1.0)
+    @subject.aggregate_timing("foo_d", 120, ["foo:bar"], false, :d, 1.0)
 
     @subject.flush
 
@@ -146,8 +128,8 @@ class AggregatorTest < Minitest::Test
   end
 
   def test_gauge_simple
-    @subject.gauge("foo", 1, tags: { foo: "bar" })
-    @subject.gauge("foo", 100, tags: { foo: "bar" })
+    @subject.gauge("foo", 1, ["foo:bar"], false)
+    @subject.gauge("foo", 100, ["foo:bar"], false)
     @subject.flush
 
     datagram = @sink.datagrams.first
@@ -157,18 +139,18 @@ class AggregatorTest < Minitest::Test
   end
 
   def test_increment_with_tags_in_different_orders
-    @subject.increment("foo", 1, tags: ["tag1:val1", "tag2:val2"])
-    @subject.increment("foo", 1, tags: ["tag2:val2", "tag1:val1"])
+    @subject.increment("foo", 1, ["tag1:val1", "tag2:val2"], false, 1.0)
+    @subject.increment("foo", 1, ["tag2:val2", "tag1:val1"], false, 1.0)
     @subject.flush
 
     assert_equal(2, @sink.datagrams.first.value)
   end
 
   def test_increment_with_different_tag_values
-    @subject.increment("foo", 1, tags: ["tag1:val1", "tag2:val2"])
-    @subject.increment("foo", 1, tags: { tag1: "val1", tag2: "val2" })
+    @subject.increment("foo", 1, ["tag1:val1", "tag2:val2"], false, 1.0)
+    @subject.increment("foo", 1, { tag1: "val1", tag2: "val2" }, false, 1.0)
 
-    @subject.increment("bar")
+    @subject.increment("bar", 1, [], false, 1.0)
     @subject.flush
 
     assert_equal(2, @sink.datagrams.first.value)
@@ -177,8 +159,8 @@ class AggregatorTest < Minitest::Test
   end
 
   def test_increment_with_different_metric_names
-    @subject.increment("foo", 1, tags: ["tag1:val1", "tag2:val2"])
-    @subject.increment("bar", 1, tags: ["tag1:val1", "tag2:val2"])
+    @subject.increment("foo", 1, ["tag1:val1", "tag2:val2"], false, 1.0)
+    @subject.increment("bar", 1, ["tag1:val1", "tag2:val2"], false, 1.0)
     @subject.flush
 
     assert_equal(1, @sink.datagrams.find { |d| d.name == "foo" }.value)
@@ -186,22 +168,22 @@ class AggregatorTest < Minitest::Test
   end
 
   def test_increment_with_different_values
-    @subject.increment("foo", 1, tags: ["tag1:val1", "tag2:val2"])
-    @subject.increment("foo", 2, tags: ["tag1:val1", "tag2:val2"])
+    @subject.increment("foo", 1, ["tag1:val1", "tag2:val2"], false, 1.0)
+    @subject.increment("foo", 2, ["tag1:val1", "tag2:val2"], false, 1.0)
     @subject.flush
 
     assert_equal(3, @sink.datagrams.first.value)
   end
 
   def test_send_mixed_types_will_pass_through
-    @subject.increment("test_counter", 1, tags: ["tag1:val1", "tag2:val2"])
-    @subject.aggregate_timing("test_counter", 100, tags: ["tag1:val1", "tag2:val2"])
+    @subject.increment("test_counter", 1, ["tag1:val1", "tag2:val2"], false, 1.0)
+    @subject.aggregate_timing("test_counter", 100, ["tag1:val1", "tag2:val2"], false, :d, 1.0)
 
-    @subject.gauge("test_gauge", 100, tags: ["tag1:val1", "tag2:val2"])
-    @subject.increment("test_gauge", 1, tags: ["tag1:val1", "tag2:val2"])
+    @subject.gauge("test_gauge", 100, ["tag1:val1", "tag2:val2"], false)
+    @subject.increment("test_gauge", 1, ["tag1:val1", "tag2:val2"], false, 1.0)
 
-    @subject.aggregate_timing("test_timing", 100, tags: ["tag1:val1", "tag2:val2"])
-    @subject.gauge("test_timing", 100, tags: ["tag1:val1", "tag2:val2"])
+    @subject.aggregate_timing("test_timing", 100, ["tag1:val1", "tag2:val2"], false, :d, 1.0)
+    @subject.gauge("test_timing", 100, ["tag1:val1", "tag2:val2"], false)
     @subject.flush
 
     assert_equal(6, @sink.datagrams.size)
@@ -216,12 +198,12 @@ class AggregatorTest < Minitest::Test
   end
 
   def test_with_prefix
-    aggregator = KeywordTestAggregator.new(@sink, StatsD::Instrument::DatagramBuilder, "MyApp", [])
+    aggregator = StatsD::Instrument::Aggregator.new(@sink, StatsD::Instrument::DatagramBuilder, "MyApp", [])
 
-    aggregator.increment("foo", 1, tags: ["tag1:val1", "tag2:val2"])
-    aggregator.increment("foo", 1, tags: ["tag1:val1", "tag2:val2"])
+    aggregator.increment("foo", 1, ["tag1:val1", "tag2:val2"], false, 1.0)
+    aggregator.increment("foo", 1, ["tag1:val1", "tag2:val2"], false, 1.0)
 
-    aggregator.increment("foo", 1, tags: ["tag1:val1", "tag2:val2"], no_prefix: true)
+    aggregator.increment("foo", 1, ["tag1:val1", "tag2:val2"], true, 1.0)
     aggregator.flush
 
     assert_equal(2, @sink.datagrams.size)
@@ -233,14 +215,11 @@ class AggregatorTest < Minitest::Test
   end
 
   def test_finalizer_with_prefix
-    # Test that the finalizer correctly uses the prefix when flushing metrics
-    # IMPORTANT: Use empty tags to ensure datagram_builder is not pre-created by tags_sorted
-    aggregator = KeywordTestAggregator.new(@sink, StatsD::Instrument::DatagramBuilder, "MyApp", [])
+    aggregator = StatsD::Instrument::Aggregator.new(@sink, StatsD::Instrument::DatagramBuilder, "MyApp", [])
 
-    aggregator.increment("foo", 1, tags: [])
-    aggregator.increment("bar", 1, tags: [], no_prefix: true)
+    aggregator.increment("foo", 1, [], false, 1.0)
+    aggregator.increment("bar", 1, [], true, 1.0)
 
-    # Manually trigger the finalizer (simulates GC cleanup)
     finalizer = StatsD::Instrument::Aggregator.finalize(
       aggregator.instance_variable_get(:@finalizer),
     )
@@ -258,18 +237,15 @@ class AggregatorTest < Minitest::Test
   end
 
   def test_synchronous_operation_on_thread_failure
-    # Force thread_healthcheck to return false
     @subject.stubs(:thread_healthcheck).returns(false)
 
-    # Stub methods on @aggregation_state to ensure they are not called
     aggregation_state = @subject.instance_variable_get(:@aggregation_state)
     aggregation_state.stubs(:[]=).never
 
-    @subject.increment("foo", 1, tags: { foo: "bar" })
-    @subject.aggregate_timing("bar", 100, tags: { foo: "bar" })
-    @subject.gauge("baz", 100, tags: { foo: "bar" })
+    @subject.increment("foo", 1, ["foo:bar"], false, 1.0)
+    @subject.aggregate_timing("bar", 100, ["foo:bar"], false, :d, 1.0)
+    @subject.gauge("baz", 100, ["foo:bar"], false)
 
-    # Verify metrics were sent immediately
     assert_equal(3, @sink.datagrams.size)
 
     counter_datagram = @sink.datagrams.find { |d| d.name == "foo" }
@@ -284,11 +260,9 @@ class AggregatorTest < Minitest::Test
     assert_equal(100, gauge_datagram.value)
     assert_equal(["foo:bar"], gauge_datagram.tags)
 
-    # Additional metrics should also go through synchronously
-    @subject.increment("foo", 1, tags: { foo: "bar" })
-    @subject.aggregate_timing("bar", 200, tags: { foo: "bar" }, sample_rate: 0.5)
+    @subject.increment("foo", 1, ["foo:bar"], false, 1.0)
+    @subject.aggregate_timing("bar", 200, ["foo:bar"], false, :d, 0.5)
 
-    # Verify new metrics were also sent immediately
     assert_equal(5, @sink.datagrams.size)
 
     counter_datagram = @sink.datagrams.select { |d| d.name == "foo" }.last
@@ -303,65 +277,52 @@ class AggregatorTest < Minitest::Test
     after_aggregation_state = @subject.instance_variable_get(:@aggregation_state)
     assert_same(after_aggregation_state, aggregation_state)
 
-    # undo the stubbing
     @subject.unstub(:thread_healthcheck)
   end
 
   def test_recreate_thread_after_fork
     skip("#{RUBY_ENGINE} not supported for this test. Reason: fork()") if RUBY_ENGINE != "ruby"
-    # Record initial metrics
-    @subject.increment("foo", 1, tags: { foo: "bar" })
-    @subject.aggregate_timing("bar", 100, tags: { foo: "bar" })
+    @subject.increment("foo", 1, ["foo:bar"], false, 1.0)
+    @subject.aggregate_timing("bar", 100, ["foo:bar"], false, :d, 1.0)
 
-    # kill the flush thread
     @subject.instance_variable_get(:@flush_thread).kill
 
-    # Fork the process
     pid = Process.fork do
-      # In forked process, send more metrics
-      @subject.increment("foo", 2, tags: { foo: "bar" })
-      @subject.aggregate_timing("bar", 200, tags: { foo: "bar" })
+      @subject.increment("foo", 2, ["foo:bar"], false, 1.0)
+      @subject.aggregate_timing("bar", 200, ["foo:bar"], false, :d, 1.0)
       @subject.flush
 
       assert_equal(2, @sink.datagrams.size)
       exit!
     end
 
-    # Wait for forked process to complete
     Process.wait(pid)
 
-    # Send metrics in parent process
-    @subject.increment("foo", 3, tags: { foo: "bar" })
-    @subject.aggregate_timing("bar", 300, tags: { foo: "bar" })
+    @subject.increment("foo", 3, ["foo:bar"], false, 1.0)
+    @subject.aggregate_timing("bar", 300, ["foo:bar"], false, :d, 1.0)
     @subject.flush
 
     assert_equal(2, @sink.datagrams.size)
 
-    # Verify metrics were properly aggregated in parent process
     counter_datagrams = @sink.datagrams.select { |d| d.name == "foo" }
     timing_datagrams = @sink.datagrams.select { |d| d.name == "bar" }
 
     assert_equal(1, counter_datagrams.size)
     assert_equal(1, timing_datagrams.size)
 
-    # Aggregate despite fork
     assert_equal(4, counter_datagrams.last.value)
     assert_equal([100.0, 300.0], timing_datagrams.last.value)
   end
 
   def test_race_condition_during_forking
     skip("#{RUBY_ENGINE} not supported for this test. Reason: fork()") if RUBY_ENGINE != "ruby"
-    # Record initial metrics
-    @subject.increment("before_fork.count", 1, tags: { foo: "bar" })
-    @subject.aggregate_timing("before_fork.timing", 100, tags: { foo: "bar" })
+    @subject.increment("before_fork.count", 1, ["foo:bar"], false, 1.0)
+    @subject.aggregate_timing("before_fork.timing", 100, ["foo:bar"], false, :d, 1.0)
 
-    # Fork the process
     pid = Process.fork do
-      # In forked process, send more metrics
-      @subject.increment("in_child.count", 2, tags: { foo: "bar" })
-      @subject.aggregate_timing("in_child.timing", 200, tags: { foo: "bar" })
+      @subject.increment("in_child.count", 2, ["foo:bar"], false, 1.0)
+      @subject.aggregate_timing("in_child.timing", 200, ["foo:bar"], false, :d, 1.0)
 
-      # Simulate thread waiting for flush
       sleep(0.1)
       @subject.flush
 
@@ -369,20 +330,16 @@ class AggregatorTest < Minitest::Test
       exit!
     end
 
-    # Call flush concurrently in parent process
     @subject.flush
 
-    # Wait for forked process to complete
     Process.wait(pid)
 
-    # Send metrics in parent process
-    @subject.increment("after_fork.count", 3, tags: { foo: "bar" })
-    @subject.aggregate_timing("after_fork.timing", 300, tags: { foo: "bar" })
+    @subject.increment("after_fork.count", 3, ["foo:bar"], false, 1.0)
+    @subject.aggregate_timing("after_fork.timing", 300, ["foo:bar"], false, :d, 1.0)
     @subject.flush
 
     assert_equal(4, @sink.datagrams.size)
 
-    # Verify metrics were properly aggregated in parent process
     counter_datagrams = @sink.datagrams.select { |d| d.name == "before_fork.count" }
     timing_datagrams = @sink.datagrams.select { |d| d.name == "before_fork.count" }
     assert_equal(
@@ -392,7 +349,6 @@ class AggregatorTest < Minitest::Test
     )
     assert_equal(1, timing_datagrams.size)
 
-    # After fork metrics
     counter_datagrams = @sink.datagrams.select { |d| d.name == "after_fork.count" }
     timing_datagrams = @sink.datagrams.select { |d| d.name == "after_fork.count" }
     assert_equal(1, counter_datagrams.size)
@@ -400,18 +356,16 @@ class AggregatorTest < Minitest::Test
   end
 
   def test_finalizer_flushes_pending_metrics
-    @subject.increment("foo", 1, tags: { foo: "bar" })
-    @subject.aggregate_timing("bar", 100, tags: { foo: "bar" })
-    @subject.gauge("baz", 100, tags: { foo: "bar" })
-    @subject.aggregate_timing("sampled_timing", 100, tags: { foo: "bar" }, sample_rate: 0.01)
+    @subject.increment("foo", 1, ["foo:bar"], false, 1.0)
+    @subject.aggregate_timing("bar", 100, ["foo:bar"], false, :d, 1.0)
+    @subject.gauge("baz", 100, ["foo:bar"], false)
+    @subject.aggregate_timing("sampled_timing", 100, ["foo:bar"], false, :d, 0.01)
 
-    # Manually trigger the finalizer
     finalizer = StatsD::Instrument::Aggregator.finalize(
       @subject.instance_variable_get(:@finalizer),
     )
     finalizer.call
 
-    # Verify that all pending metrics are sent
     assert_equal(4, @sink.datagrams.size)
 
     counter_datagram = @sink.datagrams.find { |d| d.name == "foo" }
@@ -434,13 +388,11 @@ class AggregatorTest < Minitest::Test
   def test_aggregator_finalizer_is_called_on_gc
     skip_on_jruby("JRuby's GC does not guarantee finalizers are called promptly")
 
-    5.times { @subject.increment("foo", 1, tags: { foo: "bar" }) }
+    5.times { @subject.increment("foo", 1, ["foo:bar"], false, 1.0) }
 
     @subject.instance_variable_get(:@flush_thread)&.kill
-    # Unbind the aggregator to allow GC to collect it.
     @subject = nil
 
-    # We expect the finalizer to flush the aggregated metrics.
     assert_empty(@sink.datagrams)
 
     5.times do
@@ -457,10 +409,11 @@ class AggregatorTest < Minitest::Test
   end
 
   def test_aggregator_finalizer_is_called_on_gc_after_aggregation_state_move
-    (StatsD::Instrument::Aggregator::DEFAULT_MAX_CONTEXT_SIZE + 5).times { @subject.aggregate_timing("foo", 1) }
+    (StatsD::Instrument::Aggregator::DEFAULT_MAX_CONTEXT_SIZE + 5).times do
+      @subject.aggregate_timing("foo", 1, [], false, :d, 1.0)
+    end
     assert_equal(1, @sink.datagrams.size)
 
-    # Unbind the aggregator to allow GC to collect it.
     @subject = nil
     5.times do
       GC.start(full_mark: true, immediate_mark: true, immediate_sweep: true)
@@ -484,10 +437,9 @@ class AggregatorTest < Minitest::Test
 
     old_trap = Signal.trap("USR1") do
       signal_received = true
-      # These operations should now fall back to direct writes
-      @subject.increment("trap_counter", 1)
-      @subject.gauge("trap_gauge", 42)
-      @subject.aggregate_timing("trap_timing", 100)
+      @subject.increment("trap_counter", 1, [], false, 1.0)
+      @subject.gauge("trap_gauge", 42, [], false)
+      @subject.aggregate_timing("trap_timing", 100, [], false, :d, 1.0)
 
       metrics_sent_in_trap = @sink.datagrams.map(&:name)
     end

--- a/test/aggregator_test.rb
+++ b/test/aggregator_test.rb
@@ -3,6 +3,22 @@
 require "test_helper"
 
 class AggregatorTest < Minitest::Test
+  # Keeps the behavior-focused tests readable while the production Aggregator
+  # exposes only its strict positional interface.
+  class KeywordTestAggregator < StatsD::Instrument::Aggregator
+    def increment(name, value = 1, tags: [], no_prefix: false, sample_rate: 1.0)
+      super(name, value, tags, no_prefix, sample_rate)
+    end
+
+    def gauge(name, value, tags: [], no_prefix: false)
+      super(name, value, tags, no_prefix)
+    end
+
+    def aggregate_timing(name, value, tags: [], no_prefix: false, type: :d, sample_rate: 1.0)
+      super(name, value, tags, no_prefix, type, sample_rate)
+    end
+  end
+
   class CaptureLogger
     attr_reader :messages
 
@@ -24,7 +40,7 @@ class AggregatorTest < Minitest::Test
     StatsD.logger = @logger
 
     @sink = StatsD::Instrument::CaptureSink.new(parent: StatsD::Instrument::NullSink.new)
-    @subject = StatsD::Instrument::Aggregator.new(
+    @subject = KeywordTestAggregator.new(
       @sink, StatsD::Instrument::DatagramBuilder, nil, [], flush_interval: 0.1
     )
   end
@@ -35,14 +51,14 @@ class AggregatorTest < Minitest::Test
     StatsD.logger = @old_logger
   end
 
-  def test_record_entrypoints_use_fixed_positional_arguments
+  def test_aggregator_entrypoints_use_fixed_positional_arguments
     assert_equal(
       [[:req, :name], [:req, :value], [:req, :tags], [:req, :no_prefix], [:req, :sample_rate]],
-      @subject.method(:record_counter).parameters,
+      StatsD::Instrument::Aggregator.instance_method(:increment).parameters,
     )
     assert_equal(
       [[:req, :name], [:req, :value], [:req, :tags], [:req, :no_prefix]],
-      @subject.method(:record_gauge).parameters,
+      StatsD::Instrument::Aggregator.instance_method(:gauge).parameters,
     )
     assert_equal(
       [
@@ -53,7 +69,7 @@ class AggregatorTest < Minitest::Test
         [:req, :type],
         [:req, :sample_rate],
       ],
-      @subject.method(:record_timing).parameters,
+      StatsD::Instrument::Aggregator.instance_method(:aggregate_timing).parameters,
     )
   end
 
@@ -222,7 +238,7 @@ class AggregatorTest < Minitest::Test
   end
 
   def test_with_prefix
-    aggregator = StatsD::Instrument::Aggregator.new(@sink, StatsD::Instrument::DatagramBuilder, "MyApp", [])
+    aggregator = KeywordTestAggregator.new(@sink, StatsD::Instrument::DatagramBuilder, "MyApp", [])
 
     aggregator.increment("foo", 1, tags: ["tag1:val1", "tag2:val2"])
     aggregator.increment("foo", 1, tags: ["tag1:val1", "tag2:val2"])
@@ -241,7 +257,7 @@ class AggregatorTest < Minitest::Test
   def test_finalizer_with_prefix
     # Test that the finalizer correctly uses the prefix when flushing metrics
     # IMPORTANT: Use empty tags to ensure datagram_builder is not pre-created by tags_sorted
-    aggregator = StatsD::Instrument::Aggregator.new(@sink, StatsD::Instrument::DatagramBuilder, "MyApp", [])
+    aggregator = KeywordTestAggregator.new(@sink, StatsD::Instrument::DatagramBuilder, "MyApp", [])
 
     aggregator.increment("foo", 1, tags: [])
     aggregator.increment("bar", 1, tags: [], no_prefix: true)

--- a/test/aggregator_test.rb
+++ b/test/aggregator_test.rb
@@ -35,6 +35,28 @@ class AggregatorTest < Minitest::Test
     StatsD.logger = @old_logger
   end
 
+  def test_record_entrypoints_use_fixed_positional_arguments
+    assert_equal(
+      [[:req, :name], [:req, :value], [:req, :tags], [:req, :no_prefix], [:req, :sample_rate]],
+      @subject.method(:record_counter).parameters,
+    )
+    assert_equal(
+      [[:req, :name], [:req, :value], [:req, :tags], [:req, :no_prefix]],
+      @subject.method(:record_gauge).parameters,
+    )
+    assert_equal(
+      [
+        [:req, :name],
+        [:req, :value],
+        [:req, :tags],
+        [:req, :no_prefix],
+        [:req, :type],
+        [:req, :sample_rate],
+      ],
+      @subject.method(:record_timing).parameters,
+    )
+  end
+
   def test_increment_simple
     @subject.increment("foo", 1, tags: { foo: "bar" })
     @subject.increment("foo", 1, tags: { foo: "bar" })

--- a/test/aggregator_test.rb
+++ b/test/aggregator_test.rb
@@ -51,28 +51,6 @@ class AggregatorTest < Minitest::Test
     StatsD.logger = @old_logger
   end
 
-  def test_aggregator_entrypoints_use_fixed_positional_arguments
-    assert_equal(
-      [[:req, :name], [:req, :value], [:req, :tags], [:req, :no_prefix], [:req, :sample_rate]],
-      StatsD::Instrument::Aggregator.instance_method(:increment).parameters,
-    )
-    assert_equal(
-      [[:req, :name], [:req, :value], [:req, :tags], [:req, :no_prefix]],
-      StatsD::Instrument::Aggregator.instance_method(:gauge).parameters,
-    )
-    assert_equal(
-      [
-        [:req, :name],
-        [:req, :value],
-        [:req, :tags],
-        [:req, :no_prefix],
-        [:req, :type],
-        [:req, :sample_rate],
-      ],
-      StatsD::Instrument::Aggregator.instance_method(:aggregate_timing).parameters,
-    )
-  end
-
   def test_increment_simple
     @subject.increment("foo", 1, tags: { foo: "bar" })
     @subject.increment("foo", 1, tags: { foo: "bar" })

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -3,6 +3,42 @@
 require "test_helper"
 
 class ClientTest < Minitest::Test
+  class PositionalAggregator
+    attr_reader :calls
+
+    def initialize
+      @calls = []
+    end
+
+    def record_counter(name, value, tags, no_prefix, sample_rate)
+      @calls << [:counter, name, value, tags, no_prefix, sample_rate]
+    end
+
+    def record_gauge(name, value, tags, no_prefix)
+      @calls << [:gauge, name, value, tags, no_prefix]
+    end
+
+    def record_timing(name, value, tags, no_prefix, type, sample_rate)
+      @calls << [:timing, name, value, tags, no_prefix, type, sample_rate]
+    end
+
+    def aggregate_precompiled_increment_metric(datagram, value)
+      @calls << [:precompiled_counter, datagram, value]
+    end
+
+    def aggregate_precompiled_timing_metric(datagram, value)
+      @calls << [:precompiled_timing, datagram, value]
+    end
+
+    def aggregate_precompiled_gauge_metric(datagram, value)
+      @calls << [:precompiled_gauge, datagram, value]
+    end
+
+    def flush
+      @calls << [:flush]
+    end
+  end
+
   def setup
     @client = StatsD::Instrument::Client.new(datagram_builder_class: StatsD::Instrument::StatsDDatagramBuilder)
     @dogstatsd_client = StatsD::Instrument::Client.new(implementation: "datadog")
@@ -100,6 +136,101 @@ class ClientTest < Minitest::Test
 
     datagram = client.sink.datagrams.find { |d| d.name == "bar.block_duration_example" }
     assert_equal(true, !datagram.nil?)
+  end
+
+  def test_default_aggregator_keeps_keyword_dispatch
+    client = StatsD::Instrument::Client.new(enable_aggregation: true)
+    aggregator = client.instance_variable_get(:@aggregator)
+    tags = ["route:cart"]
+    aggregator.expects(:increment).with("requests", 1, tags: tags, no_prefix: false, sample_rate: nil)
+
+    client.increment("requests", tags: tags)
+  ensure
+    aggregator&.instance_variable_get(:@flush_thread)&.kill
+  end
+
+  def test_positional_aggregator
+    aggregator = PositionalAggregator.new
+    client = StatsD::Instrument::Client.new(
+      aggregator: aggregator,
+      default_sample_rate: 0.5,
+      sink: StatsD::Instrument::NullSink.new,
+    )
+
+    tags = ["route:cart"]
+    client.increment("requests", 2, tags: tags)
+    client.gauge("active", 3, tags: tags, no_prefix: true)
+    client.distribution("latency", 4.5, tags: tags)
+    client.measure("duration", 5.5, tags: tags, no_prefix: true)
+    client.histogram("size", 6, tags: tags)
+    client.force_flush
+
+    assert_equal(
+      [
+        [:counter, "requests", 2, tags, false, 0.5],
+        [:gauge, "active", 3, tags, true],
+        [:timing, "latency", 4.5, tags, false, :d, 0.5],
+        [:timing, "duration", 5.5, tags, true, :ms, 0.5],
+        [:timing, "size", 6, tags, false, :h, 0.5],
+        [:flush],
+      ],
+      aggregator.calls,
+    )
+  end
+
+  def test_positional_aggregator_preserves_block_timing_and_return_value
+    aggregator = PositionalAggregator.new
+    client = StatsD::Instrument::Client.new(aggregator: aggregator)
+    Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC, :float_millisecond).returns(100.0, 125.0)
+
+    result = client.distribution("latency", tags: ["route:cart"]) { :result }
+
+    assert_equal(:result, result)
+    assert_equal(
+      [[:timing, "latency", 25.0, ["route:cart"], false, :d, nil]],
+      aggregator.calls,
+    )
+  end
+
+  def test_positional_aggregator_receives_only_sampled_metrics
+    aggregator = PositionalAggregator.new
+    sink = StatsD::Instrument::NullSink.new
+    sink.stubs(:sample?).with(0.1).returns(false)
+    client = StatsD::Instrument::Client.new(aggregator: aggregator, sink: sink)
+
+    client.increment("requests", sample_rate: 0.1)
+    client.distribution("latency", 10, sample_rate: 0.1)
+    client.histogram("size", 20, sample_rate: 0.1)
+
+    assert_empty(aggregator.calls)
+  end
+
+  def test_positional_aggregator_supports_existing_compiled_metrics
+    aggregator = PositionalAggregator.new
+    client = StatsD::Instrument::Client.new(aggregator: aggregator)
+    old_client = StatsD.singleton_client
+    StatsD.singleton_client = client
+    metric = Class.new(StatsD::Instrument::CompiledMetric::Counter) do
+      define(name: "compiled.requests")
+    end
+
+    metric.increment(2)
+
+    assert_equal(:precompiled_counter, aggregator.calls.first[0])
+    assert_kind_of(StatsD::Instrument::CompiledMetric::PrecompiledDatagram, aggregator.calls.first[1])
+    assert_equal(2, aggregator.calls.first[2])
+  ensure
+    StatsD.singleton_client = old_client
+  end
+
+  def test_clone_with_options_preserves_positional_aggregator
+    aggregator = PositionalAggregator.new
+    client = StatsD::Instrument::Client.new(aggregator: aggregator)
+    clone = client.clone_with_options(prefix: "clone")
+
+    clone.increment("requests")
+
+    assert_equal([[:counter, "requests", 1, [], false, nil]], aggregator.calls)
   end
 
   def test_capture

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -3,42 +3,6 @@
 require "test_helper"
 
 class ClientTest < Minitest::Test
-  class PositionalAggregator
-    attr_reader :calls
-
-    def initialize
-      @calls = []
-    end
-
-    def increment(name, value, tags, no_prefix, sample_rate)
-      @calls << [:counter, name, value, tags, no_prefix, sample_rate]
-    end
-
-    def gauge(name, value, tags, no_prefix)
-      @calls << [:gauge, name, value, tags, no_prefix]
-    end
-
-    def aggregate_timing(name, value, tags, no_prefix, type, sample_rate)
-      @calls << [:timing, name, value, tags, no_prefix, type, sample_rate]
-    end
-
-    def aggregate_precompiled_increment_metric(datagram, value)
-      @calls << [:precompiled_counter, datagram, value]
-    end
-
-    def aggregate_precompiled_timing_metric(datagram, value)
-      @calls << [:precompiled_timing, datagram, value]
-    end
-
-    def aggregate_precompiled_gauge_metric(datagram, value)
-      @calls << [:precompiled_gauge, datagram, value]
-    end
-
-    def flush
-      @calls << [:flush]
-    end
-  end
-
   def setup
     @client = StatsD::Instrument::Client.new(datagram_builder_class: StatsD::Instrument::StatsDDatagramBuilder)
     @dogstatsd_client = StatsD::Instrument::Client.new(implementation: "datadog")
@@ -138,23 +102,12 @@ class ClientTest < Minitest::Test
     assert_equal(true, !datagram.nil?)
   end
 
-  def test_default_aggregator_uses_positional_dispatch
-    client = StatsD::Instrument::Client.new(enable_aggregation: true)
-    aggregator = client.instance_variable_get(:@aggregator)
-    tags = ["route:cart"]
-    aggregator.expects(:increment).with("requests", 1, tags, false, nil)
-
-    client.increment("requests", tags: tags)
-  ensure
-    aggregator&.instance_variable_get(:@flush_thread)&.kill
-  end
-
-  def test_positional_aggregator
-    aggregator = PositionalAggregator.new
+  def test_injected_aggregator_dispatches_all_metric_types
+    sink = StatsD::Instrument::CaptureSink.new(parent: StatsD::Instrument::NullSink.new)
     client = StatsD::Instrument::Client.new(
-      aggregator: aggregator,
+      sink: sink,
       default_sample_rate: 0.5,
-      sink: StatsD::Instrument::NullSink.new,
+      enable_aggregation: true,
     )
 
     tags = ["route:cart"]
@@ -165,49 +118,65 @@ class ClientTest < Minitest::Test
     client.histogram("size", 6, tags: tags)
     client.force_flush
 
-    assert_equal(
-      [
-        [:counter, "requests", 2, tags, false, 0.5],
-        [:gauge, "active", 3, tags, true],
-        [:timing, "latency", 4.5, tags, false, :d, 0.5],
-        [:timing, "duration", 5.5, tags, true, :ms, 0.5],
-        [:timing, "size", 6, tags, false, :h, 0.5],
-        [:flush],
-      ],
-      aggregator.calls,
-    )
+    counter = sink.datagrams.find { |d| d.name == "requests" }
+    assert_equal(2, counter.value)
+    assert_equal(0.5, counter.sample_rate)
+    assert_equal(tags, counter.tags)
+
+    gauge = sink.datagrams.find { |d| d.name == "active" }
+    assert_equal(3, gauge.value)
+    assert_equal(:g, gauge.type)
+    assert_equal(tags, gauge.tags)
+
+    dist = sink.datagrams.find { |d| d.name == "latency" }
+    assert_equal(4.5, dist.value)
+    assert_equal(:d, dist.type)
+    assert_equal(0.5, dist.sample_rate)
+
+    measure = sink.datagrams.find { |d| d.name == "duration" }
+    assert_equal(5.5, measure.value)
+    assert_equal(:ms, measure.type)
+
+    histogram = sink.datagrams.find { |d| d.name == "size" }
+    assert_equal(6, histogram.value)
+    assert_equal(:h, histogram.type)
+  ensure
+    client&.instance_variable_get(:@aggregator)&.instance_variable_get(:@flush_thread)&.kill
   end
 
-  def test_positional_aggregator_preserves_block_timing_and_return_value
-    aggregator = PositionalAggregator.new
-    client = StatsD::Instrument::Client.new(aggregator: aggregator)
+  def test_aggregation_preserves_block_timing_and_return_value
+    sink = StatsD::Instrument::CaptureSink.new(parent: StatsD::Instrument::NullSink.new)
+    client = StatsD::Instrument::Client.new(sink: sink, enable_aggregation: true)
     Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC, :float_millisecond).returns(100.0, 125.0)
 
     result = client.distribution("latency", tags: ["route:cart"]) { :result }
 
     assert_equal(:result, result)
-    assert_equal(
-      [[:timing, "latency", 25.0, ["route:cart"], false, :d, nil]],
-      aggregator.calls,
-    )
+    client.force_flush
+    datagram = sink.datagrams.find { |d| d.name == "latency" }
+    assert_equal(25.0, datagram.value)
+  ensure
+    client&.instance_variable_get(:@aggregator)&.instance_variable_get(:@flush_thread)&.kill
   end
 
-  def test_positional_aggregator_receives_only_sampled_metrics
-    aggregator = PositionalAggregator.new
-    sink = StatsD::Instrument::NullSink.new
+  def test_aggregation_skips_sampled_out_metrics
+    sink = StatsD::Instrument::CaptureSink.new(parent: StatsD::Instrument::NullSink.new)
     sink.stubs(:sample?).with(0.1).returns(false)
-    client = StatsD::Instrument::Client.new(aggregator: aggregator, sink: sink)
+    client = StatsD::Instrument::Client.new(sink: sink, enable_aggregation: true)
 
     client.increment("requests", sample_rate: 0.1)
     client.distribution("latency", 10, sample_rate: 0.1)
     client.histogram("size", 20, sample_rate: 0.1)
+    client.force_flush
 
-    assert_empty(aggregator.calls)
+    assert_empty(sink.datagrams)
+  ensure
+    client&.instance_variable_get(:@aggregator)&.instance_variable_get(:@flush_thread)&.kill
   end
 
-  def test_positional_aggregator_supports_existing_compiled_metrics
-    aggregator = PositionalAggregator.new
-    client = StatsD::Instrument::Client.new(aggregator: aggregator)
+  def test_aggregation_supports_existing_compiled_metrics
+    sink = StatsD::Instrument::CaptureSink.new(parent: StatsD::Instrument::NullSink.new)
+    client = StatsD::Instrument::Client.new(sink: sink, enable_aggregation: true)
     old_client = StatsD.singleton_client
     StatsD.singleton_client = client
     metric = Class.new(StatsD::Instrument::CompiledMetric::Counter) do
@@ -215,22 +184,28 @@ class ClientTest < Minitest::Test
     end
 
     metric.increment(2)
+    client.force_flush
 
-    assert_equal(:precompiled_counter, aggregator.calls.first[0])
-    assert_kind_of(StatsD::Instrument::CompiledMetric::PrecompiledDatagram, aggregator.calls.first[1])
-    assert_equal(2, aggregator.calls.first[2])
+    datagram = sink.datagrams.find { |d| d.name == "compiled.requests" }
+    assert_equal(2, datagram.value)
   ensure
     StatsD.singleton_client = old_client
+    client&.instance_variable_get(:@aggregator)&.instance_variable_get(:@flush_thread)&.kill
   end
 
-  def test_clone_with_options_preserves_positional_aggregator
-    aggregator = PositionalAggregator.new
-    client = StatsD::Instrument::Client.new(aggregator: aggregator)
+  def test_clone_with_options_preserves_aggregator
+    sink = StatsD::Instrument::CaptureSink.new(parent: StatsD::Instrument::NullSink.new)
+    client = StatsD::Instrument::Client.new(sink: sink, enable_aggregation: true)
     clone = client.clone_with_options(prefix: "clone")
 
     clone.increment("requests")
+    clone.force_flush
 
-    assert_equal([[:counter, "requests", 1, [], false, nil]], aggregator.calls)
+    datagram = sink.datagrams.find { |d| d.name == "clone.requests" }
+    assert_equal(1, datagram.value)
+  ensure
+    client&.instance_variable_get(:@aggregator)&.instance_variable_get(:@flush_thread)&.kill
+    clone&.instance_variable_get(:@aggregator)&.instance_variable_get(:@flush_thread)&.kill
   end
 
   def test_capture

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -117,6 +117,21 @@ class ClientTest < Minitest::Test
     client&.instance_variable_get(:@aggregator)&.instance_variable_get(:@flush_thread)&.kill
   end
 
+  def test_injected_aggregator_receives_positional_calls
+    aggregator = mock("aggregator")
+    tags = ["route:cart"]
+    aggregator.expects(:increment).with("requests", 2, tags, false, nil)
+    aggregator.expects(:flush)
+
+    client = StatsD::Instrument::Client.new(
+      aggregator: aggregator,
+      sink: StatsD::Instrument::NullSink.new,
+    )
+
+    client.increment("requests", 2, tags: tags)
+    client.force_flush
+  end
+
   def test_aggregation_supports_existing_compiled_metrics
     sink = StatsD::Instrument::CaptureSink.new(parent: StatsD::Instrument::NullSink.new)
     client = StatsD::Instrument::Client.new(sink: sink, enable_aggregation: true)

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -10,15 +10,15 @@ class ClientTest < Minitest::Test
       @calls = []
     end
 
-    def record_counter(name, value, tags, no_prefix, sample_rate)
+    def increment(name, value, tags, no_prefix, sample_rate)
       @calls << [:counter, name, value, tags, no_prefix, sample_rate]
     end
 
-    def record_gauge(name, value, tags, no_prefix)
+    def gauge(name, value, tags, no_prefix)
       @calls << [:gauge, name, value, tags, no_prefix]
     end
 
-    def record_timing(name, value, tags, no_prefix, type, sample_rate)
+    def aggregate_timing(name, value, tags, no_prefix, type, sample_rate)
       @calls << [:timing, name, value, tags, no_prefix, type, sample_rate]
     end
 
@@ -138,11 +138,11 @@ class ClientTest < Minitest::Test
     assert_equal(true, !datagram.nil?)
   end
 
-  def test_default_aggregator_keeps_keyword_dispatch
+  def test_default_aggregator_uses_positional_dispatch
     client = StatsD::Instrument::Client.new(enable_aggregation: true)
     aggregator = client.instance_variable_get(:@aggregator)
     tags = ["route:cart"]
-    aggregator.expects(:increment).with("requests", 1, tags: tags, no_prefix: false, sample_rate: nil)
+    aggregator.expects(:increment).with("requests", 1, tags, false, nil)
 
     client.increment("requests", tags: tags)
   ensure

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -102,48 +102,6 @@ class ClientTest < Minitest::Test
     assert_equal(true, !datagram.nil?)
   end
 
-  def test_injected_aggregator_dispatches_all_metric_types
-    sink = StatsD::Instrument::CaptureSink.new(parent: StatsD::Instrument::NullSink.new)
-    client = StatsD::Instrument::Client.new(
-      sink: sink,
-      default_sample_rate: 0.5,
-      enable_aggregation: true,
-    )
-
-    tags = ["route:cart"]
-    client.increment("requests", 2, tags: tags)
-    client.gauge("active", 3, tags: tags, no_prefix: true)
-    client.distribution("latency", 4.5, tags: tags)
-    client.measure("duration", 5.5, tags: tags, no_prefix: true)
-    client.histogram("size", 6, tags: tags)
-    client.force_flush
-
-    counter = sink.datagrams.find { |d| d.name == "requests" }
-    assert_equal(2, counter.value)
-    assert_equal(0.5, counter.sample_rate)
-    assert_equal(tags, counter.tags)
-
-    gauge = sink.datagrams.find { |d| d.name == "active" }
-    assert_equal(3, gauge.value)
-    assert_equal(:g, gauge.type)
-    assert_equal(tags, gauge.tags)
-
-    dist = sink.datagrams.find { |d| d.name == "latency" }
-    assert_equal(4.5, dist.value)
-    assert_equal(:d, dist.type)
-    assert_equal(0.5, dist.sample_rate)
-
-    measure = sink.datagrams.find { |d| d.name == "duration" }
-    assert_equal(5.5, measure.value)
-    assert_equal(:ms, measure.type)
-
-    histogram = sink.datagrams.find { |d| d.name == "size" }
-    assert_equal(6, histogram.value)
-    assert_equal(:h, histogram.type)
-  ensure
-    client&.instance_variable_get(:@aggregator)&.instance_variable_get(:@flush_thread)&.kill
-  end
-
   def test_aggregation_preserves_block_timing_and_return_value
     sink = StatsD::Instrument::CaptureSink.new(parent: StatsD::Instrument::NullSink.new)
     client = StatsD::Instrument::Client.new(sink: sink, enable_aggregation: true)
@@ -155,21 +113,6 @@ class ClientTest < Minitest::Test
     client.force_flush
     datagram = sink.datagrams.find { |d| d.name == "latency" }
     assert_equal(25.0, datagram.value)
-  ensure
-    client&.instance_variable_get(:@aggregator)&.instance_variable_get(:@flush_thread)&.kill
-  end
-
-  def test_aggregation_skips_sampled_out_metrics
-    sink = StatsD::Instrument::CaptureSink.new(parent: StatsD::Instrument::NullSink.new)
-    sink.stubs(:sample?).with(0.1).returns(false)
-    client = StatsD::Instrument::Client.new(sink: sink, enable_aggregation: true)
-
-    client.increment("requests", sample_rate: 0.1)
-    client.distribution("latency", 10, sample_rate: 0.1)
-    client.histogram("size", 20, sample_rate: 0.1)
-    client.force_flush
-
-    assert_empty(sink.datagrams)
   ensure
     client&.instance_variable_get(:@aggregator)&.instance_variable_get(:@flush_thread)&.kill
   end


### PR DESCRIPTION
## Why

Aggregation is currently hard-coded to the built-in implementation and receives metric options as keyword arguments. The aggregator is an internal hot-path interface, so a single fixed-arity positional contract is simpler, cheaper to dispatch, and easier to implement with alternative aggregation strategies.

## What changed

- Make the internal aggregator interface positional-only:

  ```ruby
  increment(name, value, tags, no_prefix, sample_rate)
  gauge(name, value, tags, no_prefix)
  aggregate_timing(name, value, tags, no_prefix, type, sample_rate)
  ```

- Keep the public `Client` metric API unchanged, including its keyword options.
- Add optional `aggregator:` injection to `Client.new` and `.from_env`.
- Preserve an injected aggregator through `with_options` / `clone_with_options` unless explicitly overridden.
- Providing `aggregator:` implicitly enables aggregation.
- Convert untagged aggregation calls to one shared frozen empty array; other tag values are forwarded as-is, so custom implementations may require canonical arrays.
- Keep sampling in `Client` before aggregation dispatch.
- Keep the existing precompiled aggregation methods and `flush` as part of the aggregator contract.
- Document the interface and add a changelog entry.

## Compatibility

Public `StatsD` and `Client` metric methods keep their existing signatures and behavior. Code that directly calls or prepends the internal `Aggregator` methods must update to the positional signatures.

Injected aggregators own prefix/default-tag policy and lifecycle behavior. Cloned clients reuse the injected instance unless `aggregator:` is overridden.

## Performance

Linux arm64, Ruby 3.4.10 + YJIT, 1M calls:

| Path | Median | Ruby allocations/call |
|---|---:|---:|
| Direct positional aggregator method | 24.6 ns/call | 0 |
| Client → aggregator | 32.5 ns/call | 0 |

A five-process before/after run found no regression in existing direct or CompiledMetric paths. Representative medians:

| Path | main | this branch |
|---|---:|---:|
| Client distribution | 1,351.9 ns | 1,321.8 ns |
| Dynamic compiled distribution | 184.5 ns | 178.7 ns |
| Static compiled distribution | 133.7 ns | 134.5 ns |
| Dynamic compiled counter | 216.6 ns | 214.2 ns |

## Validation

- `bundle exec rake test` — 397 runs, 1,111 assertions, 0 failures/errors
- `bundle exec rubocop` — 79 files, no offenses
- Ruby 2.7–3.3, ruby-head, JRuby, and TruffleRuby CI coverage
- UDP integration test

#gsd:52109
