### PR TITLE
Modernize supported Ruby CI versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', 'ruby-head', 'jruby-9.4.9.0', 'truffleruby-25.0.0']
+        ruby: ['3.0', '3.1', '3.2', '3.3', '3.4', 'ruby-head', 'jruby-10.1.1.0', 'truffleruby-34.0.1']
 
     steps:
     - uses: actions/checkout@v4

--- a/Gemfile
+++ b/Gemfile
@@ -13,15 +13,12 @@ gem "rubocop-shopify", require: false
 gem "benchmark-ips"
 gem "dogstatsd-ruby", "~> 5.0", require: false
 gem "simplecov", require: false, group: :test
+# logger is no longer bundled with newer Ruby and JRuby releases.
+gem "logger"
 
 platform :mri do
   # only if Ruby is MRI && >= 3.2
   if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.2")
     gem "vernier", require: false
-  end
-
-  # From Ruby >= 3.5, logger is not part of the stdlib anymore
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.5")
-    gem "logger"
   end
 end

--- a/test/compiled_metric_test.rb
+++ b/test/compiled_metric_test.rb
@@ -349,6 +349,8 @@ class CompiledMetricDefinitionTest < Minitest::Test
   end
 
   def test_cache_key_computation_does_not_allocate
+    skip_on_jruby("JRuby does not support GC.stat(:total_allocated_objects)")
+
     single_tag_metric = Class.new(StatsD::Instrument::CompiledMetric::Counter) do
       define(name: "foo.single", tags: { a: String })
     end


### PR DESCRIPTION
## Why

The CI matrix still includes Ruby 2.7, which has been EOL for a long time, while omitting Ruby 3.4 and using stale JRuby/TruffleRuby versions. The JRuby job also fails on an allocation-counting test because JRuby does not support `GC.stat(:total_allocated_objects)`.

This is a standalone CI maintenance PR so feature PRs do not need to carry runtime-specific workarounds.

## What changed

- Drop Ruby 2.7 from the test matrix.
- Add Ruby 3.4.
- Update JRuby from `9.4.9.0` to `10.1.1.0`.
- Update TruffleRuby from `25.0.0` to `34.0.1`.
- Skip only `test_cache_key_computation_does_not_allocate` on JRuby, preserving the allocation test on CRuby and other runtimes.

## Validation

- `bundle exec ruby -Itest test/compiled_metric_test.rb`
- `bundle exec rake test` — 376 runs, 1,061 assertions, 0 failures/errors
- `bundle exec rubocop test/compiled_metric_test.rb`
- GitHub Actions workflow YAML parses successfully

This is intended to unblock and clean up statsd-instrument PR #423, which can drop its temporary JRuby skip commit and rebase after this PR lands.