### PR TITLE
Fix RuboCop 3 baseline offenses on main

### DIFF
--- a/lib/statsd/instrument/datagram.rb
+++ b/lib/statsd/instrument/datagram.rb
@@ -77,7 +77,7 @@ module StatsD
         (?:\|\#(?<tags>(?:[^\|,]+(?:,[^\|,]+)*)))?
         \n? # In some implementations, the datagram may include a trailing newline.
         \z
-      }x
+      }x.freeze
 
       def parsed_datagram
         @parsed ||= if (match_info = PARSER.match(@source))

--- a/lib/statsd/instrument/dogstatsd_datagram.rb
+++ b/lib/statsd/instrument/dogstatsd_datagram.rb
@@ -69,7 +69,7 @@ module StatsD
         (?:\|m:(?<message>[^\|]+))?
         \n? # In some implementations, the datagram may include a trailing newline.
         \z
-      }x
+      }x.freeze
 
       # |k:my-key|p:low|s:source|t:success|
       EVENT_PARSER = %r{
@@ -84,7 +84,7 @@ module StatsD
         (?:\|\#(?<tags>(?:[^\|,]+(?:,[^\|,]+)*)))?
         \n? # In some implementations, the datagram may include a trailing newline.
         \z
-      }x
+      }x.freeze
 
       PARSER = Regexp.union(StatsD::Instrument::Datagram::PARSER, SERVICE_CHECK_PARSER, EVENT_PARSER)
     end

--- a/lib/statsd/instrument/rubocop.rb
+++ b/lib/statsd/instrument/rubocop.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module StatsD
-      METRIC_METHODS = [:increment, :gauge, :measure, :set, :histogram, :distribution, :key_value]
+      METRIC_METHODS = [:increment, :gauge, :measure, :set, :histogram, :distribution, :key_value].freeze
 
       METAPROGRAMMING_METHODS = [
         :statsd_measure,
@@ -11,7 +11,7 @@ module RuboCop
         :statsd_count_success,
         :statsd_count_if,
         :statsd_count,
-      ]
+      ].freeze
 
       SINGLETON_CONFIGURATION_METHODS = [
         :backend,
@@ -22,7 +22,7 @@ module RuboCop
         :"default_tags=",
         :default_sample_rate,
         :"default_sample_rate=",
-      ]
+      ].freeze
 
       private
 

--- a/lib/statsd/instrument/rubocop/metric_return_value.rb
+++ b/lib/statsd/instrument/rubocop/metric_return_value.rb
@@ -19,7 +19,7 @@ module RuboCop
 
         MSG = "Do not use the return value of StatsD metric methods"
 
-        INVALID_PARENTS = [:lvasgn, :array, :pair, :send, :return, :yield]
+        INVALID_PARENTS = [:lvasgn, :array, :pair, :send, :return, :yield].freeze
 
         def on_send(node)
           if metric_method?(node) && node.arguments.last&.type != :block_pass

--- a/test/rubocop/singleton_configuration_test.rb
+++ b/test/rubocop/singleton_configuration_test.rb
@@ -18,7 +18,10 @@ module Rubocop
 
     def test_offense_statsd_prefix
       assert_offense('StatsD.prefix = "foo"')
+      # The interpolation is intentionally literal source passed to the cop under test.
+      # rubocop:disable Lint/InterpolationCheck
       assert_offense('"#{StatsD.prefix}.foo"')
+      # rubocop:enable Lint/InterpolationCheck
     end
 
     def test_offense_statsd_default_tags


### PR DESCRIPTION
## Summary

Clean main currently has 8 RuboCop offenses that fail CI lint. This PR fixes all of them so that branches based on `main` start from a clean RuboCop baseline.

These fixes are unrelated to the positional aggregator work in #423 and are split out here so that PR can stay focused.

## Offenses fixed

- 7 × `Style/MutableConstant` — freeze mutable objects assigned to constants:
  - `lib/statsd/instrument/datagram.rb` (`PARSER` regex)
  - `lib/statsd/instrument/dogstatsd_datagram.rb` (`PARSER`, `EVENT_PARSER` regexes)
  - `lib/statsd/instrument/rubocop.rb` (`METRIC_METHODS`, `METAPROGRAMMING_METHODS`, `SINGLETON_CONFIGURATION_METHODS`)
  - `lib/statsd/instrument/rubocop/metric_return_value.rb` (`INVALID_PARENTS`)
- 1 × `Lint/InterpolationCheck` — `test/rubocop/singleton_configuration_test.rb` passes literal interpolated source to the cop under test; annotated with a scoped `rubocop:disable`/`enable` since the interpolation is intentional test input.

## Validation

- `bundle exec rubocop` → 79 files inspected, **no offenses detected** (was 8 offenses on `main`).
- `bundle exec rake test` → 390 runs, 1098 assertions, **0 failures, 0 errors**.