### PR TITLE
Add Client tag enricher extension point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ section below.
 
 ## Unreleased changes
 
+- Add a `Client`-level `tag_enricher` callable for runtime tag enrichment before direct emission or aggregation. The public Client metric API remains keyword-based, and aggregation backends continue to receive the fixed-arity positional interface.
+
 ## Version 3.12.0
 
 - Make the internal aggregator interface positional-only and injectable through `Client`, with fixed-arity `increment`, `gauge`, and `aggregate_timing` entrypoints for native aggregation backends. Public Client metric methods retain their keyword API.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,26 @@ Please note that since aggregation is an experimental feature, it should be used
 > [!WARNING]
 > This feature is only compatible with Datadog Agent's version >=6.25.0 && <7.0.0 or Agent's versions >=7.25.0.
 
+### Per-metric tag enrichment
+
+Applications that need to add runtime-dependent tags can provide a callable to
+`Client` or `Environment#client`. The callable receives the metric name and
+explicit tags, and returns the tags to use for the metric:
+
+```ruby
+tag_enricher = lambda do |name, tags|
+  add_runtime_tags(name, tags)
+end
+
+client = StatsD::Instrument::Environment.current.client(tag_enricher: tag_enricher)
+```
+
+The callable runs after sampling and before either aggregation or datagram
+construction. This ordering ensures that runtime tags remain part of the
+aggregation key. It is used by the standard `Client` metric methods; service
+checks, events, and `CompiledMetric` use separate emission paths and are not
+changed by this option.
+
 ## StatsD keys
 
 StatsD keys look like 'admin.logins.api.success'. Dots are used as namespace separators.

--- a/lib/statsd/instrument/client.rb
+++ b/lib/statsd/instrument/client.rb
@@ -257,7 +257,7 @@ module StatsD
 
         return StatsD::Instrument::VOID if sample_rate && !sample?(sample_rate)
 
-        tags = enrich_tags(name, tags)
+        tags = @tag_enricher.call(name, tags) if @tag_enricher
         if @enable_aggregation
           @aggregator.increment(name, value, tags || EMPTY_TAGS, no_prefix, sample_rate)
         else
@@ -392,7 +392,7 @@ module StatsD
           return latency(name, sample_rate: sample_rate, tags: tags, metric_type: :ms, no_prefix: no_prefix, &block)
         end
 
-        tags = enrich_tags(name, tags)
+        tags = @tag_enricher.call(name, tags) if @tag_enricher
         if @enable_aggregation
           @aggregator.aggregate_timing(name, value, tags || EMPTY_TAGS, no_prefix, :ms, sample_rate)
           return StatsD::Instrument::VOID
@@ -416,14 +416,14 @@ module StatsD
       # @return [void]
       def gauge(name, value, sample_rate: nil, tags: nil, no_prefix: false)
         if @enable_aggregation
-          tags = enrich_tags(name, tags)
+          tags = @tag_enricher.call(name, tags) if @tag_enricher
           @aggregator.gauge(name, value, tags || EMPTY_TAGS, no_prefix)
           return StatsD::Instrument::VOID
         end
 
         sample_rate ||= @default_sample_rate
         if sample_rate.nil? || sample?(sample_rate)
-          tags = enrich_tags(name, tags)
+          tags = @tag_enricher.call(name, tags) if @tag_enricher
           emit(datagram_builder(no_prefix: no_prefix).g(name, value, sample_rate, tags))
         end
         StatsD::Instrument::VOID
@@ -439,7 +439,7 @@ module StatsD
       def set(name, value, sample_rate: nil, tags: nil, no_prefix: false)
         sample_rate ||= @default_sample_rate
         if sample_rate.nil? || sample?(sample_rate)
-          tags = enrich_tags(name, tags)
+          tags = @tag_enricher.call(name, tags) if @tag_enricher
           emit(datagram_builder(no_prefix: no_prefix).s(name, value, sample_rate, tags))
         end
         StatsD::Instrument::VOID
@@ -470,7 +470,7 @@ module StatsD
           return StatsD::Instrument::VOID
         end
 
-        tags = enrich_tags(name, tags)
+        tags = @tag_enricher.call(name, tags) if @tag_enricher
         if @enable_aggregation
           @aggregator.aggregate_timing(name, value, tags || EMPTY_TAGS, no_prefix, :d, sample_rate)
           return StatsD::Instrument::VOID
@@ -500,7 +500,7 @@ module StatsD
           return StatsD::Instrument::VOID
         end
 
-        tags = enrich_tags(name, tags)
+        tags = @tag_enricher.call(name, tags) if @tag_enricher
         if @enable_aggregation
           @aggregator.aggregate_timing(name, value, tags || EMPTY_TAGS, no_prefix, :h, sample_rate)
           return StatsD::Instrument::VOID
@@ -538,7 +538,7 @@ module StatsD
 
             metric_type ||= datagram_builder(no_prefix: no_prefix).latency_metric_type
             latency_in_ms = stop - start
-            tags = enrich_tags(name, tags)
+            tags = @tag_enricher.call(name, tags) if @tag_enricher
 
             if @enable_aggregation
               @aggregator.aggregate_timing(
@@ -710,12 +710,6 @@ module StatsD
 
       def sample?(sample_rate)
         @sink.sample?(sample_rate)
-      end
-
-      def enrich_tags(name, tags)
-        return tags unless @tag_enricher
-
-        @tag_enricher.call(name, tags)
       end
 
       def emit(datagram)

--- a/lib/statsd/instrument/client.rb
+++ b/lib/statsd/instrument/client.rb
@@ -35,7 +35,8 @@ module StatsD
           implementation: env.statsd_implementation,
           sink: env.default_sink_for_environment,
           datagram_builder_class: datagram_builder_class_for_implementation(implementation),
-          aggregator: nil
+          aggregator: nil,
+          tag_enricher: nil
         )
           new(
             prefix: prefix,
@@ -47,6 +48,7 @@ module StatsD
             enable_aggregation: env.experimental_aggregation_enabled?,
             aggregation_flush_interval: env.aggregation_interval,
             aggregator: aggregator,
+            tag_enricher: tag_enricher,
           )
         end
 
@@ -139,6 +141,17 @@ module StatsD
       # @return [Array<String>, Hash, nil]
       attr_reader :default_tags
 
+      # A callable that can add or transform per-metric tags before the metric is
+      # passed to the aggregator or datagram builder.
+      #
+      # The callable receives the metric name and the explicit tags supplied to
+      # the metric method, and must return tags in one of the forms accepted by
+      # the client. It is not called for sampled-out metrics, service checks,
+      # events, or compiled metrics.
+      #
+      # @return [#call, nil]
+      attr_reader :tag_enricher
+
       # The default sample rate to use for metrics that are emitted without a
       # sample rate set. This should be a value between 0 (never emit a metric) and
       # 1.0 (always emit). If it is not set, the default value 1.0 is used.
@@ -162,6 +175,9 @@ module StatsD
       #
       # @param aggregator [#increment, #gauge, #aggregate_timing, nil]
       #   Optional external aggregation backend.
+      # @param tag_enricher [#call, nil]
+      #   Optional callable invoked with `(name, tags)` before normal metric
+      #   dispatch. The returned tags are used for aggregation and emission.
       # @see .from_env to instantiate a client using environment variables.
       def initialize(
         prefix: nil,
@@ -173,7 +189,8 @@ module StatsD
         enable_aggregation: false,
         aggregation_flush_interval: 2.0,
         aggregation_max_context_size: StatsD::Instrument::Aggregator::DEFAULT_MAX_CONTEXT_SIZE,
-        aggregator: nil
+        aggregator: nil,
+        tag_enricher: nil
       )
         @sink = sink
         @datagram_builder_class = datagram_builder_class
@@ -181,6 +198,7 @@ module StatsD
         @prefix = prefix
         @default_tags = default_tags
         @default_sample_rate = default_sample_rate
+        @tag_enricher = tag_enricher
 
         @datagram_builder = { false => nil, true => nil }
         @injected_aggregator = aggregator
@@ -239,6 +257,7 @@ module StatsD
 
         return StatsD::Instrument::VOID if sample_rate && !sample?(sample_rate)
 
+        tags = enrich_tags(name, tags)
         if @enable_aggregation
           @aggregator.increment(name, value, tags || EMPTY_TAGS, no_prefix, sample_rate)
         else
@@ -373,6 +392,7 @@ module StatsD
           return latency(name, sample_rate: sample_rate, tags: tags, metric_type: :ms, no_prefix: no_prefix, &block)
         end
 
+        tags = enrich_tags(name, tags)
         if @enable_aggregation
           @aggregator.aggregate_timing(name, value, tags || EMPTY_TAGS, no_prefix, :ms, sample_rate)
           return StatsD::Instrument::VOID
@@ -396,12 +416,14 @@ module StatsD
       # @return [void]
       def gauge(name, value, sample_rate: nil, tags: nil, no_prefix: false)
         if @enable_aggregation
+          tags = enrich_tags(name, tags)
           @aggregator.gauge(name, value, tags || EMPTY_TAGS, no_prefix)
           return StatsD::Instrument::VOID
         end
 
         sample_rate ||= @default_sample_rate
         if sample_rate.nil? || sample?(sample_rate)
+          tags = enrich_tags(name, tags)
           emit(datagram_builder(no_prefix: no_prefix).g(name, value, sample_rate, tags))
         end
         StatsD::Instrument::VOID
@@ -417,6 +439,7 @@ module StatsD
       def set(name, value, sample_rate: nil, tags: nil, no_prefix: false)
         sample_rate ||= @default_sample_rate
         if sample_rate.nil? || sample?(sample_rate)
+          tags = enrich_tags(name, tags)
           emit(datagram_builder(no_prefix: no_prefix).s(name, value, sample_rate, tags))
         end
         StatsD::Instrument::VOID
@@ -447,6 +470,7 @@ module StatsD
           return StatsD::Instrument::VOID
         end
 
+        tags = enrich_tags(name, tags)
         if @enable_aggregation
           @aggregator.aggregate_timing(name, value, tags || EMPTY_TAGS, no_prefix, :d, sample_rate)
           return StatsD::Instrument::VOID
@@ -476,6 +500,7 @@ module StatsD
           return StatsD::Instrument::VOID
         end
 
+        tags = enrich_tags(name, tags)
         if @enable_aggregation
           @aggregator.aggregate_timing(name, value, tags || EMPTY_TAGS, no_prefix, :h, sample_rate)
           return StatsD::Instrument::VOID
@@ -513,6 +538,7 @@ module StatsD
 
             metric_type ||= datagram_builder(no_prefix: no_prefix).latency_metric_type
             latency_in_ms = stop - start
+            tags = enrich_tags(name, tags)
 
             if @enable_aggregation
               @aggregator.aggregate_timing(
@@ -609,7 +635,8 @@ module StatsD
         default_sample_rate: NO_CHANGE,
         default_tags: NO_CHANGE,
         datagram_builder_class: NO_CHANGE,
-        aggregator: NO_CHANGE
+        aggregator: NO_CHANGE,
+        tag_enricher: NO_CHANGE
       )
         client = clone_with_options(
           sink: sink,
@@ -618,6 +645,7 @@ module StatsD
           default_tags: default_tags,
           datagram_builder_class: datagram_builder_class,
           aggregator: aggregator,
+          tag_enricher: tag_enricher,
         )
 
         yield(client)
@@ -629,7 +657,8 @@ module StatsD
         default_sample_rate: NO_CHANGE,
         default_tags: NO_CHANGE,
         datagram_builder_class: NO_CHANGE,
-        aggregator: NO_CHANGE
+        aggregator: NO_CHANGE,
+        tag_enricher: NO_CHANGE
       )
         self.class.new(
           sink: sink == NO_CHANGE ? @sink : sink,
@@ -641,6 +670,7 @@ module StatsD
           enable_aggregation: @enable_aggregation,
           aggregation_flush_interval: @aggregation_flush_interval,
           aggregator: aggregator == NO_CHANGE ? @injected_aggregator : aggregator,
+          tag_enricher: tag_enricher == NO_CHANGE ? @tag_enricher : tag_enricher,
         )
       end
 
@@ -680,6 +710,12 @@ module StatsD
 
       def sample?(sample_rate)
         @sink.sample?(sample_rate)
+      end
+
+      def enrich_tags(name, tags)
+        return tags unless @tag_enricher
+
+        @tag_enricher.call(name, tags)
       end
 
       def emit(datagram)

--- a/lib/statsd/instrument/environment.rb
+++ b/lib/statsd/instrument/environment.rb
@@ -132,8 +132,8 @@ module StatsD
         ))
       end
 
-      def client
-        StatsD::Instrument::Client.from_env(self)
+      def client(**options)
+        StatsD::Instrument::Client.from_env(self, **options)
       end
 
       def default_sink_for_environment

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -67,6 +67,14 @@ class ClientTest < Minitest::Test
     assert_kind_of(StatsD::Instrument::NullSink, client.sink)
   end
 
+  def test_client_from_env_accepts_tag_enricher
+    env = StatsD::Instrument::Environment.new({})
+    tag_enricher = ->(_name, tags) { tags }
+    client = StatsD::Instrument::Client.from_env(env, tag_enricher: tag_enricher)
+
+    assert_same(tag_enricher, client.tag_enricher)
+  end
+
   def test_client_from_env_with_aggregation
     env = StatsD::Instrument::Environment.new(
       "STATSD_SAMPLE_RATE" => "0.1",
@@ -100,6 +108,80 @@ class ClientTest < Minitest::Test
 
     datagram = client.sink.datagrams.find { |d| d.name == "bar.block_duration_example" }
     assert_equal(true, !datagram.nil?)
+  end
+
+  def test_tag_enricher_runs_before_direct_emission
+    calls = []
+    tag_enricher = lambda do |name, tags|
+      calls << [name, tags]
+      Array(tags).dup << "context:one"
+    end
+    client = StatsD::Instrument::Client.new(tag_enricher: tag_enricher)
+
+    datagrams = client.capture do
+      client.increment("counter", tags: ["explicit:yes"], no_prefix: true)
+      client.gauge("gauge", 1)
+      client.set("set", "value")
+    end
+
+    assert_equal(["counter", "gauge", "set"], calls.map(&:first))
+    assert_equal(["explicit:yes"], calls.first.last)
+    assert_equal("counter", datagrams[0].name)
+    assert_includes(datagrams[0].tags, "explicit:yes")
+    assert_includes(datagrams[0].tags, "context:one")
+    assert_equal("gauge", datagrams[1].name)
+    assert_includes(datagrams[1].tags, "context:one")
+    assert_equal("set", datagrams[2].name)
+    assert_includes(datagrams[2].tags, "context:one")
+  end
+
+  def test_tag_enricher_runs_before_aggregation_key_is_built
+    contexts = ["one", "two"]
+    tag_enricher = ->(_name, _tags) { ["pod:#{contexts.shift}"] }
+    sink = StatsD::Instrument::CaptureSink.new(parent: StatsD::Instrument::NullSink.new)
+    client = StatsD::Instrument::Client.new(
+      sink: sink,
+      enable_aggregation: true,
+      tag_enricher: tag_enricher,
+    )
+
+    client.increment("counter")
+    client.increment("counter")
+    client.force_flush
+
+    assert_equal(2, sink.datagrams.size)
+    assert_equal(["pod:one", "pod:two"], sink.datagrams.map { |datagram| datagram.tags.first })
+    assert_equal([1, 1], sink.datagrams.map(&:value))
+  ensure
+    client&.instance_variable_get(:@aggregator)&.instance_variable_get(:@flush_thread)&.kill
+  end
+
+  def test_tag_enricher_is_not_called_for_sampled_out_metrics
+    calls = 0
+    sink = mock("sink")
+    sink.stubs(:sample?).returns(false)
+    tag_enricher = lambda do |_name, _tags|
+      calls += 1
+      []
+    end
+    client = StatsD::Instrument::Client.new(
+      sink: sink,
+      default_sample_rate: 1.0,
+      tag_enricher: tag_enricher,
+    )
+
+    client.increment("dropped")
+
+    assert_equal(0, calls)
+  end
+
+  def test_clone_with_options_preserves_and_overrides_tag_enricher
+    tag_enricher = ->(_name, tags) { tags }
+    replacement = ->(_name, tags) { tags }
+    client = StatsD::Instrument::Client.new(tag_enricher: tag_enricher)
+
+    assert_same(tag_enricher, client.clone_with_options.tag_enricher)
+    assert_same(replacement, client.clone_with_options(tag_enricher: replacement).tag_enricher)
   end
 
   def test_aggregation_preserves_block_timing_and_return_value

--- a/test/environment_test.rb
+++ b/test/environment_test.rb
@@ -36,6 +36,13 @@ class EnvironmentTest < Minitest::Test
     assert_kind_of(StatsD::Instrument::Client, env.client)
   end
 
+  def test_client_forwards_client_options
+    env = StatsD::Instrument::Environment.new({})
+    tag_enricher = ->(_name, tags) { tags }
+
+    assert_same(tag_enricher, env.client(tag_enricher: tag_enricher).tag_enricher)
+  end
+
   def test_client_from_env_uses_log_sink_in_development_environment
     env = StatsD::Instrument::Environment.new("STATSD_USE_NEW_CLIENT" => "1", "STATSD_ENV" => "development")
     assert_kind_of(StatsD::Instrument::LogSink, env.client.sink)


### PR DESCRIPTION
## Summary

- Add an explicit `Client#tag_enricher` extension point for runtime-dependent metric tags.
- Run enrichment after sampling and before either aggregation or datagram construction.
- Preserve the public keyword-based Client API and PR #423's fixed-arity positional aggregator API.
- Forward the option through `Client.from_env`, `Environment#client`, `with_options`, and `clone_with_options`.

## Why this boundary

Runtime tags must be part of the aggregation key. Applying them only in a datagram builder would merge values from different runtime contexts before the tags are materialized.

The callable receives `(metric_name, explicit_tags)` and returns any tag representation accepted by the Client (`nil`, `String`, `Hash`, or `Array`). It is not invoked for sampled-out metrics, service checks, events, or the separate `CompiledMetric` precompiled path.

This PR intentionally does not modify the aggregator interface. The change is stacked on the positional aggregator API from #423.

## Follow-up

The downstream migration will configure the callable and remove its aggregator/datagram-builder monkey patches. Dynamic enrichment for `CompiledMetric` needs a separate design because its precompiled datagram object is also the aggregation key; it is not silently changed here.

## Validation

- `bundle exec rake test` — 385 runs, 1,086 assertions, 0 failures
- `bundle exec rake lint` — clean
- Temporary exploratory `benchmark-ips` comparisons were run on local Ruby 4.0.6/arm64 using the same synthetic tag provider.
- Compared with the PR #423 baseline (no tag-enricher code at all), the inline nil guard adds roughly 0–4% overhead on the default interpreter; aggregated gauge was within noise.
- With `--yjit`, the no-enricher paths were effectively within run-to-run noise (roughly 0–1.5% across the measured increment/gauge cases).
- Compared with the previous helper implementation, inline dispatch removes one Ruby method call and is at least comparable on the active-enricher paths.

The benchmark was not committed, following the repository benchmark guidance. UDP throughput benchmarks should be run after the downstream integration is added.
